### PR TITLE
[CI/testing infra] Disable background wildcard subscription in TC_ICDB_2_4

### DIFF
--- a/src/python_testing/TC_ICDB_2_4.py
+++ b/src/python_testing/TC_ICDB_2_4.py
@@ -87,6 +87,10 @@ ONE_HOUR_S = 3600
 
 class TC_ICDB_2_4(ICDBaseTest):
 
+    # ICD state machine transitions between subscribed and check-in states are validated
+    # explicitly; background wildcard subscription interferes with quiet-device assertions.
+    disable_wildcard_subscription = True
+
     # DUT can take more than one cycle to detect a dropped subscriber and resume check-ins, default_timeout
     # is raised to accommodate that (can be overridden by a --timeout on the command line)
     @property


### PR DESCRIPTION
#### Summary

Disable background wildcard subscription in `TC_ICDB_2_4` to prevent intermittent test failures caused by background subscription reports interfering with ICD state machine recovery assertions.

##### Problem

`TC_ICDB_2_4` validates multi-fabric ICD state transitions between **Subscribed** and **Check-In** states. In Step 6, TH1 tears down its subscription and asserts that the DUT resumes sending Check-In messages to TH1 while TH2 remains subscribed.

The test experiences intermittent flakiness (~80–90% pass rate) due to:
* **Background Wildcard Subscription**: `MatterBaseTest` starts a background wildcard subscription (`*/*/*`, 30s interval) on Fabric 1 via a secondary controller.
* **Timing Collisions**:
```
[Before: Background Wildcard Active]
TH1 Subscription Drop ----> DUT receives InvalidSubscription
                               │
Background Wildcard Report ────┴─► Resets/Extends ActiveMode Duration
                                   └─► Delays/Shifts Check-In cycle beyond expected wait window
```
* **Sequential Assertion Window in Step 6**:
  * Step 6 awaits TH1 Check-In (~15–30s).
  * During this wait, TH2 heartbeats arrive every 10s unbuffered.
  * Once TH1 Check-In completes, the test waits only `MaxInterval + 1.0s` (11s) for the next TH2 heartbeat. If timing jitter or active mode extension pushes the report past 11.0s, the step times out.

##### Solution

```
[After: disable_wildcard_subscription = True]
Fabric 1: TH1 Explicit Subscription (Step 4) ──(Step 6 Drop)──► Clean Transition to Check-In
Fabric 2: TH2 Explicit Subscription (Step 4) ─────────────────► Steady Heartbeats (Step 6)
(No background controllers generating asynchronous traffic on Fabric 1)
```

* Set `disable_wildcard_subscription = True` in `TC_ICDB_2_4` so all active subscriptions are controlled explicitly by the test.

#### Testing

* Verified in `TC_ICDB_2_4.py`.
