### PR TITLE
Stop using pointer delegates for OperationalStateCluster and make composite devices generic

### DIFF
--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
@@ -19,21 +19,6 @@
 #include <devices/Types.h>
 
 namespace chip::app {
-namespace {
-
-const Clusters::Globals::Structs::SemanticTagStruct::Type kSurface1Tag = {
-    .mfgCode     = DataModel::NullNullable,
-    .namespaceID = CommonNamespace::kPositionId,
-    .tag         = static_cast<uint8_t>(Clusters::Globals::PositionTag::kLeft),
-};
-
-const Clusters::Globals::Structs::SemanticTagStruct::Type kSurface2Tag = {
-    .mfgCode     = DataModel::NullNullable,
-    .namespaceID = CommonNamespace::kPositionId,
-    .tag         = static_cast<uint8_t>(Clusters::Globals::PositionTag::kRight),
-};
-
-} // namespace
 
 // CookSurfacePart
 
@@ -76,11 +61,7 @@ void CookSurfacePart::Unregister(CodeDrivenDataModelProvider & provider)
 
 // Cooktop
 
-Cooktop::Cooktop(TimerDelegate & timerDelegate, Clusters::OnOffDelegate & surface1OnOff, Clusters::OnOffDelegate & surface2OnOff,
-                 Clusters::IdentifyDelegate & surface1Identify, Clusters::IdentifyDelegate & surface2Identify) :
-    DeviceInterface(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kCooktop, 1)),
-    mSurface1(timerDelegate, surface1OnOff, surface1Identify), mSurface2(timerDelegate, surface2OnOff, surface2Identify)
-{}
+Cooktop::Cooktop() : DeviceInterface(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kCooktop, 1)) {}
 
 CHIP_ERROR Cooktop::Register(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider,
                              EndpointComposition composition)
@@ -95,12 +76,7 @@ CHIP_ERROR Cooktop::Register(EndpointIdAllocator & allocator, CodeDrivenDataMode
         EndpointComposition(composition.parentId, DataModel::EndpointCompositionPattern::kTree, composition.tagList)));
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));
 
-    ReturnErrorOnFailure(mSurface1.Register(
-        allocator.Allocate(), provider,
-        EndpointComposition(mEndpointId, DataModel::EndpointCompositionPattern::kFullFamily, Span(&kSurface1Tag, 1))));
-    ReturnErrorOnFailure(mSurface2.Register(
-        allocator.Allocate(), provider,
-        EndpointComposition(mEndpointId, DataModel::EndpointCompositionPattern::kFullFamily, Span(&kSurface2Tag, 1))));
+    ReturnErrorOnFailure(RegisterParts(allocator, provider));
 
     transaction.Commit();
     return CHIP_NO_ERROR;
@@ -108,9 +84,7 @@ CHIP_ERROR Cooktop::Register(EndpointIdAllocator & allocator, CodeDrivenDataMode
 
 void Cooktop::Unregister(CodeDrivenDataModelProvider & provider)
 {
-    mSurface2.Unregister(provider);
-    mSurface1.Unregister(provider);
-
+    UnregisterParts(provider);
     UnregisterDescriptor(mEndpointId, provider);
     mEndpointId = kInvalidEndpointId;
 }

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.h
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.h
@@ -54,22 +54,21 @@ private:
 class Cooktop : public DeviceInterface
 {
 public:
-    Cooktop(TimerDelegate & timerDelegate, Clusters::OnOffDelegate & surface1OnOff, Clusters::OnOffDelegate & surface2OnOff,
-            Clusters::IdentifyDelegate & surface1Identify, Clusters::IdentifyDelegate & surface2Identify);
+    Cooktop();
     ~Cooktop() override = default;
 
     CHIP_ERROR Register(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider,
                         EndpointComposition composition = {}) override;
     void Unregister(CodeDrivenDataModelProvider & provider) override;
 
-    // Composition getters to expose child endpoints
-    CookSurfacePart & Surface1() { return mSurface1; }
-    CookSurfacePart & Surface2() { return mSurface2; }
+    EndpointId GetEndpointId() const { return mEndpointId; }
+
+protected:
+    virtual CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) = 0;
+    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                       = 0;
 
 private:
     EndpointId mEndpointId = kInvalidEndpointId;
-    CookSurfacePart mSurface1;
-    CookSurfacePart mSurface2;
 };
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.h
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.h
@@ -65,7 +65,7 @@ public:
 
 protected:
     virtual CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) = 0;
-    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                       = 0;
+    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                      = 0;
 
 private:
     EndpointId mEndpointId = kInvalidEndpointId;

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
@@ -67,8 +67,7 @@ const Clusters::Globals::Structs::SemanticTagStruct::Type kSurface2Tag = {
 
 // LoggingCooktop
 
-LoggingCooktop::LoggingCooktop(TimerDelegate & timerDelegate) :
-    mSurface1(timerDelegate, "Left"), mSurface2(timerDelegate, "Right")
+LoggingCooktop::LoggingCooktop(TimerDelegate & timerDelegate) : mSurface1(timerDelegate, "Left"), mSurface2(timerDelegate, "Right")
 {}
 
 CHIP_ERROR LoggingCooktop::RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider)

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
@@ -49,11 +49,43 @@ void LoggingCookSurfacePart::OnTriggerEffect(Clusters::IdentifyCluster & cluster
     ChipLogProgress(DeviceLayer, "CookSurface (%s): OnTriggerEffect", mName);
 }
 
+namespace {
+
+const Clusters::Globals::Structs::SemanticTagStruct::Type kSurface1Tag = {
+    .mfgCode     = DataModel::NullNullable,
+    .namespaceID = CommonNamespace::kPositionId,
+    .tag         = static_cast<uint8_t>(Clusters::Globals::PositionTag::kLeft),
+};
+
+const Clusters::Globals::Structs::SemanticTagStruct::Type kSurface2Tag = {
+    .mfgCode     = DataModel::NullNullable,
+    .namespaceID = CommonNamespace::kPositionId,
+    .tag         = static_cast<uint8_t>(Clusters::Globals::PositionTag::kRight),
+};
+
+} // namespace
+
 // LoggingCooktop
 
 LoggingCooktop::LoggingCooktop(TimerDelegate & timerDelegate) :
-    Cooktop(timerDelegate, mLoggingSurface1, mLoggingSurface2, mLoggingSurface1, mLoggingSurface2),
-    mLoggingSurface1(timerDelegate, "Left"), mLoggingSurface2(timerDelegate, "Right")
+    mSurface1(timerDelegate, "Left"), mSurface2(timerDelegate, "Right")
 {}
+
+CHIP_ERROR LoggingCooktop::RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider)
+{
+    ReturnErrorOnFailure(mSurface1.Register(
+        allocator.Allocate(), provider,
+        EndpointComposition(GetEndpointId(), DataModel::EndpointCompositionPattern::kFullFamily, Span(&kSurface1Tag, 1))));
+    ReturnErrorOnFailure(mSurface2.Register(
+        allocator.Allocate(), provider,
+        EndpointComposition(GetEndpointId(), DataModel::EndpointCompositionPattern::kFullFamily, Span(&kSurface2Tag, 1))));
+    return CHIP_NO_ERROR;
+}
+
+void LoggingCooktop::UnregisterParts(CodeDrivenDataModelProvider & provider)
+{
+    mSurface2.Unregister(provider);
+    mSurface1.Unregister(provider);
+}
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.h
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.h
@@ -47,9 +47,16 @@ public:
     explicit LoggingCooktop(TimerDelegate & timerDelegate);
     ~LoggingCooktop() override = default;
 
+    LoggingCookSurfacePart & Surface1() { return mSurface1; }
+    LoggingCookSurfacePart & Surface2() { return mSurface2; }
+
+protected:
+    CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) override;
+    void UnregisterParts(CodeDrivenDataModelProvider & provider) override;
+
 private:
-    LoggingCookSurfacePart mLoggingSurface1;
-    LoggingCookSurfacePart mLoggingSurface2;
+    LoggingCookSurfacePart mSurface1;
+    LoggingCookSurfacePart mSurface2;
 };
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/dishwasher/Dishwasher.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/dishwasher/Dishwasher.cpp
@@ -32,7 +32,7 @@ CHIP_ERROR Dishwasher::Register(EndpointId endpoint, CodeDrivenDataModelProvider
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mOperationalStateCluster.Create(endpoint, &mOperationalStateDelegate);
+    mOperationalStateCluster.Create(endpoint, mOperationalStateDelegate);
     ReturnErrorOnFailure(provider.AddCluster(mOperationalStateCluster.Registration()));
 
     mDishwasherModeCluster.Create(endpoint, Clusters::ModeBase::kDishwasherMode,

--- a/examples/all-devices-app/all-devices-common/device/types/laundry-dryer/LaundryDryer.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/laundry-dryer/LaundryDryer.cpp
@@ -30,7 +30,7 @@ CHIP_ERROR LaundryDryer::Register(EndpointId endpoint, CodeDrivenDataModelProvid
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mOperationalStateCluster.Create(endpoint, &mDelegate);
+    mOperationalStateCluster.Create(endpoint, mDelegate);
     ReturnErrorOnFailure(provider.AddCluster(mOperationalStateCluster.Registration()));
 
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));

--- a/examples/all-devices-app/all-devices-common/device/types/laundry-washer/LaundryWasher.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/laundry-washer/LaundryWasher.cpp
@@ -33,7 +33,7 @@ CHIP_ERROR LaundryWasher::Register(EndpointId endpoint, CodeDrivenDataModelProvi
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     mOperationalStateCluster.Create(
-        endpoint, &mOperationalStateDelegate,
+        endpoint, mOperationalStateDelegate,
         Clusters::OperationalState::OperationalStateCluster::Config{
             .optionalAttributes = Clusters::OperationalState::OperationalStateCluster::OptionalAttributeSet()
                                       .Set<Clusters::OperationalState::Attributes::CountdownTime::Id>(),

--- a/examples/all-devices-app/all-devices-common/device/types/microwave-oven/MicrowaveOven.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/microwave-oven/MicrowaveOven.cpp
@@ -33,7 +33,7 @@ CHIP_ERROR MicrowaveOven::Register(EndpointId endpoint, CodeDrivenDataModelProvi
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mOperationalStateCluster.Create(endpoint, &mOperationalStateDelegate);
+    mOperationalStateCluster.Create(endpoint, mOperationalStateDelegate);
     ReturnErrorOnFailure(provider.AddCluster(mOperationalStateCluster.Registration()));
 
     mMicrowaveOvenControlCluster.Create(

--- a/examples/all-devices-app/all-devices-common/device/types/oven/Oven.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/oven/Oven.cpp
@@ -20,12 +20,7 @@
 
 namespace chip::app {
 
-Oven::Oven(TimerDelegate & timerDelegate, Clusters::OnOffDelegate & surfaceOnOff, Clusters::IdentifyDelegate & cavityIdentify,
-           Clusters::IdentifyDelegate & surfaceIdentify, const Config & config) :
-    DeviceInterface(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kOven, 1)),
-    mCavity(timerDelegate, config.cavityConfig, config.cavityOperationalStateDelegate, cavityIdentify),
-    mSurface(timerDelegate, surfaceOnOff, surfaceIdentify)
-{}
+Oven::Oven() : DeviceInterface(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kOven, 1)) {}
 
 CHIP_ERROR Oven::Register(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
 {
@@ -39,8 +34,7 @@ CHIP_ERROR Oven::Register(EndpointIdAllocator & allocator, CodeDrivenDataModelPr
         EndpointComposition(composition.parentId, DataModel::EndpointCompositionPattern::kTree, composition.tagList)));
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));
 
-    ReturnErrorOnFailure(mCavity.Register(allocator, provider, EndpointComposition::WithParent(mEndpointId)));
-    ReturnErrorOnFailure(mSurface.Register(allocator, provider, EndpointComposition::WithParent(mEndpointId)));
+    ReturnErrorOnFailure(RegisterParts(allocator, provider));
 
     transaction.Commit();
     return CHIP_NO_ERROR;
@@ -48,8 +42,7 @@ CHIP_ERROR Oven::Register(EndpointIdAllocator & allocator, CodeDrivenDataModelPr
 
 void Oven::Unregister(CodeDrivenDataModelProvider & provider)
 {
-    mSurface.Unregister(provider);
-    mCavity.Unregister(provider);
+    UnregisterParts(provider);
     UnregisterDescriptor(mEndpointId, provider);
     mEndpointId = kInvalidEndpointId;
 }

--- a/examples/all-devices-app/all-devices-common/device/types/oven/Oven.h
+++ b/examples/all-devices-app/all-devices-common/device/types/oven/Oven.h
@@ -17,36 +17,27 @@
 #pragma once
 
 #include <device/api/Interface.h>
-#include <device/types/cooktop/Cooktop.h>
-#include <device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h>
 
 namespace chip::app {
 
 class Oven : public DeviceInterface
 {
 public:
-    struct Config
-    {
-        Clusters::OperationalState::OperationalStateCluster::Delegate & cavityOperationalStateDelegate;
-        TemperatureControlledCabinetPart::Config cavityConfig;
-    };
-
-    Oven(TimerDelegate & timerDelegate, Clusters::OnOffDelegate & surfaceOnOff, Clusters::IdentifyDelegate & cavityIdentify,
-         Clusters::IdentifyDelegate & surfaceIdentify, const Config & config);
+    Oven();
     ~Oven() override = default;
 
     CHIP_ERROR Register(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider,
                         EndpointComposition composition = {}) override;
     void Unregister(CodeDrivenDataModelProvider & provider) override;
 
-    // Composition getters to expose child endpoints
-    TemperatureControlledCabinetPart & Cavity() { return mCavity; }
-    CookSurfacePart & Surface() { return mSurface; }
+    EndpointId GetEndpointId() const { return mEndpointId; }
+
+protected:
+    virtual CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) = 0;
+    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                       = 0;
 
 private:
     EndpointId mEndpointId = kInvalidEndpointId;
-    TemperatureControlledCabinetPart mCavity;
-    CookSurfacePart mSurface;
 };
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/oven/Oven.h
+++ b/examples/all-devices-app/all-devices-common/device/types/oven/Oven.h
@@ -34,7 +34,7 @@ public:
 
 protected:
     virtual CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) = 0;
-    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                       = 0;
+    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                      = 0;
 
 private:
     EndpointId mEndpointId = kInvalidEndpointId;

--- a/examples/all-devices-app/all-devices-common/device/types/oven/impl/LoggingOven.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/oven/impl/LoggingOven.cpp
@@ -21,9 +21,20 @@ namespace chip::app {
 LoggingOven::LoggingOven(TimerDelegate & timerDelegate) : LoggingOven(timerDelegate, Config{}) {}
 
 LoggingOven::LoggingOven(TimerDelegate & timerDelegate, Config config) :
-    Oven(timerDelegate, mLoggingSurface, mLoggingCavity, mLoggingSurface,
-         Oven::Config{ .cavityOperationalStateDelegate = mLoggingCavity, .cavityConfig = config.cavityConfig }),
-    mLoggingCavity(timerDelegate, config.cavityConfig, "Cavity"), mLoggingSurface(timerDelegate, "Top Surface")
+    mCavity(timerDelegate, config.cavityConfig, "Cavity"), mSurface(timerDelegate, "Top Surface")
 {}
+
+CHIP_ERROR LoggingOven::RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider)
+{
+    ReturnErrorOnFailure(mCavity.Register(allocator, provider, EndpointComposition::WithParent(GetEndpointId())));
+    ReturnErrorOnFailure(mSurface.Register(allocator, provider, EndpointComposition::WithParent(GetEndpointId())));
+    return CHIP_NO_ERROR;
+}
+
+void LoggingOven::UnregisterParts(CodeDrivenDataModelProvider & provider)
+{
+    mSurface.Unregister(provider);
+    mCavity.Unregister(provider);
+}
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/oven/impl/LoggingOven.h
+++ b/examples/all-devices-app/all-devices-common/device/types/oven/impl/LoggingOven.h
@@ -34,9 +34,16 @@ public:
     LoggingOven(TimerDelegate & timerDelegate, Config config);
     ~LoggingOven() override = default;
 
+    LoggingTemperatureControlledCabinetPart & Cavity() { return mCavity; }
+    LoggingCookSurfacePart & Surface() { return mSurface; }
+
+protected:
+    CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) override;
+    void UnregisterParts(CodeDrivenDataModelProvider & provider) override;
+
 private:
-    LoggingTemperatureControlledCabinetPart mLoggingCavity;
-    LoggingCookSurfacePart mLoggingSurface;
+    LoggingTemperatureControlledCabinetPart mCavity;
+    LoggingCookSurfacePart mSurface;
 };
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/refrigerator/Refrigerator.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/refrigerator/Refrigerator.cpp
@@ -20,10 +20,7 @@
 
 namespace chip::app {
 
-Refrigerator::Refrigerator(TimerDelegate & timerDelegate, Clusters::IdentifyDelegate & cabinetIdentify, const Config & config) :
-    DeviceInterface(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRefrigerator, 1)),
-    mCabinet(timerDelegate, config.cabinetConfig, config.operationalStateDelegate, cabinetIdentify)
-{}
+Refrigerator::Refrigerator() : DeviceInterface(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRefrigerator, 1)) {}
 
 CHIP_ERROR Refrigerator::Register(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider,
                                   EndpointComposition composition)
@@ -38,7 +35,7 @@ CHIP_ERROR Refrigerator::Register(EndpointIdAllocator & allocator, CodeDrivenDat
         EndpointComposition(composition.parentId, DataModel::EndpointCompositionPattern::kTree, composition.tagList)));
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));
 
-    ReturnErrorOnFailure(mCabinet.Register(allocator, provider, EndpointComposition::WithParent(mEndpointId)));
+    ReturnErrorOnFailure(RegisterParts(allocator, provider));
 
     transaction.Commit();
     return CHIP_NO_ERROR;
@@ -46,7 +43,7 @@ CHIP_ERROR Refrigerator::Register(EndpointIdAllocator & allocator, CodeDrivenDat
 
 void Refrigerator::Unregister(CodeDrivenDataModelProvider & provider)
 {
-    mCabinet.Unregister(provider);
+    UnregisterParts(provider);
     UnregisterDescriptor(mEndpointId, provider);
     mEndpointId = kInvalidEndpointId;
 }

--- a/examples/all-devices-app/all-devices-common/device/types/refrigerator/Refrigerator.h
+++ b/examples/all-devices-app/all-devices-common/device/types/refrigerator/Refrigerator.h
@@ -17,32 +17,27 @@
 #pragma once
 
 #include <device/api/Interface.h>
-#include <device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h>
 
 namespace chip::app {
 
 class Refrigerator : public DeviceInterface
 {
 public:
-    struct Config
-    {
-        Clusters::OperationalState::OperationalStateCluster::Delegate & operationalStateDelegate;
-        TemperatureControlledCabinetPart::Config cabinetConfig{};
-    };
-
-    Refrigerator(TimerDelegate & timerDelegate, Clusters::IdentifyDelegate & cabinetIdentify, const Config & config);
+    Refrigerator();
     ~Refrigerator() override = default;
 
     CHIP_ERROR Register(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider,
                         EndpointComposition composition = {}) override;
     void Unregister(CodeDrivenDataModelProvider & provider) override;
 
-    // Composition getters to expose child endpoints
-    TemperatureControlledCabinetPart & Cabinet() { return mCabinet; }
+    EndpointId GetEndpointId() const { return mEndpointId; }
+
+protected:
+    virtual CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) = 0;
+    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                       = 0;
 
 private:
     EndpointId mEndpointId = kInvalidEndpointId;
-    TemperatureControlledCabinetPart mCabinet;
 };
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/refrigerator/Refrigerator.h
+++ b/examples/all-devices-app/all-devices-common/device/types/refrigerator/Refrigerator.h
@@ -34,7 +34,7 @@ public:
 
 protected:
     virtual CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) = 0;
-    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                       = 0;
+    virtual void UnregisterParts(CodeDrivenDataModelProvider & provider)                                      = 0;
 
 private:
     EndpointId mEndpointId = kInvalidEndpointId;

--- a/examples/all-devices-app/all-devices-common/device/types/refrigerator/impl/LoggingRefrigerator.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/refrigerator/impl/LoggingRefrigerator.cpp
@@ -21,9 +21,18 @@ namespace chip::app {
 LoggingRefrigerator::LoggingRefrigerator(TimerDelegate & timerDelegate) : LoggingRefrigerator(timerDelegate, Config{}) {}
 
 LoggingRefrigerator::LoggingRefrigerator(TimerDelegate & timerDelegate, Config config) :
-    Refrigerator(timerDelegate, mLoggingCabinet,
-                 Refrigerator::Config{ .operationalStateDelegate = mLoggingCabinet, .cabinetConfig = config.cabinetConfig }),
-    mLoggingCabinet(timerDelegate, config.cabinetConfig, "Cabinet")
+    mCabinet(timerDelegate, config.cabinetConfig, "Cabinet")
 {}
+
+CHIP_ERROR LoggingRefrigerator::RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider)
+{
+    ReturnErrorOnFailure(mCabinet.Register(allocator, provider, EndpointComposition::WithParent(GetEndpointId())));
+    return CHIP_NO_ERROR;
+}
+
+void LoggingRefrigerator::UnregisterParts(CodeDrivenDataModelProvider & provider)
+{
+    mCabinet.Unregister(provider);
+}
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/refrigerator/impl/LoggingRefrigerator.h
+++ b/examples/all-devices-app/all-devices-common/device/types/refrigerator/impl/LoggingRefrigerator.h
@@ -48,8 +48,14 @@ public:
     LoggingRefrigerator(TimerDelegate & timerDelegate, Config config);
     ~LoggingRefrigerator() override = default;
 
+    LoggingTemperatureControlledCabinetPart & Cabinet() { return mCabinet; }
+
+protected:
+    CHIP_ERROR RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider) override;
+    void UnregisterParts(CodeDrivenDataModelProvider & provider) override;
+
 private:
-    LoggingTemperatureControlledCabinetPart mLoggingCabinet;
+    LoggingTemperatureControlledCabinetPart mCabinet;
 };
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/robotic-vacuum-cleaner/RoboticVacuumCleaner.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/robotic-vacuum-cleaner/RoboticVacuumCleaner.cpp
@@ -31,7 +31,7 @@ CHIP_ERROR RoboticVacuumCleaner::Register(EndpointId endpoint, CodeDrivenDataMod
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mOperationalStateCluster.Create(endpoint, &mDelegate);
+    mOperationalStateCluster.Create(endpoint, mDelegate);
     mDelegate.SetCluster(&mOperationalStateCluster.Cluster());
     ReturnErrorOnFailure(provider.AddCluster(mOperationalStateCluster.Registration()));
 

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.cpp
@@ -53,7 +53,7 @@ CHIP_ERROR TemperatureControlledCabinetPart::Register(EndpointId endpoint, CodeD
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
     ReturnErrorOnFailure(provider.AddCluster(mTemperatureControlCluster.Registration()));
 
-    mOperationalStateCluster.Create(endpoint, &mOperationalStateDelegate);
+    mOperationalStateCluster.Create(endpoint, mOperationalStateDelegate);
     ReturnErrorOnFailure(provider.AddCluster(mOperationalStateCluster.Registration()));
 
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h
@@ -50,10 +50,18 @@ public:
     void Unregister(CodeDrivenDataModelProvider & provider) override;
 
     // Public cluster getters for programmatic control
-    Clusters::TemperatureControlCluster & TemperatureControlCluster() { return mTemperatureControlCluster.Cluster(); }
-    Clusters::IdentifyCluster & IdentifyCluster() { return mIdentifyCluster.Cluster(); }
+    // Values only available after registration.
+    Clusters::TemperatureControlCluster & TemperatureControlCluster() { 
+        VerifyOrDie(mTemperatureControlCluster.IsConstructed());
+        return mTemperatureControlCluster.Cluster(); 
+    }
+    Clusters::IdentifyCluster & IdentifyCluster() {
+        VerifyOrDie(mIdentifyCluster.IsConstructed());
+        return mIdentifyCluster.Cluster(); 
+    }
     Clusters::OvenCavityOperationalState::OvenCavityOperationalStateCluster & OperationalState()
     {
+        VerifyOrDie(mOperationalStateCluster.IsConstructed());
         return mOperationalStateCluster.Cluster();
     }
 

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h
@@ -51,13 +51,15 @@ public:
 
     // Public cluster getters for programmatic control
     // Values only available after registration.
-    Clusters::TemperatureControlCluster & TemperatureControlCluster() { 
+    Clusters::TemperatureControlCluster & TemperatureControlCluster()
+    {
         VerifyOrDie(mTemperatureControlCluster.IsConstructed());
-        return mTemperatureControlCluster.Cluster(); 
+        return mTemperatureControlCluster.Cluster();
     }
-    Clusters::IdentifyCluster & IdentifyCluster() {
+    Clusters::IdentifyCluster & IdentifyCluster()
+    {
         VerifyOrDie(mIdentifyCluster.IsConstructed());
-        return mIdentifyCluster.Cluster(); 
+        return mIdentifyCluster.Cluster();
     }
     Clusters::OvenCavityOperationalState::OvenCavityOperationalStateCluster & OperationalState()
     {

--- a/src/app/clusters/operational-state-server/CodegenIntegration.cpp
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.cpp
@@ -35,17 +35,19 @@ using namespace chip::app::Clusters::OperationalState;
 
 // Standalone constructor: creates and owns an OperationalStateCluster.
 Instance::Instance(Delegate * aDelegate, EndpointId aEndpointId, const OperationalStateCluster::Config & config) :
-    mDelegate(aDelegate), mOwnedStorage(Platform::MakeUnique<detail::OperationalInstanceBase>(aDelegate, aEndpointId, config)),
-    mCluster(mOwnedStorage->mCluster.Cluster()), mRegPtr(&mOwnedStorage->mCluster.Registration())
+    mOwnedStorage(Platform::MakeUnique<detail::OperationalInstanceBase>(aDelegate, aEndpointId, config)),
+    mCluster(mOwnedStorage->mCluster.Cluster()), mRegPtr(&mOwnedStorage->mCluster.Registration()),
+    mDelegateWrapperPtr(&mOwnedStorage->mDelegateWrapper)
 {
-    aDelegate->SetInstance(this);
+    mDelegateWrapperPtr->SetInstance(this);
 }
 
 // Protected constructor: cluster storage is owned by the derived class (Rvc, OvenCavity).
-Instance::Instance(OperationalStateCluster & cluster, ServerClusterRegistration & registration, Delegate * aDelegate) :
-    mDelegate(aDelegate), mCluster(cluster), mRegPtr(&registration)
+Instance::Instance(OperationalStateCluster & cluster, ServerClusterRegistration & registration,
+                   detail::InstanceDelegateWrapper & delegateWrapper, Delegate * aDelegate) :
+    mCluster(cluster), mRegPtr(&registration), mDelegateWrapperPtr(&delegateWrapper)
 {
-    aDelegate->SetInstance(this);
+    mDelegateWrapperPtr->SetInstance(this);
 }
 
 Instance::~Instance()
@@ -55,11 +57,24 @@ Instance::~Instance()
         ChipLogError(AppServer, "OperationalState::Instance destroyed without Shutdown(); shutting down now.");
         Shutdown();
     }
-    if (mDelegate)
+    if (mDelegateWrapperPtr != nullptr)
     {
-        mDelegate->SetInstance(nullptr);
+        mDelegateWrapperPtr->SetInstance(nullptr);
     }
     // mOwnedStorage (Platform::UniquePtr) frees the owned cluster automatically.
+}
+
+void Instance::SetDelegate(Delegate * aDelegate)
+{
+    if (mDelegateWrapperPtr != nullptr)
+    {
+        mDelegateWrapperPtr->SetDelegate(aDelegate);
+    }
+}
+
+Delegate * Instance::GetDelegate() const
+{
+    return mDelegateWrapperPtr != nullptr ? mDelegateWrapperPtr->GetDelegate() : nullptr;
 }
 
 CHIP_ERROR Instance::Init()

--- a/src/app/clusters/operational-state-server/CodegenIntegration.cpp
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.cpp
@@ -45,7 +45,8 @@ Instance::Instance(Delegate * aDelegate, EndpointId aEndpointId, const Operation
 // Protected constructor: cluster storage is owned by the derived class (Rvc, OvenCavity).
 Instance::Instance(OperationalStateCluster & cluster, ServerClusterRegistration & registration,
                    detail::InstanceDelegateWrapper & delegateWrapper, Delegate * aDelegate) :
-    mCluster(cluster), mRegPtr(&registration), mDelegateWrapperPtr(&delegateWrapper)
+    mCluster(cluster),
+    mRegPtr(&registration), mDelegateWrapperPtr(&delegateWrapper)
 {
     mDelegateWrapperPtr->SetInstance(this);
 }

--- a/src/app/clusters/operational-state-server/CodegenIntegration.h
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.h
@@ -36,13 +36,126 @@ namespace OperationalState {
 // detail:: base classes guarantee that the cluster + registration storage is initialized
 // before Instance receives references to them (base classes initialize before members).
 namespace detail {
+
+using LegacyDelegate = chip::app::Clusters::OperationalState::Delegate;
+
+class InstanceDelegateWrapper : public OperationalStateCluster::Delegate
+{
+public:
+    InstanceDelegateWrapper(LegacyDelegate * aDelegate = nullptr) { SetDelegate(aDelegate); }
+    ~InstanceDelegateWrapper() override { SetDelegate(nullptr); }
+
+    void SetInstance(Instance * aInstance)
+    {
+        mInstance = aInstance;
+        if (mDelegate != nullptr)
+        {
+            mDelegate->SetInstance(aInstance);
+        }
+    }
+
+    void SetDelegate(LegacyDelegate * aDelegate)
+    {
+        if (mDelegate != nullptr)
+        {
+            mDelegate->SetInstance(nullptr);
+        }
+        mDelegate = aDelegate;
+        if (mDelegate != nullptr)
+        {
+            mDelegate->SetInstance(mInstance);
+        }
+    }
+
+    LegacyDelegate * GetDelegate() const { return mDelegate; }
+
+    DataModel::Nullable<uint32_t> GetCountdownTime() override
+    {
+        if (mDelegate != nullptr)
+        {
+            return mDelegate->GetCountdownTime();
+        }
+        return DataModel::NullNullable;
+    }
+
+    CHIP_ERROR GetOperationalStateAtIndex(size_t index, GenericOperationalState & operationalState) override
+    {
+        if (mDelegate != nullptr)
+        {
+            return mDelegate->GetOperationalStateAtIndex(index, operationalState);
+        }
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+    CHIP_ERROR GetOperationalPhaseAtIndex(size_t index, MutableCharSpan & operationalPhase) override
+    {
+        if (mDelegate != nullptr)
+        {
+            return mDelegate->GetOperationalPhaseAtIndex(index, operationalPhase);
+        }
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+    void HandlePauseStateCallback(GenericOperationalError & err) override
+    {
+        if (mDelegate != nullptr)
+        {
+            mDelegate->HandlePauseStateCallback(err);
+        }
+    }
+
+    void HandleResumeStateCallback(GenericOperationalError & err) override
+    {
+        if (mDelegate != nullptr)
+        {
+            mDelegate->HandleResumeStateCallback(err);
+        }
+    }
+
+    void HandleStartStateCallback(GenericOperationalError & err) override
+    {
+        if (mDelegate != nullptr)
+        {
+            mDelegate->HandleStartStateCallback(err);
+        }
+    }
+
+    void HandleStopStateCallback(GenericOperationalError & err) override
+    {
+        if (mDelegate != nullptr)
+        {
+            mDelegate->HandleStopStateCallback(err);
+        }
+    }
+
+    void HandleGoHomeCommandCallback(GenericOperationalError & err) override
+    {
+        if (mDelegate != nullptr)
+        {
+            mDelegate->HandleGoHomeCommandCallback(err);
+        }
+        else
+        {
+            err.Set(to_underlying(ErrorStateEnum::kUnknownEnumValue));
+        }
+    }
+
+private:
+    Instance * mInstance      = nullptr;
+    LegacyDelegate * mDelegate = nullptr;
+};
+
 struct OperationalInstanceBase
 {
+    InstanceDelegateWrapper mDelegateWrapper;
     RegisteredServerCluster<OperationalStateCluster> mCluster;
-    OperationalInstanceBase(Delegate * aDelegate, EndpointId aEndpointId, const OperationalStateCluster::Config & config = {}) :
-        mCluster(aEndpointId, aDelegate, config)
+    OperationalInstanceBase(LegacyDelegate * aDelegate, EndpointId aEndpointId,
+                            const OperationalStateCluster::Config & config = {}) :
+        mDelegateWrapper(aDelegate),
+        mCluster(aEndpointId, mDelegateWrapper, config)
     {}
 };
+
 } // namespace detail
 
 /**
@@ -63,10 +176,13 @@ public:
      * Standalone constructor: creates and owns an OperationalStateCluster for the given endpoint.
      */
     Instance(Delegate * aDelegate, EndpointId aEndpointId, const OperationalStateCluster::Config & config = {});
-    ~Instance();
+    virtual ~Instance();
 
     CHIP_ERROR Init();
     void Shutdown();
+
+    void SetDelegate(Delegate * aDelegate);
+    Delegate * GetDelegate() const;
 
     // Forwarders to the underlying cluster. Defined out-of-line in CodegenIntegration.cpp so the
     // cluster methods are not inlined (and duplicated) into each shim — keeps the back-compat layer small.
@@ -90,7 +206,8 @@ protected:
      * Constructor for derived instances (Rvc, OvenCavity) that supply their own cluster storage.
      * The derived class must ensure the cluster and registration outlive this object.
      */
-    Instance(OperationalStateCluster & cluster, ServerClusterRegistration & registration, Delegate * aDelegate);
+    Instance(OperationalStateCluster & cluster, ServerClusterRegistration & registration,
+             detail::InstanceDelegateWrapper & delegateWrapper, Delegate * aDelegate);
 
     OperationalStateCluster & Cluster() { return mCluster; }
     const OperationalStateCluster & Cluster() const { return mCluster; }
@@ -98,13 +215,14 @@ protected:
     bool mRegistered = false;
 
 private:
-    Delegate * mDelegate;
-    // mOwnedStorage declared before mCluster so it is initialized first in the standalone constructor,
-    // allowing mCluster to be bound to the storage's cluster object. Held by Platform::UniquePtr so the
-    // storage lifetime is managed automatically (no manual delete) and the type is non-copyable.
+    // mOwnedStorage declared first so it is initialized first in the standalone constructor,
+    // allowing mCluster, mRegPtr, and mDelegateWrapperPtr to be bound to the storage's objects.
+    // Held by Platform::UniquePtr so the storage lifetime is managed automatically (no manual delete)
+    // and the type is non-copyable.
     Platform::UniquePtr<detail::OperationalInstanceBase> mOwnedStorage;
     OperationalStateCluster & mCluster;
     ServerClusterRegistration * mRegPtr;
+    detail::InstanceDelegateWrapper * mDelegateWrapperPtr;
 };
 
 } // namespace OperationalState
@@ -114,10 +232,11 @@ namespace RvcOperationalState {
 namespace detail {
 struct RvcInstanceBase
 {
+    OperationalState::detail::InstanceDelegateWrapper mDelegateWrapper;
     RegisteredServerCluster<RvcOperationalStateCluster> mCluster;
     RvcInstanceBase(Delegate * aDelegate, EndpointId aEndpointId,
                     const OperationalState::OperationalStateCluster::Config & config = {}) :
-        mCluster(aEndpointId, aDelegate, config)
+        mDelegateWrapper(aDelegate), mCluster(aEndpointId, mDelegateWrapper, config)
     {}
 };
 } // namespace detail
@@ -128,7 +247,7 @@ public:
     Instance(Delegate * aDelegate, EndpointId aEndpointId, const OperationalState::OperationalStateCluster::Config & config = {}) :
         detail::RvcInstanceBase(aDelegate, aEndpointId, config),
         OperationalState::Instance(detail::RvcInstanceBase::mCluster.Cluster(), detail::RvcInstanceBase::mCluster.Registration(),
-                                   aDelegate)
+                                   detail::RvcInstanceBase::mDelegateWrapper, aDelegate)
     {}
 };
 
@@ -139,10 +258,11 @@ namespace OvenCavityOperationalState {
 namespace detail {
 struct OvenInstanceBase
 {
+    OperationalState::detail::InstanceDelegateWrapper mDelegateWrapper;
     RegisteredServerCluster<OvenCavityOperationalStateCluster> mCluster;
     OvenInstanceBase(OperationalState::Delegate * aDelegate, EndpointId aEndpointId,
                      const OperationalState::OperationalStateCluster::Config & config = {}) :
-        mCluster(aEndpointId, aDelegate, config)
+        mDelegateWrapper(aDelegate), mCluster(aEndpointId, mDelegateWrapper, config)
     {}
 };
 } // namespace detail
@@ -154,7 +274,7 @@ public:
              const OperationalState::OperationalStateCluster::Config & config = {}) :
         detail::OvenInstanceBase(aDelegate, aEndpointId, config),
         OperationalState::Instance(detail::OvenInstanceBase::mCluster.Cluster(), detail::OvenInstanceBase::mCluster.Registration(),
-                                   aDelegate)
+                                   detail::OvenInstanceBase::mDelegateWrapper, aDelegate)
     {}
 };
 

--- a/src/app/clusters/operational-state-server/CodegenIntegration.h
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.h
@@ -141,7 +141,7 @@ public:
     }
 
 private:
-    Instance * mInstance      = nullptr;
+    Instance * mInstance       = nullptr;
     LegacyDelegate * mDelegate = nullptr;
 };
 
@@ -236,7 +236,8 @@ struct RvcInstanceBase
     RegisteredServerCluster<RvcOperationalStateCluster> mCluster;
     RvcInstanceBase(Delegate * aDelegate, EndpointId aEndpointId,
                     const OperationalState::OperationalStateCluster::Config & config = {}) :
-        mDelegateWrapper(aDelegate), mCluster(aEndpointId, mDelegateWrapper, config)
+        mDelegateWrapper(aDelegate),
+        mCluster(aEndpointId, mDelegateWrapper, config)
     {}
 };
 } // namespace detail
@@ -262,7 +263,8 @@ struct OvenInstanceBase
     RegisteredServerCluster<OvenCavityOperationalStateCluster> mCluster;
     OvenInstanceBase(OperationalState::Delegate * aDelegate, EndpointId aEndpointId,
                      const OperationalState::OperationalStateCluster::Config & config = {}) :
-        mDelegateWrapper(aDelegate), mCluster(aEndpointId, mDelegateWrapper, config)
+        mDelegateWrapper(aDelegate),
+        mCluster(aEndpointId, mDelegateWrapper, config)
     {}
 };
 } // namespace detail

--- a/src/app/clusters/operational-state-server/OperationalStateCluster.cpp
+++ b/src/app/clusters/operational-state-server/OperationalStateCluster.cpp
@@ -39,11 +39,11 @@ constexpr size_t kMaxOperationalStateCount = 256;
 // OperationalStateCluster — constructors
 // ---------------------------------------------------------------------------
 
-OperationalStateCluster::OperationalStateCluster(EndpointId endpointId, Delegate * delegate, const Config & config) :
+OperationalStateCluster::OperationalStateCluster(EndpointId endpointId, Delegate & delegate, const Config & config) :
     OperationalStateCluster(endpointId, OperationalState::Id, OperationalState::kRevision, delegate, config)
 {}
 
-OperationalStateCluster::OperationalStateCluster(EndpointId endpointId, ClusterId clusterId, uint16_t revision, Delegate * delegate,
+OperationalStateCluster::OperationalStateCluster(EndpointId endpointId, ClusterId clusterId, uint16_t revision, Delegate & delegate,
                                                  const Config & config) :
     DefaultServerCluster({ endpointId, clusterId }),
     mDelegate(delegate), mRevision(revision), mConfig(config)
@@ -150,7 +150,7 @@ void OperationalStateCluster::ReportPhaseListChange()
 
 void OperationalStateCluster::UpdateCountdownTime(bool fromDelegate)
 {
-    DataModel::Nullable<uint32_t> newCountdownTime = mDelegate->GetCountdownTime();
+    DataModel::Nullable<uint32_t> newCountdownTime = mDelegate.GetCountdownTime();
     auto now                                       = System::SystemClock().GetMonotonicTimestamp();
     bool markDirty                                 = false;
 
@@ -188,13 +188,13 @@ bool OperationalStateCluster::IsSupportedPhase(uint8_t aPhase)
 {
     char buffer[kMaxPhaseNameLength];
     MutableCharSpan phase(buffer);
-    return mDelegate->GetOperationalPhaseAtIndex(aPhase, phase) == CHIP_NO_ERROR;
+    return mDelegate.GetOperationalPhaseAtIndex(aPhase, phase) == CHIP_NO_ERROR;
 }
 
 bool OperationalStateCluster::IsSupportedOperationalState(uint8_t aState)
 {
     GenericOperationalState opState;
-    for (size_t i = 0; i < kMaxOperationalStateCount && mDelegate->GetOperationalStateAtIndex(i, opState) == CHIP_NO_ERROR; i++)
+    for (size_t i = 0; i < kMaxOperationalStateCount && mDelegate.GetOperationalStateAtIndex(i, opState) == CHIP_NO_ERROR; i++)
     {
         if (opState.operationalStateID == aState)
         {
@@ -221,7 +221,7 @@ DataModel::ActionReturnStatus OperationalStateCluster::ReadAttribute(const DataM
     case PhaseList::Id: {
         char firstBuf[kMaxPhaseNameLength];
         MutableCharSpan firstPhase(firstBuf);
-        if (mDelegate->GetOperationalPhaseAtIndex(0, firstPhase) == CHIP_ERROR_NOT_FOUND)
+        if (mDelegate.GetOperationalPhaseAtIndex(0, firstPhase) == CHIP_ERROR_NOT_FOUND)
         {
             return encoder.EncodeNull();
         }
@@ -231,7 +231,7 @@ DataModel::ActionReturnStatus OperationalStateCluster::ReadAttribute(const DataM
             {
                 char buf[kMaxPhaseNameLength];
                 MutableCharSpan phase(buf);
-                CHIP_ERROR err = mDelegate->GetOperationalPhaseAtIndex(i, phase);
+                CHIP_ERROR err = mDelegate.GetOperationalPhaseAtIndex(i, phase);
                 if (err == CHIP_ERROR_NOT_FOUND)
                 {
                     return CHIP_NO_ERROR;
@@ -245,13 +245,13 @@ DataModel::ActionReturnStatus OperationalStateCluster::ReadAttribute(const DataM
     case CurrentPhase::Id:
         return encoder.Encode(mCurrentPhase);
     case CountdownTime::Id:
-        return encoder.Encode(mDelegate->GetCountdownTime());
+        return encoder.Encode(mDelegate.GetCountdownTime());
     case OperationalStateList::Id:
         return encoder.EncodeList([this](const auto & listEncoder) -> CHIP_ERROR {
             GenericOperationalState opState;
             for (size_t i = 0; i < kMaxOperationalStateCount; i++)
             {
-                CHIP_ERROR err = mDelegate->GetOperationalStateAtIndex(i, opState);
+                CHIP_ERROR err = mDelegate.GetOperationalStateAtIndex(i, opState);
                 if (err == CHIP_ERROR_NOT_FOUND)
                 {
                     return CHIP_NO_ERROR;
@@ -391,11 +391,11 @@ std::optional<DataModel::ActionReturnStatus> OperationalStateCluster::HandlePaus
     {
         if (isPause)
         {
-            mDelegate->HandlePauseStateCallback(err);
+            mDelegate.HandlePauseStateCallback(err);
         }
         else
         {
-            mDelegate->HandleResumeStateCallback(err);
+            mDelegate.HandleResumeStateCallback(err);
         }
     }
 
@@ -421,11 +421,11 @@ std::optional<DataModel::ActionReturnStatus> OperationalStateCluster::HandleStar
     {
         if (isStart)
         {
-            mDelegate->HandleStartStateCallback(err);
+            mDelegate.HandleStartStateCallback(err);
         }
         else
         {
-            mDelegate->HandleStopStateCallback(err);
+            mDelegate.HandleStopStateCallback(err);
         }
     }
 

--- a/src/app/clusters/operational-state-server/OperationalStateCluster.h
+++ b/src/app/clusters/operational-state-server/OperationalStateCluster.h
@@ -99,7 +99,7 @@ public:
      *                          The caller must ensure the delegate outlives this object.
      * @param config            Configuration including optional attributes to expose.
      */
-    OperationalStateCluster(EndpointId endpointId, Delegate * delegate, const Config & config = {});
+    OperationalStateCluster(EndpointId endpointId, Delegate & delegate, const Config & config = {});
 
     ~OperationalStateCluster() override = default;
 
@@ -143,7 +143,7 @@ public:
     CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder) override;
 
 protected:
-    OperationalStateCluster(EndpointId endpointId, ClusterId clusterId, uint16_t revision, Delegate * delegate,
+    OperationalStateCluster(EndpointId endpointId, ClusterId clusterId, uint16_t revision, Delegate & delegate,
                             const Config & config = {});
 
     virtual bool IsDerivedClusterStatePauseCompatible(uint8_t aState) { return false; }
@@ -158,10 +158,11 @@ protected:
     void UpdateCountdownTime(bool fromDelegate);
     void UpdateCountdownTimeFromClusterLogic() { UpdateCountdownTime(/* fromDelegate = */ false); }
 
-    Delegate * GetDelegate() { return mDelegate; }
+    Delegate & GetDelegate() { return mDelegate; }
+    const Delegate & GetDelegate() const { return mDelegate; }
 
 private:
-    Delegate * mDelegate;
+    Delegate & mDelegate;
     // ClusterRevision is not a fixed constant for this class: it varies by the concrete (derived)
     // cluster. OperationalState and RvcOperationalState are at revision 3, while OvenCavityOperationalState
     // is at revision 2, so each derived class passes its own value through the protected constructor.

--- a/src/app/clusters/operational-state-server/OvenCavityOperationalStateCluster.cpp
+++ b/src/app/clusters/operational-state-server/OvenCavityOperationalStateCluster.cpp
@@ -27,7 +27,7 @@ namespace Clusters {
 namespace OvenCavityOperationalState {
 
 OvenCavityOperationalStateCluster::OvenCavityOperationalStateCluster(
-    EndpointId endpointId, OperationalState::OperationalStateCluster::Delegate * delegate,
+    EndpointId endpointId, OperationalState::OperationalStateCluster::Delegate & delegate,
     const OperationalState::OperationalStateCluster::Config & config) :
     OperationalState::OperationalStateCluster(endpointId, OvenCavityOperationalState::Id, OvenCavityOperationalState::kRevision,
                                               delegate, config)

--- a/src/app/clusters/operational-state-server/OvenCavityOperationalStateCluster.h
+++ b/src/app/clusters/operational-state-server/OvenCavityOperationalStateCluster.h
@@ -28,7 +28,7 @@ namespace OvenCavityOperationalState {
 class OvenCavityOperationalStateCluster : public OperationalState::OperationalStateCluster
 {
 public:
-    OvenCavityOperationalStateCluster(EndpointId endpointId, OperationalState::OperationalStateCluster::Delegate * delegate,
+    OvenCavityOperationalStateCluster(EndpointId endpointId, OperationalState::OperationalStateCluster::Delegate & delegate,
                                       const OperationalState::OperationalStateCluster::Config & config = {});
 
     CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,

--- a/src/app/clusters/operational-state-server/RvcOperationalStateCluster.cpp
+++ b/src/app/clusters/operational-state-server/RvcOperationalStateCluster.cpp
@@ -41,7 +41,7 @@ std::optional<DataModel::ActionReturnStatus> AddCommandResponse(const ConcreteCo
 } // namespace
 
 RvcOperationalStateCluster::RvcOperationalStateCluster(EndpointId endpointId,
-                                                       OperationalState::OperationalStateCluster::Delegate * delegate,
+                                                       OperationalState::OperationalStateCluster::Delegate & delegate,
                                                        const OperationalState::OperationalStateCluster::Config & config) :
     OperationalState::OperationalStateCluster(endpointId, RvcOperationalState::Id, RvcOperationalState::kRevision, delegate, config)
 {}
@@ -102,7 +102,7 @@ std::optional<DataModel::ActionReturnStatus> RvcOperationalStateCluster::HandleG
 
     if (err.errorStateID == 0 && opState != to_underlying(RvcOperationalState::OperationalStateEnum::kSeekingCharger))
     {
-        GetDelegate()->HandleGoHomeCommandCallback(err);
+        GetDelegate().HandleGoHomeCommandCallback(err);
     }
 
     return AddCommandResponse(path, handler, err);

--- a/src/app/clusters/operational-state-server/RvcOperationalStateCluster.h
+++ b/src/app/clusters/operational-state-server/RvcOperationalStateCluster.h
@@ -28,7 +28,7 @@ namespace RvcOperationalState {
 class RvcOperationalStateCluster : public OperationalState::OperationalStateCluster
 {
 public:
-    RvcOperationalStateCluster(EndpointId endpointId, OperationalState::OperationalStateCluster::Delegate * delegate,
+    RvcOperationalStateCluster(EndpointId endpointId, OperationalState::OperationalStateCluster::Delegate & delegate,
                                const OperationalState::OperationalStateCluster::Config & config = {});
 
     CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,

--- a/src/app/clusters/operational-state-server/tests/TestOperationalStateCluster.cpp
+++ b/src/app/clusters/operational-state-server/tests/TestOperationalStateCluster.cpp
@@ -121,7 +121,7 @@ public:
     void SetUp() override
     {
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
-        mCluster = std::make_unique<TestableOperationalStateCluster>(kTestEndpoint, &mDelegate);
+        mCluster = std::make_unique<TestableOperationalStateCluster>(kTestEndpoint, mDelegate);
         mTester  = std::make_unique<Testing::ClusterTester>(*mCluster);
         ASSERT_EQ(mCluster->Startup(mTester->GetServerClusterContext()), CHIP_NO_ERROR);
 
@@ -181,7 +181,7 @@ TEST_F(OperationalStateClusterTest, AttributeList_WithCountdownTime)
 {
     OperationalStateCluster::Config cfg;
     cfg.optionalAttributes.Set<CountdownTime::Id>();
-    TestableOperationalStateCluster clusterWithCountdown(kTestEndpoint, &mDelegate, cfg);
+    TestableOperationalStateCluster clusterWithCountdown(kTestEndpoint, mDelegate, cfg);
     Testing::ClusterTester tester(clusterWithCountdown);
     ASSERT_EQ(clusterWithCountdown.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
     EXPECT_EQ(clusterWithCountdown.SetOperationalState(to_underlying(OperationalStateEnum::kStopped)), CHIP_NO_ERROR);
@@ -303,7 +303,7 @@ TEST_F(OperationalStateClusterTest, SetOperationalState_PausedReportsCountdownTi
 {
     OperationalStateCluster::Config cfg;
     cfg.optionalAttributes.Set<CountdownTime::Id>();
-    TestableOperationalStateCluster clusterWithCountdown(kTestEndpoint, &mDelegate, cfg);
+    TestableOperationalStateCluster clusterWithCountdown(kTestEndpoint, mDelegate, cfg);
     Testing::ClusterTester tester(clusterWithCountdown);
     ASSERT_EQ(clusterWithCountdown.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
@@ -554,7 +554,7 @@ TEST(RvcOperationalStateClusterTest, AcceptedCommands_RvcSet)
     ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
 
     MockRvcDelegate delegate;
-    RvcOperationalStateCluster cluster(1, &delegate);
+    RvcOperationalStateCluster cluster(1, delegate);
     Testing::ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
     ASSERT_EQ(cluster.SetOperationalState(to_underlying(OperationalStateEnum::kStopped)), CHIP_NO_ERROR);
@@ -587,7 +587,7 @@ TEST(RvcOperationalStateClusterTest, InvokeGoHome_CallsDelegate)
     ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
     {
         MockRvcDelegate delegate;
-        RvcOperationalStateCluster cluster(1, &delegate);
+        RvcOperationalStateCluster cluster(1, delegate);
         Testing::ClusterTester tester(cluster);
         ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
         ASSERT_EQ(cluster.SetOperationalState(to_underlying(OperationalStateEnum::kRunning)), CHIP_NO_ERROR);
@@ -665,7 +665,7 @@ TEST(OvenCavityOperationalStateClusterTest, AcceptedCommands_OvenSet)
     ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
 
     MockOvenDelegate delegate;
-    OvenCavityOperationalStateCluster cluster(1, &delegate);
+    OvenCavityOperationalStateCluster cluster(1, delegate);
     Testing::ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
     ASSERT_EQ(cluster.SetOperationalState(to_underlying(OperationalStateEnum::kStopped)), CHIP_NO_ERROR);
@@ -697,7 +697,7 @@ TEST(OvenCavityOperationalStateClusterTest, ClusterRevision_IsTwo)
     ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
 
     MockOvenDelegate delegate;
-    OvenCavityOperationalStateCluster cluster(1, &delegate);
+    OvenCavityOperationalStateCluster cluster(1, delegate);
     Testing::ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
     ASSERT_EQ(cluster.SetOperationalState(to_underlying(OperationalStateEnum::kStopped)), CHIP_NO_ERROR);


### PR DESCRIPTION
#### Summary

Pass delegates by reference in OperationalStateCluster and refactor composite device types to be generic.

##### Problem

- OperationalStateCluster took and stored its Delegate as a pointer (Delegate *), making it easy to pass nullptr and crash at runtime.
- Composite device types (Oven, Refrigerator, Cooktop) hardcoded child part members in the generic base class and created duplicate Logging* part instances in subclasses to act as delegates.
- Because these duplicate Logging* parts were never registered with the data model provider, calling operational state methods on the unregistered instances resulted in a crash due to unconstructed cluster state.

##### Solution

- Changed OperationalStateCluster, RvcOperationalStateCluster, and OvenCavityOperationalStateCluster to take and store Delegate & by reference.
- Added detail::InstanceDelegateWrapper in CodegenIntegration.h to maintain backward compatibility for the legacy Instance API.
- Refactored composite device base classes (Oven, Refrigerator, Cooktop) to be generic and provide RegisterParts / UnregisterParts pure virtual lifecycle hooks.
- Concrete subclasses (LoggingOven, LoggingRefrigerator, LoggingCooktop) now directly own and register their child parts.

#### Testing

- Built and ran unit test suite (TestOperationalStateCluster) 
- Compiled linux-x64-all-devices-clang target.
- CI will run the rest of tests  (e.g. integration tests must still pass)

MANUAL side:

```
./out/linux-x64-chip-tool-clang/chip-tool ovencavityoperationalstate start 1 2 --trace-to json:log
```

used to crash all-devices before this. Now it does not crash anymore (checked that `./out/linux-x64-chip-tool-clang/chip-tool ovencavityoperationalstate read operational-state 1 2 --trace-to json:log` shows Running and after the timeout it moves to Stopped again)
