### PR TITLE
[Silabs] Cherry-pick: Serialize SI91x UART prints with si91x_prints_mutex (#73464)

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -54,6 +54,7 @@ extern "C" {
 #endif // SL_SI91X_BOARD_INIT
 #include "rsi_debug.h"
 #include "rsi_rom_egpio.h"
+extern osMutexId_t si91x_prints_mutex;
 #else // For EFR32
 #if (_SILICON_LABS_32B_SERIES < 3)
 #include "em_core.h"
@@ -671,10 +672,12 @@ void uartSendBytes(uint8_t * data, uint16_t length)
     //
     // Board_UARTPutSTR(data) does the exact same thing and is not compatible with
     // the Silabs Matter console.
+    osMutexAcquire(si91x_prints_mutex, osWaitForever);
     for (uint8_t i = 0; i < length; i++)
     {
         Board_UARTPutChar(data[i]);
     }
+    osMutexRelease(si91x_prints_mutex);
 #else
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);


### PR DESCRIPTION
Cherry-pick of #73464 

### Summary
Serialize SI91x UART console output so Matter logs and platform prints do not interleave when the RTOS is running.

**Problem** -
In the SI91x path, Matter uartSendBytes() sends logs using Board_UARTPutChar() directly, one character at a time. Board_UARTPutChar() uses shared resources such as UARTdrv, send_done, and the UART completion callback. The direct uartSendBytes() path does not appear to protect access to these shared resources.

**Fix** -
Protect uartSendBytes() with si91x_prints_mutex so that only one task accesses Board_UARTPutChar() at a time. This prevents concurrent access to the shared UART state and avoids potential races during heavy logging.

### Related issues
MATTER-6925

### Testing
- Tested manual build and ran an example app with Tx/Rx enabled.