### PR TITLE
Fix premature assertion inside per-endpoint loop in TC-CNET-4.9

### DIFF
--- a/src/python_testing/TC_CNET_4_9.py
+++ b/src/python_testing/TC_CNET_4_9.py
@@ -138,9 +138,9 @@ class TC_CNET_4_9(MatterBaseTest):
         # Verify that there is a single connected network across ALL network commissioning clusters
         for ep in networks_dict:
             connected_network_count[ep] = sum(x.connected for x in networks_dict[ep])
-            log.info("Connected networks count by endpoint: %s", connected_network_count)
-            asserts.assert_equal(sum(connected_network_count.values()), 1,
-                                 "Verify that only one entry has connected status as TRUE across ALL endpoints")
+        log.info("Connected networks count by endpoint: %s", connected_network_count)
+        asserts.assert_equal(sum(connected_network_count.values()), 1,
+                             "Verify that only one entry has connected status as TRUE across ALL endpoints")
 
         # Skip remaining steps if the connected network is NOT on the cluster currently being verified
         self.step(3)


### PR DESCRIPTION
### Summary

The assertion verifying that only one network is connected across ALL
endpoints in `TC_CNET_4_9.py` was incorrectly indented inside the
per-endpoint loop that populates `connected_network_count`. As a
result, the assertion ran on every loop iteration instead of once
after all endpoints had been processed, producing a false failure
whenever the connected-network data was incomplete at an early
iteration (e.g. a secondary NetworkCommissioning endpoint that has not
yet connected at that point in the loop).

This change moves the `log.info` and `asserts.assert_equal` statements
outside the `for` loop so they execute once, after
`connected_network_count` has been fully populated across all
endpoints.

### Related issues

Fixes #73525

### Testing

- Verified with `ruff check` (all checks passed) and `python3 -m
  py_compile` on the modified file.
- Manually reproduced the false failure on a dual Wi-Fi/Ethernet
  endpoint device prior to the fix, and confirmed the assertion now
  correctly evaluates only after all endpoints are processed.