### PR TITLE
[NXP][Zephyr] Add common config prerequisites for crypto unit tests

### DIFF
--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -622,6 +622,11 @@ config MBEDTLS_CTR_DRBG_C
 config MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
 	default y
 
+# CSR parsing is only needed by the unit tests, so gate it to test builds to
+# keep the production image small (mirrors the NXP FreeRTOS mbedtls config).
+config MBEDTLS_X509_CSR_PARSE_C
+	default y if CHIP_BUILD_TESTS
+
 choice CHIP_CRYPTO
     default CHIP_CRYPTO_PSA
 

--- a/src/test_driver/nxp/zephyr/CMakeLists.txt
+++ b/src/test_driver/nxp/zephyr/CMakeLists.txt
@@ -20,6 +20,11 @@ get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/third_party/connect
 # Perform common operations before find_package(Zephyr)
 include(${CHIP_ROOT}/config/nxp/app/pre-zephyr.cmake)
 
+# This build has no wall-clock time source (CONFIG_MBEDTLS_HAVE_TIME_DATE
+# unset), so mbedtls stubs mbedtls_x509_time_is_past/is_future to return 0 and
+# the crypto test's IsCertificateValidAtCurrentTime check cannot pass.
+list(APPEND CHIP_CFLAGS -DCURRENT_TIME_NOT_IMPLEMENTED=1)
+
 list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/zephyr/chip-module)
 list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/third_party/pigweed/repo)
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION

### Summary

Adds the shared configuration prerequisites needed by the NXP Zephyr crypto unit tests. This lands the changes in common files so they are available.

#### Changes

- __`config/nxp/chip-module/Kconfig.defaults`__

  - `MBEDTLS_X509_CSR_PARSE_C`: default `y` only under `CHIP_BUILD_TESTS`. CSR parsing is required by the unit tests but not by production apps, so it is gated to test builds to keep the production image small (mirrors the NXP FreeRTOS mbedTLS config).

- __`src/test_driver/nxp/zephyr/CMakeLists.txt`__
  - Define `CURRENT_TIME_NOT_IMPLEMENTED=1` for the NXP Zephyr test driver build. This build has no wall-clock time source (`CONFIG_MBEDTLS_HAVE_TIME_DATE` unset), so mbedTLS stubs the X.509 time-validity checks and the crypto test's `IsCertificateValidAtCurrentTime` path is skipped.

### Testing

Built the NXP Zephyr crypto unit-test, and confirmed it passed.
Example build command: "west build -d build_ut -b frdm_rw612 src/test_driver/nxp/zephyr -p always"
