### PR TITLE
Darwin:  Add attribute report / response timestamp

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -56,6 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
  *                MTREventIsHistoricalKey : NSNumber-wrapped BOOL value.
  *                                          Value is YES if the event is in the far past or not realtime.
  *                                          Only present when MTREventPathKey is present.
+ *                MTRLocalReceiptTimeKey : NSDate object.
+ *                                         The local time at which the value was received from the device.  This is an
+ *                                         observation made by this system, not a timestamp supplied by the device, and is
+ *                                         therefore not comparable to MTREventTimestampDateKey or to any device-reported
+ *                                         time.
+ *                                         Only present when MTRAttributePathKey is present.
  *
  *                Only one of MTREventTimestampDateKey and MTREventSystemUpTimeKey will be present, depending on the value for
  *                MTREventTimeTypeKey.
@@ -146,6 +152,7 @@ MTR_EXTERN NSString * const MTREventTimeTypeKey MTR_AVAILABLE(ios(16.5), macos(1
 MTR_EXTERN NSString * const MTREventSystemUpTimeKey MTR_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5));
 MTR_EXTERN NSString * const MTREventTimestampDateKey MTR_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5));
 MTR_EXTERN NSString * const MTREventIsHistoricalKey MTR_AVAILABLE(ios(17.3), macos(14.3), watchos(10.3), tvos(17.3));
+MTR_EXTERN NSString * const MTRLocalReceiptTimeKey MTR_PROVISIONALLY_AVAILABLE;
 
 @class MTRClusterStateCacheContainer;
 @class MTRAttributeCacheContainer;
@@ -668,6 +675,16 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * path.
  */
 @property (nonatomic, readonly, copy, nullable) NSError * error;
+
+/**
+ * The local time at which this value was received from the device, as described
+ * for MTRLocalReceiptTimeKey in MTRDeviceResponseHandler.
+ *
+ * Nil when the value did not come from the device (locally synthesized expected
+ * values) or came from a local cache, whose age is not tracked.  Nil means "age
+ * unknown", not "just now".
+ */
+@property (nonatomic, readonly, copy, nullable) NSDate * localReceiptTime MTR_PROVISIONALLY_AVAILABLE;
 
 /**
  * Initialize an MTRAttributeReport with a response-value dictionary of the sort

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -76,6 +76,7 @@ NSString * const MTRErrorKey = @"error";
 NSString * const MTRTypeKey = @"type";
 NSString * const MTRValueKey = @"value";
 NSString * const MTRContextTagKey = @"contextTag";
+NSString * const MTRLocalReceiptTimeKey = @"localReceiptTime";
 NSString * const MTRSignedIntegerValueType = @"SignedInteger";
 NSString * const MTRUnsignedIntegerValueType = @"UnsignedInteger";
 NSString * const MTRBooleanValueType = @"Boolean";
@@ -1119,17 +1120,26 @@ private:
             auto resultArray = [[NSMutableArray alloc] init];
             auto onAttributeSuccessCb
                 = [resultArray, includeDataVersion](const ConcreteDataAttributePath & aAttributePath, const MTRDataValueDictionaryDecodableType & aData) {
+                      // Capture the receipt time here, as close to the wire as we can get: this runs
+                      // synchronously as the ReadClient decodes the incoming report, before the
+                      // results are handed back to the caller's queue.  Stamping here is what gives
+                      // the key its meaning: a value that carries one arrived from the device at that
+                      // instant, as opposed to coming from a cache or being synthesized locally.
+                      NSDate * localReceiptTime = [NSDate now];
+
                       // TODO: move this logic into MTRDataValueDictionaryDecodableType
                       if (includeDataVersion && aAttributePath.mDataVersion.HasValue()) {
                           NSDictionary * dataValue = aData.GetDecodedObject();
                           [resultArray addObject:@{
                               MTRAttributePathKey : [[MTRAttributePath alloc] initWithPath:aAttributePath],
-                              MTRDataKey : _MakeDataValueDictionary(dataValue[MTRTypeKey], dataValue[MTRValueKey], @(aAttributePath.mDataVersion.Value()))
+                              MTRDataKey : _MakeDataValueDictionary(dataValue[MTRTypeKey], dataValue[MTRValueKey], @(aAttributePath.mDataVersion.Value())),
+                              MTRLocalReceiptTimeKey : localReceiptTime,
                           }];
                       } else {
                           [resultArray addObject:@ {
                               MTRAttributePathKey : [[MTRAttributePath alloc] initWithPath:aAttributePath],
-                              MTRDataKey : aData.GetDecodedObject()
+                              MTRDataKey : aData.GetDecodedObject(),
+                              MTRLocalReceiptTimeKey : localReceiptTime,
                           }];
                       }
                   };
@@ -3197,6 +3207,17 @@ static bool EncodeDataValueToTLV(System::PacketBufferHandle & buffer, Platform::
     }
     MTRAttributePath * path = responseValue[MTRAttributePathKey];
 
+    // Optional: present only when this value came from the device.  Assigned before the
+    // branches below so that it survives on every path that returns a report, whether the
+    // report ends up carrying data or an error.
+    if (responseValue[MTRLocalReceiptTimeKey] != nil) {
+        if (!CheckMemberOfType(responseValue, MTRLocalReceiptTimeKey, [NSDate class],
+                @"response-value local receipt time is not an NSDate.", error)) {
+            return nil;
+        }
+        _localReceiptTime = responseValue[MTRLocalReceiptTimeKey];
+    }
+
     id _Nullable value = responseValue[MTRErrorKey];
     if (value != nil) {
         if (!CheckMemberOfType(responseValue, MTRErrorKey, [NSError class], @"response-value error is not an NSError.", error)) {
@@ -3256,7 +3277,11 @@ static bool EncodeDataValueToTLV(System::PacketBufferHandle & buffer, Platform::
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return [[MTRAttributeReport alloc] initWithPath:[self.path _asConcretePath] value:self.value error:self.error];
+    auto * copy = [[MTRAttributeReport alloc] initWithPath:[self.path _asConcretePath] value:self.value error:self.error];
+    // initWithPath:value:error: has no receipt time to work from, so carry it over
+    // explicitly; otherwise copying would silently drop the age of the value.
+    copy->_localReceiptTime = self.localReceiptTime;
+    return copy;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -416,9 +416,18 @@ MTR_EXTERN NSString * const MTRDataVersionKey MTR_AVAILABLE(ios(17.6), macos(14.
  *
  * @param attributeReport  An array of response-value objects as described in MTRDeviceResponseHandler
  *
- *                In addition to MTRDataKey, each response-value dictionary in the array may also have this key:
+ *                In addition to MTRDataKey, each response-value dictionary in the array may also have these keys:
  *
  *                MTRPreviousDataKey : Same data-value dictionary format as the object for MTRDataKey. This is included when the previous value is known for an attribute.
+ *
+ *                MTRLocalReceiptTimeKey : NSDate object, as described in MTRDeviceResponseHandler.  The local time at which
+ *                                         this value was received from the device.
+ *
+ *                                         Present only for values that were in fact received from the device, whether via
+ *                                         a subscription report or via a read.  Absent for locally synthesized expected
+ *                                         values, and for values served from the local cache (for example, when an
+ *                                         expected value expires and the cached value is reported in its place), whose age
+ *                                         is not tracked.  Absent means "age unknown", not "just now".
  *
  *                The data-value dictionary also contains this key:
  *

--- a/src/darwin/Framework/CHIP/MTRDeviceDataValidation.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceDataValidation.mm
@@ -85,6 +85,13 @@ BOOL MTRAttributeReportIsWellFormed(NSArray<MTRDeviceResponseValueDictionary> * 
             MTR_LOG_ERROR("Attribute report contains an entry that claims to be both data and error: %@", item);
             return NO;
         }
+
+        // MTRLocalReceiptTimeKey is optional, but if present it must be an NSDate.
+        id localReceiptTime = item[MTRLocalReceiptTimeKey];
+        if (localReceiptTime != nil && !MTR_SAFE_CAST(localReceiptTime, NSDate)) {
+            MTR_LOG_ERROR("Attribute report contains an entry whose local receipt time is not an NSDate: %@", item);
+            return NO;
+        }
     }
 
     return YES;

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -5351,12 +5351,26 @@ void SubscriptionCallback::OnAttributeData(
     }
 
     MTRAttributePath * attributePath = [[MTRAttributePath alloc] initWithPath:aPath];
+
+    // Capture the receipt time here, as close to the wire as we can get: this
+    // runs synchronously as the ReadClient processes the incoming report, before
+    // the report is queued over to the MTRDevice's queue for handling.  Stamping
+    // here is what gives the key its meaning: a value that carries one arrived
+    // from the device at that instant.  A stamp applied further out could not tell
+    // that apart from a value served from the cache or synthesized locally.
+    NSDate * localReceiptTime = [NSDate now];
+
     if (aStatus.mStatus != Status::Success) {
-        [mAttributeReports addObject:@ { MTRAttributePathKey : attributePath, MTRErrorKey : [MTRError errorForIMStatus:aStatus] }];
+        [mAttributeReports addObject:@ {
+            MTRAttributePathKey : attributePath,
+            MTRErrorKey : [MTRError errorForIMStatus:aStatus],
+            MTRLocalReceiptTimeKey : localReceiptTime,
+        }];
     } else if (apData == nullptr) {
         [mAttributeReports addObject:@ {
             MTRAttributePathKey : attributePath,
-            MTRErrorKey : [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_ARGUMENT]
+            MTRErrorKey : [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_ARGUMENT],
+            MTRLocalReceiptTimeKey : localReceiptTime,
         }];
     } else {
         NSNumber * dataVersionNumber = aPath.mDataVersion.HasValue() ? @(aPath.mDataVersion.Value()) : nil;
@@ -5366,9 +5380,14 @@ void SubscriptionCallback::OnAttributeData(
             [mAttributeReports addObject:@ {
                 MTRAttributePathKey : attributePath,
                 MTRErrorKey : [MTRError errorForCHIPErrorCode:CHIP_ERROR_DECODE_FAILED],
+                MTRLocalReceiptTimeKey : localReceiptTime,
             }];
         } else {
-            [mAttributeReports addObject:@ { MTRAttributePathKey : attributePath, MTRDataKey : value }];
+            [mAttributeReports addObject:@ {
+                MTRAttributePathKey : attributePath,
+                MTRDataKey : value,
+                MTRLocalReceiptTimeKey : localReceiptTime,
+            }];
         }
     }
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6477,8 +6477,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type * injectedReport = @[ @{
         MTRAttributePathKey : [MTRAttributePath attributePathWithEndpointID:@(1)
-                                                                 clusterID:@(MTRClusterIDTypeOnOffID)
-                                                               attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnTimeID)],
+                                                                  clusterID:@(MTRClusterIDTypeOnOffID)
+                                                                attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnTimeID)],
         MTRDataKey : @ {
             MTRTypeKey : MTRUnsignedIntegerValueType,
             MTRValueKey : @(17),
@@ -6566,8 +6566,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // AttributeHasChangesOmittedQuality in MTRDevice_Concrete.mm).
     __auto_type * attributePaths = @[
         [MTRAttributeRequestPath requestPathWithEndpointID:@(0)
-                                                clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
-                                              attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeUpTimeID)],
+                                                 clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                               attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeUpTimeID)],
     ];
 
     NSDate * beforeRead = [NSDate now];
@@ -6616,8 +6616,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // could use it.
     __auto_type * receiptTime = [NSDate dateWithTimeIntervalSince1970:1750000000];
     __auto_type * path = [MTRAttributePath attributePathWithEndpointID:@(1)
-                                                            clusterID:@(MTRClusterIDTypeOnOffID)
-                                                          attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnTimeID)];
+                                                             clusterID:@(MTRClusterIDTypeOnOffID)
+                                                           attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnTimeID)];
     __auto_type * responseValue = @{
         MTRAttributePathKey : path,
         MTRDataKey : @ {

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6399,6 +6399,276 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTAssertGreaterThan(values.count, 100);
 }
 
+- (void)test051_LocalReceiptTimeOnAttributeReports
+{
+    __auto_type * device = [MTRDevice deviceWithNodeID:kDeviceId1 deviceController:sController];
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+
+    XCTestExpectation * subscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up"];
+    delegate.onReportEnd = ^{
+        [subscriptionExpectation fulfill];
+    };
+
+    // Collect everything reported during subscription priming, so we can check the
+    // receipt times against a window we control on both ends.
+    __auto_type * reportedValues = [NSMutableArray array];
+    __auto_type * lock = [[NSObject alloc] init];
+    delegate.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
+        @synchronized(lock) {
+            [reportedValues addObjectsFromArray:data];
+        }
+    };
+
+    NSDate * beforeSubscription = [NSDate now];
+    [device setDelegate:delegate queue:queue];
+    [self waitForExpectations:@[ subscriptionExpectation ] timeout:60];
+    NSDate * afterReports = [NSDate now];
+
+    NSArray<NSDictionary<NSString *, id> *> * values;
+    @synchronized(lock) {
+        values = [reportedValues copy];
+    }
+
+    // Priming a subscription to all-clusters-app reports a lot of attributes; if we got
+    // nothing, the per-value assertions below would vacuously pass.
+    XCTAssertGreaterThan(values.count, 100);
+
+    for (NSDictionary<NSString *, id> * value in values) {
+        // This data came from a report the device sent us, so we should know when it arrived.
+        NSDate * receiptTime = value[MTRLocalReceiptTimeKey];
+        XCTAssertNotNil(receiptTime, "No receipt time for reported value %@", value);
+        XCTAssertTrue([receiptTime isKindOfClass:[NSDate class]], "Receipt time is not an NSDate: %@", receiptTime);
+
+        // The report cannot have arrived before we asked for it, nor after we stopped
+        // waiting for it.
+        XCTAssertEqual([receiptTime compare:beforeSubscription], NSOrderedDescending,
+            "Receipt time %@ predates subscription setup at %@", receiptTime, beforeSubscription);
+        XCTAssertEqual([receiptTime compare:afterReports], NSOrderedAscending,
+            "Receipt time %@ postdates last report at %@", receiptTime, afterReports);
+    }
+}
+
+- (void)test051b_NoLocalReceiptTimeForValuesNotReceivedFromDevice
+{
+    // Values that did not arrive in a report from the device must not claim a receipt
+    // time, since we do not know how old they are.  This pins the receipt time to the
+    // point where a report is actually received off the wire; stamping it later (when a
+    // report is handled, or when it is handed to delegates) would wrongly attach a time
+    // to values like these.
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    // Use a node we never commission, with subscription setup skipped, so this device has
+    // an empty cache and never talks to an accessory: anything we inject counts as a
+    // change and so gets reported, and we do not disturb the shared device's cache.
+    __auto_type * device = [MTRDevice deviceWithNodeID:0x12344399 deviceController:sController];
+    __auto_type * delegate = [[MTRDeviceTestDelegateWithSubscriptionSetupOverride alloc] init];
+    delegate.skipSetupSubscription = YES;
+
+    XCTestExpectation * gotReport = [self expectationWithDescription:@"Injected report delivered"];
+    __block NSArray<NSDictionary<NSString *, id> *> * reported = nil;
+    delegate.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
+        reported = data;
+        [gotReport fulfill];
+    };
+
+    [device setDelegate:delegate queue:queue];
+
+    __auto_type * injectedReport = @[ @{
+        MTRAttributePathKey : [MTRAttributePath attributePathWithEndpointID:@(1)
+                                                                 clusterID:@(MTRClusterIDTypeOnOffID)
+                                                               attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnTimeID)],
+        MTRDataKey : @ {
+            MTRTypeKey : MTRUnsignedIntegerValueType,
+            MTRValueKey : @(17),
+        },
+    } ];
+    [device unitTestInjectAttributeReport:injectedReport fromSubscription:YES];
+
+    [self waitForExpectations:@[ gotReport ] timeout:kTimeoutInSeconds];
+
+    XCTAssertEqual(reported.count, 1);
+    XCTAssertNil(reported.firstObject[MTRLocalReceiptTimeKey]);
+}
+
+- (void)test051c_LocalReceiptTimeOnReadResults
+{
+    // Values that arrive in a read response are just as much "received from the device" as
+    // values that arrive in a subscription report, and must be stamped too.  This matters
+    // most for Changes Omitted Quality (C quality) attributes, whose values reach a
+    // consumer via read-through rather than via subscription reports, so the read path is
+    // the only place their age can be established.
+    MTRBaseDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read complete"];
+
+    __auto_type * attributePaths = @[
+        // Basic Information VendorName/VendorID/ProductName, on all endpoints that have it.
+        [MTRAttributeRequestPath requestPathWithEndpointID:nil clusterID:@40 attributeID:@1],
+        [MTRAttributeRequestPath requestPathWithEndpointID:nil clusterID:@40 attributeID:@2],
+        [MTRAttributeRequestPath requestPathWithEndpointID:nil clusterID:@40 attributeID:@3],
+    ];
+
+    NSDate * beforeRead = [NSDate now];
+    [device readAttributePaths:attributePaths
+                    eventPaths:nil
+                        params:nil
+                         queue:queue
+                    completion:^(id _Nullable values, NSError * _Nullable error) {
+                        XCTAssertNil(error);
+                        XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+
+                        NSDate * afterRead = [NSDate now];
+
+                        NSArray * resultArray = values;
+                        // If the read came back empty the per-value assertions below would
+                        // vacuously pass.
+                        XCTAssertGreaterThan(resultArray.count, 0);
+
+                        for (NSDictionary * result in resultArray) {
+                            XCTAssertNotNil(result[MTRAttributePathKey]);
+
+                            NSDate * receiptTime = result[MTRLocalReceiptTimeKey];
+                            XCTAssertNotNil(receiptTime, "No receipt time for read result %@", result);
+                            XCTAssertTrue([receiptTime isKindOfClass:[NSDate class]],
+                                "Receipt time is not an NSDate: %@", receiptTime);
+
+                            // The value cannot have arrived before we asked for it, nor after
+                            // the read completed.
+                            XCTAssertEqual([receiptTime compare:beforeRead], NSOrderedDescending,
+                                "Receipt time %@ predates read start at %@", receiptTime, beforeRead);
+                            XCTAssertEqual([receiptTime compare:afterRead], NSOrderedAscending,
+                                "Receipt time %@ postdates read completion at %@", receiptTime, afterRead);
+                        }
+
+                        [expectation fulfill];
+                    }];
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
+}
+
+- (void)test051d_LocalReceiptTimeOnReadWithDataVersion
+{
+    // The read path has two shapes, depending on whether the caller wants data versions
+    // included, and they build their response-value dictionaries separately.  MTRDevice's
+    // read-through uses the includeDataVersion:YES shape, and read-through is the only way a
+    // Changes Omitted Quality (C quality) attribute's value ever reaches a consumer -- such
+    // an attribute is not reported when it changes -- so this is the shape that matters most
+    // for establishing the age of a C quality value.  test051c covers the other shape.
+    MTRBaseDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read complete"];
+
+    // GeneralDiagnostics UpTime is Changes Omitted Quality (see
+    // AttributeHasChangesOmittedQuality in MTRDevice_Concrete.mm).
+    __auto_type * attributePaths = @[
+        [MTRAttributeRequestPath requestPathWithEndpointID:@(0)
+                                                clusterID:@(MTRClusterIDTypeGeneralDiagnosticsID)
+                                              attributeID:@(MTRAttributeIDTypeClusterGeneralDiagnosticsAttributeUpTimeID)],
+    ];
+
+    NSDate * beforeRead = [NSDate now];
+    [device readAttributePaths:attributePaths
+                    eventPaths:nil
+                        params:nil
+            includeDataVersion:YES
+                         queue:queue
+                    completion:^(id _Nullable values, NSError * _Nullable error) {
+                        XCTAssertNil(error);
+                        XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+
+                        NSDate * afterRead = [NSDate now];
+
+                        NSArray * resultArray = values;
+                        XCTAssertEqual(resultArray.count, 1);
+
+                        NSDictionary * result = resultArray.firstObject;
+
+                        // Confirm we really took the includeDataVersion:YES branch, and not the
+                        // one test051c exercises.
+                        XCTAssertNotNil(result[MTRDataKey][MTRDataVersionKey]);
+
+                        NSDate * receiptTime = result[MTRLocalReceiptTimeKey];
+                        XCTAssertNotNil(receiptTime, "No receipt time for read result %@", result);
+                        XCTAssertTrue([receiptTime isKindOfClass:[NSDate class]],
+                            "Receipt time is not an NSDate: %@", receiptTime);
+
+                        // The value cannot have arrived before we asked for it, nor after the
+                        // read completed.
+                        XCTAssertEqual([receiptTime compare:beforeRead], NSOrderedDescending,
+                            "Receipt time %@ predates read start at %@", receiptTime, beforeRead);
+                        XCTAssertEqual([receiptTime compare:afterRead], NSOrderedAscending,
+                            "Receipt time %@ postdates read completion at %@", receiptTime, afterRead);
+
+                        [expectation fulfill];
+                    }];
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
+}
+
+- (void)test051e_MTRAttributeReportCarriesLocalReceiptTime
+{
+    // MTRAttributeReport is the conversion every consumer of a response-value dictionary
+    // funnels through, so if it drops the receipt time the value never reaches anything that
+    // could use it.
+    __auto_type * receiptTime = [NSDate dateWithTimeIntervalSince1970:1750000000];
+    __auto_type * path = [MTRAttributePath attributePathWithEndpointID:@(1)
+                                                            clusterID:@(MTRClusterIDTypeOnOffID)
+                                                          attributeID:@(MTRAttributeIDTypeClusterOnOffAttributeOnTimeID)];
+    __auto_type * responseValue = @{
+        MTRAttributePathKey : path,
+        MTRDataKey : @ {
+            MTRTypeKey : MTRUnsignedIntegerValueType,
+            MTRValueKey : @(17),
+        },
+        MTRLocalReceiptTimeKey : receiptTime,
+    };
+
+    NSError * error;
+    __auto_type * report = [[MTRAttributeReport alloc] initWithResponseValue:responseValue error:&error];
+    XCTAssertNotNil(report);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(report.localReceiptTime, receiptTime);
+    XCTAssertEqualObjects(report.value, @(17));
+
+    // Copying must not lose the age of the value: copyWithZone: rebuilds via an initializer
+    // that has no receipt time of its own.
+    MTRAttributeReport * copied = [report copy];
+    XCTAssertEqualObjects(copied.localReceiptTime, receiptTime);
+
+    // Absent key means "age unknown", not zero or now.
+    NSMutableDictionary * withoutTime = [responseValue mutableCopy];
+    [withoutTime removeObjectForKey:MTRLocalReceiptTimeKey];
+    __auto_type * unstampedReport = [[MTRAttributeReport alloc] initWithResponseValue:withoutTime error:&error];
+    XCTAssertNotNil(unstampedReport);
+    XCTAssertNil(unstampedReport.localReceiptTime);
+
+    // An error report can carry a receipt time too: we know when the status arrived.
+    __auto_type * errorResponseValue = @{
+        MTRAttributePathKey : path,
+        MTRErrorKey : [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil],
+        MTRLocalReceiptTimeKey : receiptTime,
+    };
+    __auto_type * errorReport = [[MTRAttributeReport alloc] initWithResponseValue:errorResponseValue error:&error];
+    XCTAssertNotNil(errorReport);
+    XCTAssertNotNil(errorReport.error);
+    XCTAssertEqualObjects(errorReport.localReceiptTime, receiptTime);
+
+    // A wrong-typed receipt time is rejected rather than silently ignored, both by the shape
+    // validator that guards report delivery and by the initializer itself.
+    NSMutableDictionary * badTime = [responseValue mutableCopy];
+    badTime[MTRLocalReceiptTimeKey] = @"not a date";
+    XCTAssertFalse(MTRAttributeReportIsWellFormed(@[ badTime ]));
+    XCTAssertTrue(MTRAttributeReportIsWellFormed(@[ responseValue ]));
+
+    error = nil;
+    XCTAssertNil([[MTRAttributeReport alloc] initWithResponseValue:badTime error:&error]);
+    XCTAssertNotNil(error);
+}
+
 @end
 
 @interface MTRDeviceEncoderTests : XCTestCase

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -58,6 +58,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) MTRAsyncWorkQueue<MTRDeviceController *> * concurrentSubscriptionPool;
 @end
 
+@interface MTRBaseDevice (Test)
+// Same as the public readAttributePaths:eventPaths:params:queue:completion:, but also
+// includes data versions in the returned data-value dictionaries.  This is the shape
+// MTRDevice's read-through uses.  Declared here rather than imported from
+// MTRBaseDevice_Internal.h, which pulls in C++ headers.
+- (void)readAttributePaths:(NSArray<MTRAttributeRequestPath *> * _Nullable)attributePaths
+                eventPaths:(NSArray<MTREventRequestPath *> * _Nullable)eventPaths
+                    params:(MTRReadParams * _Nullable)params
+        includeDataVersion:(BOOL)includeDataVersion
+                     queue:(dispatch_queue_t)queue
+                completion:(MTRDeviceResponseHandler)completion;
+@end
+
 @interface MTRDevice (Test)
 - (NSMutableArray<NSNumber *> *)arrayOfNumbersFromAttributeValue:(MTRDeviceDataValueDictionary)dataDictionary;
 - (void)setStorageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration *)storageBehaviorConfiguration;


### PR DESCRIPTION
### Summary

Various time-related attributes can only be interpreted correctly if the time of report is also known.  Because there are caching layers, the time-at-reception isn't always time-of-report.  Add metadata when we are getting the values from the device itself. 

### Testing

Added unit tests.  New dictionary key should not cause any regressions.
