### PR TITLE
silabs/zephyr: fix Kconfig option reintroduced by merge

### DIFF
--- a/examples/lighting-app/silabs/zephyr/prj.conf
+++ b/examples/lighting-app/silabs/zephyr/prj.conf
@@ -32,6 +32,7 @@ CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 CONFIG_BT_DEVICE_NAME="MatterLight"
 CONFIG_BT_RECV_WORKQ_BT=n
 CONFIG_NET_IF_MCAST_IPV6_ADDR_COUNT=5
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=6
 CONFIG_STD_CPP17=y
 # Workaround for undefined reference to `bt_rand'
 CONFIG_BT_HOST_CRYPTO=y
@@ -50,23 +51,3 @@ CONFIG_CHIP_LIB_SHELL=y
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 CONFIG_MAIN_STACK_SIZE=8192
 CONFIG_SHELL_STACK_SIZE=4096
-CONFIG_BT_HOST_CRYPTO=y
-
-CONFIG_NET_IF_MCAST_IPV6_ADDR_COUNT=5
-
-CONFIG_BT_RECV_WORKQ_BT=n
-
-# Bluetooth Low Energy configuration
-CONFIG_BT_DEVICE_NAME="MatterLight"
-
-# Reduce application size
-CONFIG_USE_SEGGER_RTT=n
-
-# Avoid getopt multiple-definition conflict between newlib nano and Zephyr's POSIX C lib extension.
-# Newlib already provides getopt, strnlen, gmtime_r, strtok_r, etc.
-CONFIG_POSIX_AEP_CHOICE_NONE=y
-
-# CHIP's libCHIP.a uses thread_local storage (e.g. ErrorStr.cpp) which requires __aeabi_read_tp
-CONFIG_THREAD_LOCAL_STORAGE=y
-
-CONFIG_SETTINGS_NVS_SECTOR_COUNT=6


### PR DESCRIPTION
[Pull request #73226][1] cleaned up configuration file for lighting-app. However, at last minute, the merge [commit 1bb411e][2] reintroduced some removed options. The only addition we want to keep is `CONFIG_SETTINGS_NVS_SECTOR_COUNT=6`.

### Testing

 1. Compile the Lighting Application for siwx917_rb4338a on Zephyr:
```
    west build -b siwx917_rb4338a matter/examples/lighting-app/silabs/zephyr
```
 3. Ran "matter matterfactoryreset" on the target

 4. Test the commissioning process with:
```
    ./chip-tool pairing ble-wifi 15 xxx xxx 20202021 3840
```

[1]: https://github.com/project-chip/connectedhomeip/pull/73226
[2]: https://github.com/project-chip/connectedhomeip/commit/1bb411e63b89b659e00b598e319b102f3ac4fb82