### PR TITLE
silabs/zephyr: fix K_HEAP_MEM_POOL_SIZE=0

### DIFF
--- a/config/silabs/Kconfig
+++ b/config/silabs/Kconfig
@@ -288,11 +288,6 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 2560 if CHIP_WIFI
 	default 2048 if CHIP_ICD_LIT_SUPPORT
 
-config HEAP_MEM_POOL_IGNORE_MIN
-	default y if CHIP_WIFI
-
-#We use sys_heap based allocators, so make sure we don't reserve unused libc heap anyway
-
 config NVS_LOOKUP_CACHE_SIZE
 	default 512 if NVS
 


### PR DESCRIPTION
### Summary

`CONFIG_HEAP_MEM_POOL_SIZE=0` (default) allows Zephyr to automatically compute the right value for `K_HEAP_MEM_POOL_SIZE`.

However, used with `CONFIG_HEAP_MEM_POOL_IGNORE_MIN`, it force Zephyr to really set the `K_HEAP_MEM_POOL_SIZE` to 0. This leads to various complex issues.

It seems `CONFIG_HEAP_MEM_POOL_IGNORE_MIN` has been set by mistake with SIWX91X.

### Testing

 1. Compile the Lighting Application for siwx917_rb4338a on Zephyr:
```
    west build -b siwx917_rb4338a matter/examples/lighting-app/silabs/zephyr
```
 3. Ran "matter matterfactoryreset" on the target

 4. Test the commissioning process with:
```
    ./chip-tool pairing ble-wifi 15 xxx xxx 20202021 3840
```
