### PR TITLE
[Silabs] Fix LCD Update after Commissioning Backport-1.6.0

### DIFF
--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -67,8 +67,8 @@ CHIP_ERROR AppTask::AppInit()
     {
         GetLCD().ShowQRCode(true);
     }
-#endif //defined(QR_CODE_ENABLED) && (QR_CODE_ENABLED)
-#endif //defined(DISPLAY_ENABLED) && (DISPLAY_ENABLED)
+#endif // defined(QR_CODE_ENABLED) && (QR_CODE_ENABLED)
+#endif // defined(DISPLAY_ENABLED) && (DISPLAY_ENABLED)
 
     return CHIP_NO_ERROR;
 }

--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -56,9 +56,21 @@ CHIP_ERROR AppTask::AppInit()
     {
         SILABS_LOG("WindowMgr::Init() failed");
         appError(err);
+        return err;
     }
 
-    return err;
+#if defined(DISPLAY_ENABLED) && (DISPLAY_ENABLED)
+    GetLCD().SetCustomUI(WindowManager::DrawUI);
+    GetLCD().WriteDemoUI(false);
+#if defined(QR_CODE_ENABLED) && (QR_CODE_ENABLED)
+    if (BaseApplication::sIsProvisioned != true)
+    {
+        GetLCD().ShowQRCode(true);
+    }
+#endif //defined(QR_CODE_ENABLED) && (QR_CODE_ENABLED)
+#endif //defined(DISPLAY_ENABLED) && (DISPLAY_ENABLED)
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR AppTask::StartAppTask()
@@ -85,10 +97,6 @@ void AppTask::AppTaskMain(void * pvParameter)
     SILABS_LOG("App Task started");
 
     WindowManager::sWindow.UpdateLED();
-#ifdef DISPLAY_ENABLED
-    WindowManager::sWindow.UpdateLCD();
-#endif // DISPLAY_ENABLED
-
     while (true)
     {
         osStatus_t eventReceived = osMessageQueueGet(sAppEventQueue, &event, NULL, osWaitForever);


### PR DESCRIPTION
#### Summary

##### Problem

- After commissioning, the Silabs window-app LCD did not refresh to the window-covering UI.
- Cover painting only ran from `UpdateLCD()` on attribute/UI state changes, and commissioning does not produce those changes.
- Unlike other Silabs examples, window-app did not register a custom DemoScreen UI, so the shared post-commissioning `DemoScreen` update path did not draw the cover.

##### Solution

- Register `WindowManager::DrawUI` via `SetCustomUI()` and initialize the LCD with `WriteDemoUI()` / QR display when unprovisioned, matching other Silabs apps (e.g. lock).
- This allows `BaseApplication`'s commissioning-window-closed `DemoScreen` update to invoke the window cover UI.

#### Testing

- Manual on Silabs hardware 
- Commissioned the device repeatedly and confirmed LCD switches from QR to window-covering UI after commissioning completes.
- Power-cycled a provisioned device and confirmed cover UI is shown at boot.
- Issued Window Covering cluster commands and confirmed LCD updates on position/state changes.

---
Backport PR of https://github.com/project-chip/connectedhomeip/pull/73440 