### PR TITLE
Span.h helpers for ByteSpans from strings / CharSpans

### DIFF
--- a/examples/all-devices-app/all-devices-common/device/types/network-infrastructure-manager/NetworkInfrastructureManager.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/network-infrastructure-manager/NetworkInfrastructureManager.cpp
@@ -27,11 +27,6 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-inline ByteSpan ByteSpanFromCharSpan(CharSpan span)
-{
-    return ByteSpan(Uint8::from_const_char(span.data()), span.size());
-}
-
 namespace {
 constexpr uint16_t kThreadVersionForThread_1_3_1 = 5;
 } // namespace
@@ -67,7 +62,7 @@ CHIP_ERROR NetworkInfrastructureManager::Register(chip::EndpointId endpoint, Cod
     mWiFiNetworkManagementCluster.Create(endpoint);
     ReturnErrorOnFailure(provider.AddCluster(mWiFiNetworkManagementCluster.Registration()));
     ReturnErrorOnFailure(mWiFiNetworkManagementCluster.Cluster().SetNetworkCredentials(
-        ByteSpanFromCharSpan("MatterAP"_span), ByteSpanFromCharSpan("Setec Astronomy"_span)));
+        ByteSpan::fromCharSpan("MatterAP"_span), ByteSpan::fromCharSpan("Setec Astronomy"_span)));
 
     // 3. Thread Network Directory
     mThreadNetworkDirectoryCluster.Create(endpoint, mThreadNetworkDirectoryStorage);

--- a/examples/network-manager-app/linux/main.cpp
+++ b/examples/network-manager-app/linux/main.cpp
@@ -25,7 +25,6 @@
 #include <app/clusters/wifi-network-management-server/wifi-network-management-server.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
-#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
 
@@ -41,11 +40,6 @@
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
-
-ByteSpan ByteSpanFromCharSpan(CharSpan span)
-{
-    return ByteSpan(Uint8::from_const_char(span.data()), span.size());
-}
 
 #if MATTER_ENABLE_UBUS
 ubus::UbusManager gUbusManager{};
@@ -109,8 +103,8 @@ static void ApplicationEarlyInit()
 
 void ApplicationInit()
 {
-    TEMPORARY_RETURN_IGNORED gWiFiNetworkManagementServer->SetNetworkCredentials(ByteSpanFromCharSpan("MatterAP"_span),
-                                                                                 ByteSpanFromCharSpan("Setec Astronomy"_span));
+    TEMPORARY_RETURN_IGNORED gWiFiNetworkManagementServer->SetNetworkCredentials(ByteSpan::fromCharSpan("MatterAP"_span),
+                                                                                 ByteSpan::fromCharSpan("Setec Astronomy"_span));
 }
 
 void ApplicationShutdown()

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -140,13 +140,13 @@ public:
     {
         VerifyOrDie(offset <= mDataLen);
         VerifyOrDie(length <= mDataLen - offset);
-        return Span(mDataBuf + offset, length);
+        return Span(Unchecked, mDataBuf + offset, length);
     }
 
     Span SubSpan(size_t offset) const
     {
         VerifyOrDie(offset <= mDataLen);
-        return Span(mDataBuf + offset, mDataLen - offset);
+        return Span(Unchecked, mDataBuf + offset, mDataLen - offset);
     }
 
     // Allow reducing the size of a span.
@@ -156,31 +156,39 @@ public:
         mDataLen = new_size;
     }
 
-    // Allow creating ByteSpans and CharSpans from ZCL octet strings, so we
-    // don't have to reinvent it various places.
+    // Creates a ByteSpan or CharSpan from a ZCL octet string.
+    // A null pointer is treated as an empty string, yielding an empty span.
     template <class U,
               typename = std::enable_if_t<std::is_same<uint8_t, std::remove_const_t<U>>::value &&
                                           (std::is_same<const uint8_t, T>::value || std::is_same<const char, T>::value)>>
     static Span fromZclString(U * bytes)
     {
+        VerifyOrReturnValue(bytes != nullptr, Span());
         size_t length = bytes[0];
-        // Treat 0xFF (aka "null string") as zero-length.
-        if (length == 0xFF)
-        {
-            length = 0;
-        }
-        // Need reinterpret_cast if we're a CharSpan.
-        return Span(reinterpret_cast<T *>(&bytes[1]), length);
+        // Unchecked since we already checked. Treat 0xFF (aka "null string") as zero-length.
+        return Span(Unchecked, reinterpret_cast<T *>(&bytes[1]), (length != 0xFF) ? length : 0);
     }
 
-    // Creates a CharSpan from a null-terminated C character string.
+    // Creates a CharSpan or ByteSpan from a null-terminated C character string.
+    // A null pointer is treated as an empty string, yielding an empty span.
     //
     // Note that for string literals, the user-defined `_span` string
     // literal operator should be used instead, e.g. `"Hello"_span`.
-    template <class U, typename = std::enable_if_t<std::is_same<T, const U>::value && std::is_same<const char, T>::value>>
+    template <class U,
+              typename = std::enable_if_t<std::is_same<char, std::remove_const_t<U>>::value &&
+                                          (std::is_same<const uint8_t, T>::value || std::is_same<const char, T>::value)>>
     static Span fromCharString(U * chars)
     {
-        return Span(chars, strlen(chars));
+        // Unchecked since we already checked.  Need reinterpret_cast if we're a ByteSpan.
+        return (chars != nullptr) ? Span(Unchecked, reinterpret_cast<T *>(chars), strlen(chars)) : Span();
+    }
+
+    // Creates a ByteSpan that reinterprets the contents of a CharSpan as bytes.
+    template <class U = T, typename = std::enable_if_t<std::is_same<U, T>::value && std::is_same<const uint8_t, T>::value>>
+    static Span fromCharSpan(Span<const char> chars)
+    {
+        // Unchecked, the source span already guarantees data != nullptr unless size == 0.
+        return Span(Unchecked, reinterpret_cast<T *>(chars.data()), chars.size());
     }
 
     // operator== explicitly not implemented on Span, because its meaning

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -263,6 +263,7 @@ TEST(TestSpan, TestSubSpan)
 
     subspan = span.SubSpan(1, 0);
     EXPECT_EQ(subspan.size(), 0u);
+    EXPECT_EQ(subspan.data(), &array[1]); // an empty span is not normalized to nullptr
 
     subspan = span.SubSpan(10);
     EXPECT_EQ(subspan.data(), &array[10]);
@@ -270,6 +271,7 @@ TEST(TestSpan, TestSubSpan)
 
     subspan = span.SubSpan(16);
     EXPECT_EQ(subspan.size(), 0u);
+    EXPECT_EQ(subspan.data(), array + 16); // one past the end, but still not nullptr
 }
 
 TEST(TestSpan, TestFromZclString)
@@ -284,6 +286,25 @@ TEST(TestSpan, TestFromZclString)
 
     CharSpan s2 = CharSpan::fromZclString(array);
     EXPECT_TRUE(s2.data_equal(CharSpan(str, 3)));
+
+    // A zero-length string yields an empty span that still points into the buffer.
+    constexpr uint8_t empty[2] = { 0, 0x41 };
+    EXPECT_TRUE(ByteSpan::fromZclString(empty).empty());
+    EXPECT_EQ(ByteSpan::fromZclString(empty).data(), &empty[1]);
+    EXPECT_TRUE(CharSpan::fromZclString(empty).empty());
+    EXPECT_EQ(CharSpan::fromZclString(empty).data(), reinterpret_cast<const char *>(&empty[1]));
+
+    // 0xFF (aka "null string") is treated as zero-length, likewise pointing into the buffer.
+    constexpr uint8_t nullString[2] = { 0xff, 0x41 };
+    EXPECT_TRUE(ByteSpan::fromZclString(nullString).empty());
+    EXPECT_EQ(ByteSpan::fromZclString(nullString).data(), &nullString[1]);
+
+    // A null pointer yields an empty span.
+    const uint8_t * nullPtr = nullptr;
+    EXPECT_TRUE(ByteSpan::fromZclString(nullPtr).empty());
+    EXPECT_EQ(ByteSpan::fromZclString(nullPtr).data(), nullptr);
+    EXPECT_TRUE(CharSpan::fromZclString(nullPtr).empty());
+    EXPECT_EQ(CharSpan::fromZclString(nullPtr).data(), nullptr);
 }
 
 TEST(TestSpan, TestFromCharString)
@@ -292,6 +313,27 @@ TEST(TestSpan, TestFromCharString)
 
     CharSpan s1 = CharSpan::fromCharString(str);
     EXPECT_TRUE(s1.data_equal(CharSpan(str, 3)));
+
+    ByteSpan s2 = ByteSpan::fromCharString(str);
+    EXPECT_TRUE(s2.data_equal(ByteSpan(reinterpret_cast<const uint8_t *>(str), 3)));
+
+    char mutableStr[] = "AcE";
+    EXPECT_TRUE(CharSpan::fromCharString(mutableStr).data_equal(s1));
+    EXPECT_TRUE(ByteSpan::fromCharString(mutableStr).data_equal(s2));
+
+    // An empty string yields an empty span that still points at the string.
+    static constexpr char emptyStr[] = "";
+    EXPECT_TRUE(CharSpan::fromCharString(emptyStr).empty());
+    EXPECT_EQ(CharSpan::fromCharString(emptyStr).data(), emptyStr);
+    EXPECT_TRUE(ByteSpan::fromCharString(emptyStr).empty());
+    EXPECT_EQ(ByteSpan::fromCharString(emptyStr).data(), reinterpret_cast<const uint8_t *>(emptyStr));
+
+    // A null pointer produces an empty span.
+    const char * nullStr = nullptr;
+    EXPECT_TRUE(CharSpan::fromCharString(nullStr).empty());
+    EXPECT_EQ(CharSpan::fromCharString(nullStr).data(), nullptr);
+    EXPECT_TRUE(ByteSpan::fromCharString(nullStr).empty());
+    EXPECT_EQ(ByteSpan::fromCharString(nullStr).data(), nullptr);
 }
 
 TEST(TestSpan, TestLiteral)
@@ -409,4 +451,25 @@ TEST(TestSpan, TestConstructorTypeDeduction)
     Span f(constNumsConstArray);
     EXPECT_TRUE(f.data_equal(Span<const uint8_t>(otherNums, 2)));
     static_assert(std::is_same_v<decltype(f), Span<const uint8_t>>);
+}
+
+TEST(TestSpan, TestFromCharSpan)
+{
+    CharSpan chars = "the quick brown fox ..."_span;
+    ByteSpan bytes = ByteSpan::fromCharSpan(chars);
+    EXPECT_EQ(bytes.size(), chars.size());
+    EXPECT_EQ(bytes.data(), reinterpret_cast<const uint8_t *>(chars.data()));
+
+    ByteSpan empty = ByteSpan::fromCharSpan(CharSpan());
+    EXPECT_TRUE(empty.empty());
+    EXPECT_EQ(empty.data(), nullptr);
+
+    // An empty (but non-null) CharSpan keeps its pointer.
+    ByteSpan emptyAtEnd = ByteSpan::fromCharSpan(chars.SubSpan(chars.size()));
+    EXPECT_TRUE(emptyAtEnd.empty());
+    EXPECT_EQ(emptyAtEnd.data(), reinterpret_cast<const uint8_t *>(chars.data()) + chars.size());
+
+    // These should be compile errors -- fromCharSpan only takes ByteSpan.
+    // ByteSpan disallowed1 = ByteSpan::fromCharSpan(bytes);
+    // CharSpan disallowed2 = CharSpan::fromCharSpan<const uint8_t>(chars);
 }


### PR DESCRIPTION
### Summary

Move ByteSpanFromCharSpan into Span.h as ByteSpan::fromCharSpan(),
analogous to fromCharString(). Also allow fromCharString() to directly
produce a ByteSpan, in the same way fromZclString() does.

While there handle nullptr in fromCharString() and fromZclString() by
returning an empty span instead of dereferencing the null pointer. This
aligns with the nullptr handling of Span overall. Note that
fromZclString() is not used anymore from within the SDK itself.

Also use the Unchecked constructor variant internally where it's safe.

### Testing

Added test to TestSpan.cpp
