### PR TITLE
fix out-of-bounds wifi config copy in ASR driver Init

### DIFF
--- a/src/platform/ASR/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/ASR/NetworkCommissioningWiFiDriver.cpp
@@ -47,8 +47,8 @@ CHIP_ERROR ASRWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
         return CHIP_NO_ERROR;
     }
 
-    memcpy(mSavedNetwork.ssid, config.wifi_ssid, config.ssid_len + 1);
-    memcpy(mSavedNetwork.credentials, config.wifi_key, config.key_len + 1);
+    memcpy(mSavedNetwork.ssid, config.wifi_ssid, config.ssid_len);
+    memcpy(mSavedNetwork.credentials, config.wifi_key, config.key_len);
     mSavedNetwork.ssidLen        = config.ssid_len;
     mSavedNetwork.credentialsLen = config.key_len;
 


### PR DESCRIPTION
### Summary

`ASRWiFiDriver::Init` reloads the persisted WiFi config into `mSavedNetwork` with `memcpy(mSavedNetwork.ssid, config.wifi_ssid, config.ssid_len + 1)` and the matching `config.key_len + 1` copy for the key. `mSavedNetwork.ssid` and `credentials` are `char[kMaxWiFiSSIDLength]` (32) and `char[kMaxWiFiKeyLength]` (64) with no room for the extra byte. `AddOrUpdateNetwork` accepts an SSID of up to 32 bytes and a key of up to 64, `CommitConfiguration` persists that exact length, and `Init` reads it back on the next boot, so a maximum-length SSID or key makes the reload copy one byte past the end of the array.

The fix copies exactly `config.ssid_len` / `config.key_len`, which is what `CommitConfiguration` writes and how `AddOrUpdateNetwork` fills the buffers (a `memset` followed by a `memcpy` of the span size). These members are matched with `memcmp` against `ssidLen`, not read as C strings, so the trailing byte was never needed.

### Related issues

None.

### Testing

The ASR platform needs its vendor toolchain, so this driver has no host-buildable test target. I verified the fix with a standalone reproducer that mirrors the array bounds and the exact copy: under ASan the `ssid_len + 1` copy reports a heap-buffer-overflow write of size 33 zero bytes past the 32-byte region, and copying exactly `ssid_len` runs clean. A sweep of every platform WiFi driver's reload path found this `len + 1` copy into a fixed array to be unique to ASR; ESP32 caps with `strnlen` and the others copy the stored length.
