### PR TITLE
[v1.4.2] Cap googleapis-common-protos below 1.75.1 to unblock the build venv

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -292,3 +292,8 @@ setuptools==68.0.0
 # Higher versions depend on proto-plus, which break
 # nanopb code generation (due to name conflict of the 'proto' module)
 google-api-core==2.17.0
+
+# googleapis-common-protos 1.75.1 raised its requirement from protobuf>=4.25.8
+# to protobuf>=6.33.5, which cannot be satisfied together with the protobuf
+# pinned above, so the pigweed build venv fails to resolve.
+googleapis-common-protos<1.75.1


### PR DESCRIPTION
#### Summary

Same fix as #73448, applied to `v1.4.2-branch`. That PR noted this branch carries the same protobuf pin and was likely affected; it now is.

`googleapis-common-protos` 1.75.1, published 2026-08-06, raised its protobuf requirement from `>=4.25.8` to `>=6.33.5`. It is an unpinned transitive dependency, so a fresh resolve picks it up and then conflicts with the `protobuf==5.28.3` pinned in `scripts/setup/constraints.txt`, leaving the pigweed build venv unresolvable:

```
pip._vendor.resolvelib.resolvers.ResolutionImpossible:
  SpecifierRequirement('protobuf~=5.28.2')
  SpecifierRequirement('protobuf<8.0.0,>=6.33.5')  parent=googleapis_common_protos-1.75.1
```

Every job that builds that venv fails. The most recent observed instance is [run 32258915985](https://github.com/project-chip/connectedhomeip/actions/runs/32258915985), where `REPL Tests - Linux (ipv6only-no-ble-no-wifi)` died at `Build linux-x64-fabric-admin-rpc` on `pigweed_build_venv._compile_requirements`. As on v1.5, builds only began failing well after the release, once the pip cache went cold, since a warm cache reused the previously resolved wheels.

`master` is unaffected: it removed the protobuf constraints in #43377 and delegates them to pigweed's `pw_protobuf_compiler`. That change is not on this branch, so the pin here still applies and the conflict is reachable only on the release branches.

This caps the dependency at 1.75.0, which requires `protobuf>=4.25.8` and is compatible with the pinned version. It follows the existing `# Manual edits:` convention in that file, alongside the `google-api-core` cap.

#### Testing

- Not built locally; CI on this PR exercises the affected jobs.
- The 5-line diff is identical to the one merged in #73448.
- Verified the file is consumed by the failing resolution: `.gn:30` sets `pw_build_PIP_CONSTRAINTS = [ "//scripts/setup/constraints.txt" ]`, which `BUILD.gn:87` passes to the pigweed venv.
- Release metadata checked on PyPI: 1.75.0 requires `protobuf<8.0.0,>=4.25.8`; 1.75.1 requires `protobuf<8.0.0,>=6.33.5`.