### PR TITLE
[Darwin] Report the actual error on BDX transfer-session-end

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
@@ -51,7 +51,7 @@ private:
 
     CHIP_ERROR OnTransferSessionBegin(const chip::bdx::TransferSession::OutputEventType event);
 
-    CHIP_ERROR OnTransferSessionEnd(const chip::bdx::TransferSession::OutputEventType eventType);
+    CHIP_ERROR OnTransferSessionEnd(const chip::bdx::TransferSession::OutputEvent & event);
 
     CHIP_ERROR OnBlockQuery(const chip::bdx::TransferSession::OutputEventType eventType, uint64_t bytesToSkip);
 

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -168,7 +168,13 @@ CHIP_ERROR MTROTAImageTransferHandler::Init(Messaging::ExchangeContext * exchang
     } else {
         blockSize = kMaxBdxBlockSize;
     }
-    return AsyncResponder::Init(mSystemLayer, exchangeCtx, kBdxRole, flags, blockSize, kBdxTimeout);
+
+    System::Clock::Timeout timeout = kBdxTimeout;
+    auto timeoutOverride = Platform::GetUserDefaultBDXTransferTimeout();
+    if (timeoutOverride.has_value()) {
+        timeout = timeoutOverride.value();
+    }
+    return AsyncResponder::Init(mSystemLayer, exchangeCtx, kBdxRole, flags, blockSize, timeout);
 }
 
 MTROTAImageTransferHandler::~MTROTAImageTransferHandler()
@@ -176,8 +182,7 @@ MTROTAImageTransferHandler::~MTROTAImageTransferHandler()
     assertChipStackLockedByCurrentThread();
 
     if (mNeedToCallTransferSessionEnd) {
-        // TODO: Store the actual error involved in error cases, so we can pass the right thing here.
-        InvokeTransferSessionEndCallback(CHIP_ERROR_INTERNAL);
+        InvokeTransferSessionEndCallback(mTransferEndError);
     }
 
     MTROTAUnsolicitedBDXMessageHandler::GetInstance()->OnTransferHandlerDestroyed(this);
@@ -319,13 +324,17 @@ void MTROTAImageTransferHandler::InvokeTransferSessionEndCallback(CHIP_ERROR err
     }
 }
 
-CHIP_ERROR MTROTAImageTransferHandler::OnTransferSessionEnd(const TransferSession::OutputEventType eventType)
+CHIP_ERROR MTROTAImageTransferHandler::OnTransferSessionEnd(const TransferSession::OutputEvent & event)
 {
     assertChipStackLockedByCurrentThread();
+
+    TransferSession::OutputEventType eventType = event.EventType;
 
     CHIP_ERROR error = CHIP_NO_ERROR;
     if (eventType == TransferSession::OutputEventType::kTransferTimeout) {
         error = CHIP_ERROR_TIMEOUT;
+    } else if (eventType == TransferSession::OutputEventType::kStatusReceived) {
+        error = GetChipErrorFromBdxStatusCode(event.statusData.statusCode);
     } else if (eventType != TransferSession::OutputEventType::kAckEOFReceived) {
         error = CHIP_ERROR_INTERNAL;
     }
@@ -480,7 +489,7 @@ void MTROTAImageTransferHandler::HandleTransferSessionOutput(TransferSession::Ou
     case TransferSession::OutputEventType::kAckEOFReceived:
     case TransferSession::OutputEventType::kInternalError:
     case TransferSession::OutputEventType::kTransferTimeout:
-        err = OnTransferSessionEnd(eventType);
+        err = OnTransferSessionEnd(event);
         if (err != CHIP_NO_ERROR) {
             LogErrorOnFailure(err);
             NotifyEventHandled(eventType, err);

--- a/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
@@ -793,7 +793,11 @@ static BOOL sStackInitRan = NO;
             sOTAProviderDelegate.transferEndHandler = nil;
             XCTAssertEqualObjects(nodeID, @(kDeviceId1));
             XCTAssertIdentical(controller, sController);
-            XCTAssertNotNil(error); // we cancelled the transfer, so there should be an error
+            // We cancelled the transfer with a specific error, so the transfer-end callback should
+            // report that actual error rather than a generic one.
+            XCTAssertNotNil(error);
+            XCTAssertEqualObjects(error.domain, MTRErrorDomain);
+            XCTAssertEqual(error.code, MTRErrorCodeCancelled);
         };
 
         XCTAssertEqualObjects(nodeID, @(kDeviceId1));
@@ -820,8 +824,9 @@ static BOOL sStackInitRan = NO;
                                       softwareVersionString:kUpdatedSoftwareVersionString_5
                                                  completion:innerCompletion];
 
-            // Cancel the transfer with device1
-            [sOTAProviderDelegate respondErrorWithCompletion:outerCompletion];
+            // Cancel the transfer with device1, using a specific error so we can verify it is the
+            // error reported to the transfer-end callback (rather than a generic error).
+            [sOTAProviderDelegate respondErrorWithCode:MTRErrorCodeCancelled completion:outerCompletion];
         };
 
         announceResponseExpectation2 = [self announceProviderToDevice:device2];
@@ -846,6 +851,92 @@ static BOOL sStackInitRan = NO;
                  enforceOrder:YES];
 
     [self waitForExpectations:@[ announceResponseExpectation1, announceResponseExpectation2 ] timeout:kTimeoutInSeconds];
+}
+
+- (void)test003b_ReceiveQueryImageRequestThenTimeOutBDXTransfer
+{
+    // In this test we do the following:
+    //
+    // 1) Shorten the BDX transfer timeout via a user default so the exchange response timeout
+    //    fires quickly instead of after the 5 minute production default.
+    // 2) Advertise ourselves to the device and, when it queries, claim to have an image.
+    // 3) When the device tries to start a BDX transfer, terminate the requestor app so it stops
+    //    responding, then accept the transfer.
+    // 4) Since the peer is gone, the messages we send never get a response, so our exchange
+    //    response timeout fires and the transfer-end callback must report MTRErrorCodeTimeout.
+    NSString * const bdxTimeoutDefaultsKey = @"BDXTransferTimeoutInSeconds";
+    const NSInteger bdxTimeoutInSeconds = 3;
+    [[NSUserDefaults standardUserDefaults] setInteger:bdxTimeoutInSeconds forKey:bdxTimeoutDefaultsKey];
+    // Ensure the override is always cleared, even if an assertion below fails, so it can't leak
+    // into later tests.
+    [self addTeardownBlock:^() {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:bdxTimeoutDefaultsKey];
+    }];
+
+    __auto_type * downloadFilePath =
+        [NSString stringWithFormat:@"/tmp/chip-ota-requestor-downloaded-image%u", [MTROTAProviderTests nextUniqueIndex]];
+    MTRTestCaseServerApp * requestorApp = [self startCommissionedAppWithName:@"ota-requestor"
+                                                                   arguments:@[ @"--otaDownloadPath", downloadFilePath, @"--autoApplyImage" ]
+                                                                  controller:sController
+                                                                     payload:kOnboardingPayload1
+                                                                      nodeID:@(kDeviceId1)];
+    XCTAssertNotNil(requestorApp);
+    __auto_type * device = [MTRDevice deviceWithNodeID:@(kDeviceId1) controller:sController];
+
+    XCTestExpectation * queryExpectation = [self expectationWithDescription:@"handleQueryImageForNodeID called"];
+    XCTestExpectation * transferBeginExpectation = [self expectationWithDescription:@"handleBDXTransferSessionBeginForNodeID called"];
+    XCTestExpectation * transferEndExpectation = [self expectationWithDescription:@"handleBDXTransferSessionEndForNodeID called"];
+
+    NSString * fakeImageURI = @"No such image, really";
+
+    sOTAProviderDelegate.queryImageHandler = ^(NSNumber * nodeID, MTRDeviceController * controller,
+        MTROTASoftwareUpdateProviderClusterQueryImageParams * params, QueryImageCompletion completion) {
+        sOTAProviderDelegate.queryImageHandler = nil;
+        XCTAssertEqualObjects(nodeID, @(kDeviceId1));
+        XCTAssertIdentical(controller, sController);
+        [sOTAProviderDelegate respondAvailableWithDelay:@(0)
+                                                    uri:fakeImageURI
+                                            updateToken:[sOTAProviderDelegate generateUpdateToken]
+                                        softwareVersion:kUpdatedSoftwareVersion_5
+                                  softwareVersionString:kUpdatedSoftwareVersionString_5
+                                             completion:completion];
+        [queryExpectation fulfill];
+    };
+
+    sOTAProviderDelegate.transferBeginHandler = ^(NSNumber * nodeID, MTRDeviceController * controller, NSString * fileDesignator,
+        NSNumber * offset, MTRStatusCompletion completion) {
+        sOTAProviderDelegate.transferBeginHandler = nil;
+        XCTAssertEqualObjects(nodeID, @(kDeviceId1));
+        XCTAssertIdentical(controller, sController);
+
+        // Now that we've begun a transfer, we expect to be told when it ends.
+        sOTAProviderDelegate.transferEndHandler = ^(NSNumber * nodeID, MTRDeviceController * controller, MTRMetrics * metrics, NSError * _Nullable error) {
+            sOTAProviderDelegate.transferEndHandler = nil;
+            XCTAssertEqualObjects(nodeID, @(kDeviceId1));
+            XCTAssertIdentical(controller, sController);
+            // The peer stopped responding, so the transfer must end with a timeout error reported
+            // to the transfer-end callback (rather than a generic error).
+            XCTAssertNotNil(error);
+            XCTAssertEqualObjects(error.domain, MTRErrorDomain);
+            XCTAssertEqual(error.code, MTRErrorCodeTimeout);
+            [transferEndExpectation fulfill];
+        };
+
+        // Terminate the requestor so it stops responding, then accept the transfer.  Since the peer
+        // is gone, the messages we send will never get a response and our (shortened) exchange
+        // response timeout will fire.
+        [requestorApp terminate];
+        [sOTAProviderDelegate respondSuccess:completion];
+        [transferBeginExpectation fulfill];
+    };
+
+    XCTestExpectation * announceResponseExpectation = [self announceProviderToDevice:device];
+
+    // Wait long enough for commissioning/announce plus the shortened BDX timeout to fire.
+    [self waitForExpectations:@[ queryExpectation, transferBeginExpectation, transferEndExpectation ]
+                      timeout:(kTimeoutInSeconds + bdxTimeoutInSeconds + 30)
+                 enforceOrder:YES];
+    [self waitForExpectations:@[ announceResponseExpectation ] timeout:kTimeoutInSeconds];
 }
 
 - (void)test004_DoBDXTransferDenyUpdateRequest

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.h
@@ -21,6 +21,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRTestCaseServerApp : NSObject
+
+/**
+ * Terminate the running app.  Useful for simulating a peer that stops responding
+ * partway through an interaction.  The app is also terminated automatically at
+ * the end of the test, so calling this is optional; calling it more than once, or
+ * after the app has already exited, is harmless.
+ */
+- (void)terminate;
 @end
 
 @interface MTRTestCase (ServerAppRunner)

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.m
@@ -19,6 +19,8 @@
 #import "MTRTestCase+ServerAppRunner.h"
 #import "MTRTestControllerDelegate.h"
 
+#include <signal.h>
+
 static unsigned sAppRunnerIndex = 1;
 static const uint16_t kPairingTimeoutInSeconds = 30;
 
@@ -37,6 +39,36 @@ static const uint16_t kBasePort = 5542 - kMinDiscriminator;
 #endif // HAVE_NSTASK
 
 @implementation MTRTestCaseServerApp
+
+- (void)terminate
+{
+#if HAVE_NSTASK
+    NSTask * task = self.task;
+    if (task == nil || !task.isRunning) {
+        return;
+    }
+
+    [task terminate]; // Sends SIGTERM
+
+    // Wait up to 10 seconds for graceful shutdown, then force-kill, mirroring
+    // TerminateTask in MTRTestCase.mm, so a stuck child can't hang the test run.
+    BOOL terminated = NO;
+    for (int i = 0; i < 100; i++) {
+        if (![task isRunning]) {
+            terminated = YES;
+            break;
+        }
+        [NSThread sleepForTimeInterval:0.1];
+    }
+
+    if (!terminated) {
+        kill(task.processIdentifier, SIGKILL);
+    }
+
+    [task waitUntilExit];
+#endif // HAVE_NSTASK
+}
+
 @end
 
 @implementation MTRTestCase (ServerAppRunner)

--- a/src/platform/Darwin/UserDefaults.h
+++ b/src/platform/Darwin/UserDefaults.h
@@ -27,5 +27,9 @@ std::optional<System::Clock::Milliseconds16> GetUserDefaultBDXThrottleIntervalFo
 
 std::optional<uint8_t> GetUserDefaultBDXThreadFramesPerBlock();
 
+// Returns an override for the BDX transfer timeout, if one is configured. This is a debug/testing
+// hook (the OTA spec mandates a timeout of at least 5 minutes for production use).
+std::optional<System::Clock::Seconds16> GetUserDefaultBDXTransferTimeout();
+
 } // namespace Platform
 } // namespace chip

--- a/src/platform/Darwin/UserDefaults.mm
+++ b/src/platform/Darwin/UserDefaults.mm
@@ -25,6 +25,8 @@ static NSString * const kBDXThrottleIntervalInMsecsUserDefaultKey = @"BDXThrottl
 
 static NSString * const kBDXThreadFramesPerBlockDefaultKey = @"BDXThreadFramesPerBlock";
 
+static NSString * const kBDXTransferTimeoutInSecondsDefaultKey = @"BDXTransferTimeoutInSeconds";
+
 namespace chip {
 namespace Platform {
 
@@ -75,6 +77,19 @@ namespace Platform {
             ChipLogProgress(BDX, "Got a user default value for thread frames per block - %d", numberOfFrames.value());
         }
         return numberOfFrames;
+    }
+
+    std::optional<System::Clock::Seconds16> GetUserDefaultBDXTransferTimeout()
+    {
+        std::optional timeoutInSeconds = GetUserDefault<uint16_t>(kBDXTransferTimeoutInSecondsDefaultKey, kDontAcceptZero);
+        if (timeoutInSeconds.has_value()) {
+            ChipLogProgress(BDX, "Got a user default value for BDX transfer timeout - %d seconds", timeoutInSeconds.value());
+            return std::make_optional(System::Clock::Seconds16(timeoutInSeconds.value()));
+        }
+
+        // A value of 0 means either the key was not found or the value was zero; treat both as unset,
+        // since a zero-second timeout is not a feasible value.
+        return std::nullopt;
     }
 
 } // namespace Platform

--- a/src/protocols/bdx/AsyncTransferFacilitator.cpp
+++ b/src/protocols/bdx/AsyncTransferFacilitator.cpp
@@ -83,6 +83,7 @@ void AsyncTransferFacilitator::ProcessOutputEvents()
             // message!) but eventually they will time out.
             if (err != CHIP_NO_ERROR)
             {
+                mTransferEndError = err;
                 DestroySelf();
                 return;
             }
@@ -149,6 +150,7 @@ CHIP_ERROR AsyncTransferFacilitator::OnMessageReceived(Messaging::ExchangeContex
 
         // This should notify the transfer object to abort transfer so it can send a status report across the exchange
         // when we call ProcessOutputEvents below.
+        mTransferEndError = err;
         TEMPORARY_RETURN_IGNORED mTransfer.AbortTransfer(GetBdxStatusCodeFromChipError(err));
     }
     else if (!payloadHeader.HasMessageType(MessageType::BlockAckEOF))
@@ -164,6 +166,7 @@ CHIP_ERROR AsyncTransferFacilitator::OnMessageReceived(Messaging::ExchangeContex
 void AsyncTransferFacilitator::OnResponseTimeout(Messaging::ExchangeContext * ec)
 {
     ChipLogDetail(BDX, "OnResponseTimeout, ec: " ChipLogFormatExchange, ChipLogValueExchange(ec));
+    mTransferEndError = CHIP_ERROR_TIMEOUT;
     DestroySelf();
 }
 
@@ -178,6 +181,13 @@ CHIP_ERROR AsyncResponder::Init(System::Layer * layer, Messaging::ExchangeContex
 
 void AsyncResponder::NotifyEventHandled(const TransferSession::OutputEventType eventType, CHIP_ERROR status)
 {
+    // Record the error (if any) that is ending the transfer, so subclasses that report a terminal
+    // error (e.g. from their destructor) can surface the real cause instead of a generic error.
+    if (status != CHIP_NO_ERROR)
+    {
+        mTransferEndError = status;
+    }
+
     // If this is the end of the transfer (whether a clean end, or some sort of error condition), ensure
     // that we destroy ourselves after unwinding the processing loop in the ProcessOutputEvents API.
     // We can ignore the status for these output events because none of them are supposed to result in

--- a/src/protocols/bdx/AsyncTransferFacilitator.h
+++ b/src/protocols/bdx/AsyncTransferFacilitator.h
@@ -82,6 +82,10 @@ protected:
 
     bool mDestroySelfAfterProcessingEvents = false;
 
+    // The error that ended the transfer, recorded on teardown-on-error paths so subclasses can
+    // report the real cause (e.g. a timeout) instead of a generic error.
+    CHIP_ERROR mTransferEndError = CHIP_ERROR_INTERNAL;
+
 private:
     bool mProcessingOutputEvents = false;
 

--- a/src/protocols/bdx/StatusCode.cpp
+++ b/src/protocols/bdx/StatusCode.cpp
@@ -45,5 +45,37 @@ StatusCode GetBdxStatusCodeFromChipError(CHIP_ERROR error)
     return status;
 }
 
+CHIP_ERROR GetChipErrorFromBdxStatusCode(StatusCode statusCode)
+{
+    // Map a BDX StatusCode received from a peer to a CHIP_ERROR. This is the rough inverse of
+    // GetBdxStatusCodeFromChipError. Any status code that does not have a more specific mapping is
+    // reported as CHIP_ERROR_BAD_REQUEST so that a peer-initiated abort is never indistinguishable
+    // from an internal error.
+    switch (statusCode)
+    {
+    case StatusCode::kUnexpectedMessage:
+        return CHIP_ERROR_INCORRECT_STATE;
+    case StatusCode::kLengthTooLarge:
+    case StatusCode::kLengthTooShort:
+    case StatusCode::kLengthMismatch:
+    case StatusCode::kLengthRequired:
+    case StatusCode::kBadMessageContents:
+    case StatusCode::kBadBlockCounter:
+    case StatusCode::kStartOffsetNotSupported:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    case StatusCode::kResponderBusy:
+        return CHIP_ERROR_BUSY;
+    case StatusCode::kTransferMethodNotSupported:
+    case StatusCode::kVersionNotSupported:
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    case StatusCode::kFileDesignatorUnknown:
+        return CHIP_ERROR_UNKNOWN_RESOURCE_ID;
+    case StatusCode::kTransferFailedUnknownError:
+    case StatusCode::kUnknown:
+    default:
+        return CHIP_ERROR_BAD_REQUEST;
+    }
+}
+
 } // namespace bdx
 } // namespace chip

--- a/src/protocols/bdx/StatusCode.h
+++ b/src/protocols/bdx/StatusCode.h
@@ -43,5 +43,7 @@ enum class StatusCode : uint16_t
 
 StatusCode GetBdxStatusCodeFromChipError(CHIP_ERROR error);
 
+CHIP_ERROR GetChipErrorFromBdxStatusCode(StatusCode statusCode);
+
 } // namespace bdx
 } // namespace chip


### PR DESCRIPTION
### Summary

MTROTAImageTransferHandler reported a hardcoded CHIP_ERROR_INTERNAL from its transfer-session-end callback whenever the transfer was torn down through an error path, per a long-standing TODO in its destructor. As a result the real cause of an OTA BDX transfer failure — e.g. a response timeout when the peer stops responding mid-transfer, a send failure, a malformed inbound message, or a peer-initiated abort — was lost by the time the transfer-session-end callback fired, and both the callback and any telemetry saw a generic internal error.

This records the actual terminal error and reports it, fixing every teardown path (not just the timeout) by centralizing the tracking in the shared BDX base class:

- Add a protected AsyncTransferFacilitator::mTransferEndError (default CHIP_ERROR_INTERNAL) and set it to the real error at each base-class teardown-on-error site: the exchange response timeout (CHIP_ERROR_TIMEOUT), a SendMessage transport failure, an inbound message parse/decode error, and the AsyncResponder abort path (the error passed to NotifyEventHandled). MTROTAImageTransferHandler reports this from its destructor.
- Remove the previous derived-class OnResponseTimeout / NotifyEventHandled overrides now that the base tracks the error, eliminating a fragile non-virtual method hide.
- Map a peer-sent BDX StatusReport abort (kStatusReceived) to a meaningful CHIP_ERROR via a new bdx::GetChipErrorFromBdxStatusCode helper, so a peer abort is no longer indistinguishable from an internal error.

The framework only forwards this error to the transfer-session-end delegate, so there is no control-flow change; the improvement is that delegates and telemetry observe the true cause. The new base-class member is purely recorded; other BDX subclasses that never read it are unaffected. Darwin plus a small shared BDX change; negligible size impact.

### Related issues

None.

### Testing

Two automated integration tests in MTROTAProviderTests (built and run end-to-end via the CHIPTests Darwin bundle in CI, which spawns an OTA-requestor subprocess):

- test003_ReceiveQueryImageRequestWhileHandlingBDX_RespondImplicitBusy (strengthened): the transfer is now cancelled with a specific error (MTRErrorCodeCancelled) and the test asserts the transfer-session-end callback receives exactly that error (domain + code) rather than only asserting that some error was reported. This exercises the abort teardown path.
- test003b_ReceiveQueryImageRequestThenTimeOutBDXTransfer (new): drives a real transfer and terminates the requestor subprocess at transfer-begin so the peer stops responding, then asserts the transfer-session-end callback reports MTRErrorCodeTimeout. This exercises the response-timeout teardown path. A new Darwin BDXTransferTimeoutInSeconds user-default override lets the test shorten the otherwise 5-minute BDX response timeout so the timeout fires quickly; the framework only honors a below-minimum override in debug/test builds (the CHIPTests "Matter Framework Tests" scheme builds Debug), while release builds floor any override to the spec-mandated 5 minute minimum, so this seam cannot affect production OTA transfers.
