### PR TITLE
Opstate legacy delegate wrapper - enforce invariants

### DIFF
--- a/src/app/clusters/operational-state-server/CodegenIntegration.h
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.h
@@ -49,7 +49,7 @@ public:
     {
         /// identical check with OperationalState::Delegate, forcing a 1:1
         /// between instance and delegate, so that every delegate knows exactly what instance it
-        /// belongs do and every instance is managed by one delegate only. Doing this here
+        /// belongs to and every instance is managed by one delegate only. Doing this here
         /// since mDelegate may not yet be set (and that was the one doing the check before).
         VerifyOrDie(mInstance == nullptr || aInstance == nullptr || mInstance == aInstance);
 
@@ -78,8 +78,9 @@ public:
         ///   - we would do SetDelegate(nullptr) + SetDelegate(mInstance), effectively switching FOO to BAR
         ///     without erroring out.
         VerifyOrDie(
-            (mDelegate->GetInstance() == nullptr) ||
-            (mDelegate->GetInstance() == mInstance)) ;
+            (aDelegate == nullptr) ||
+            (aDelegate->GetInstance() == nullptr) ||
+            (aDelegate->GetInstance() == mInstance)) ;
 
         if (mDelegate != nullptr)
         {

--- a/src/app/clusters/operational-state-server/CodegenIntegration.h
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.h
@@ -47,6 +47,12 @@ public:
 
     void SetInstance(Instance * aInstance)
     {
+        /// identical check with OperationalState::Delegate, forcing a 1:1
+        /// between instance and delegate, so that every delegate knows exactly what instance it
+        /// belongs do and every instance is managed by one delegate only. Doing this here
+        /// since mDelegate may not yet be set (and that was the one doing the check before).
+        VerifyOrDie(mInstance == nullptr || aInstance == nullptr || mInstance == aInstance);
+
         mInstance = aInstance;
         if (mDelegate != nullptr)
         {
@@ -56,6 +62,25 @@ public:
 
     void SetDelegate(LegacyDelegate * aDelegate)
     {
+        /// We expect a general invariant of mDelegate::instance == mInstance.
+        ///
+        /// At the same time though, delegates throughout try to ensure that delegates are not reset and always
+        /// travel through a "SetInstance" from null to a value.
+        ///
+        /// Enforce that the delegates actually match: when we receive the delegate,
+        /// either it has no instance yet (and we can set it to our underlying instance whatever it is)
+        /// or it is already set to the required instance anyway.
+        ///
+        /// What we try to avoid is the case of:
+        ///   - mDelegate instance is FOO
+        ///   - mInstance is BAR
+        /// then:
+        ///   - we would do SetDelegate(nullptr) + SetDelegate(mInstance), effectively switching FOO to BAR
+        ///     without erroring out.
+        VerifyOrDie(
+            (mDelegate->GetInstance() == nullptr) ||
+            (mDelegate->GetInstance() == mInstance)) ;
+
         if (mDelegate != nullptr)
         {
             mDelegate->SetInstance(nullptr);

--- a/src/app/clusters/operational-state-server/CodegenIntegration.h
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.h
@@ -47,10 +47,10 @@ public:
 
     void SetInstance(Instance * aInstance)
     {
-        /// identical check with OperationalState::Delegate, forcing a 1:1
-        /// between instance and delegate, so that every delegate knows exactly what instance it
-        /// belongs to and every instance is managed by one delegate only. Doing this here
-        /// since mDelegate may not yet be set (and that was the one doing the check before).
+        // Identical check with OperationalState::Delegate, forcing a 1:1
+        // between instance and delegate, so that every delegate knows exactly what instance it
+        // belongs to and every instance is managed by one delegate only. Doing this here
+        // since mDelegate may not yet be set (and that was the one doing the check before).
         VerifyOrDie(mInstance == nullptr || aInstance == nullptr || mInstance == aInstance);
 
         mInstance = aInstance;
@@ -62,21 +62,21 @@ public:
 
     void SetDelegate(LegacyDelegate * aDelegate)
     {
-        /// We expect a general invariant of mDelegate::instance == mInstance.
-        ///
-        /// At the same time though, delegates throughout try to ensure that delegates are not reset and always
-        /// travel through a "SetInstance" from null to a value.
-        ///
-        /// Enforce that the delegates actually match: when we receive the delegate,
-        /// either it has no instance yet (and we can set it to our underlying instance whatever it is)
-        /// or it is already set to the required instance anyway.
-        ///
-        /// What we try to avoid is the case of:
-        ///   - mDelegate instance is FOO
-        ///   - mInstance is BAR
-        /// then:
-        ///   - we would do SetDelegate(nullptr) + SetDelegate(mInstance), effectively switching FOO to BAR
-        ///     without erroring out.
+        // We expect a general invariant of mDelegate::instance == mInstance.
+        //
+        // At the same time though, delegates throughout try to ensure that delegates are not reset and always
+        // travel through a "SetInstance" from null to a value.
+        //
+        // Enforce that the delegates actually match: when we receive the delegate,
+        // either it has no instance yet (and we can set it to our underlying instance whatever it is)
+        // or it is already set to the required instance anyway.
+        //
+        // What we try to avoid is the case of:
+        //   - mDelegate instance is FOO
+        //   - mInstance is BAR
+        // then:
+        //   - we would do SetDelegate(nullptr) + SetDelegate(mInstance), effectively switching FOO to BAR
+        //     without erroring out.
         VerifyOrDie((aDelegate == nullptr) || (aDelegate->GetInstance() == nullptr) || (aDelegate->GetInstance() == mInstance));
 
         if (mDelegate != nullptr)

--- a/src/app/clusters/operational-state-server/CodegenIntegration.h
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.h
@@ -77,10 +77,7 @@ public:
         /// then:
         ///   - we would do SetDelegate(nullptr) + SetDelegate(mInstance), effectively switching FOO to BAR
         ///     without erroring out.
-        VerifyOrDie(
-            (aDelegate == nullptr) ||
-            (aDelegate->GetInstance() == nullptr) ||
-            (aDelegate->GetInstance() == mInstance)) ;
+        VerifyOrDie((aDelegate == nullptr) || (aDelegate->GetInstance() == nullptr) || (aDelegate->GetInstance() == mInstance));
 
         if (mDelegate != nullptr)
         {

--- a/src/app/clusters/operational-state-server/CodegenIntegration.h
+++ b/src/app/clusters/operational-state-server/CodegenIntegration.h
@@ -75,7 +75,7 @@ public:
         //   - mDelegate instance is FOO
         //   - mInstance is BAR
         // then:
-        //   - we would do SetDelegate(nullptr) + SetDelegate(mInstance), effectively switching FOO to BAR
+        //   - we would do SetInstance(nullptr) + SetInstance(mInstance), effectively switching FOO to BAR
         //     without erroring out.
         VerifyOrDie((aDelegate == nullptr) || (aDelegate->GetInstance() == nullptr) || (aDelegate->GetInstance() == mInstance));
 

--- a/src/app/clusters/operational-state-server/OperationalStateDelegate.h
+++ b/src/app/clusters/operational-state-server/OperationalStateDelegate.h
@@ -31,6 +31,10 @@ namespace OperationalState {
 
 class Instance;
 
+namespace detail {
+    class InstanceDelegateWrapper;
+} // namespace detail
+
 /**
  * Backward-compat delegate for OperationalState clusters using the old Instance wrappers.
  * Extends OperationalStateCluster::Delegate with SetInstance/GetInstance for lifecycle binding.
@@ -59,6 +63,10 @@ protected:
 
 private:
     Instance * mInstance = nullptr;
+
+    // allow Getinstance access. Essentially we want the wrapper to be able to
+    // preserve invariants.
+    friend class detail::InstanceDelegateWrapper;
 };
 
 } // namespace OperationalState

--- a/src/app/clusters/operational-state-server/OperationalStateDelegate.h
+++ b/src/app/clusters/operational-state-server/OperationalStateDelegate.h
@@ -32,7 +32,7 @@ namespace OperationalState {
 class Instance;
 
 namespace detail {
-    class InstanceDelegateWrapper;
+class InstanceDelegateWrapper;
 } // namespace detail
 
 /**

--- a/src/app/clusters/operational-state-server/OperationalStateDelegate.h
+++ b/src/app/clusters/operational-state-server/OperationalStateDelegate.h
@@ -64,8 +64,9 @@ protected:
 private:
     Instance * mInstance = nullptr;
 
-    // allow Getinstance access. Essentially we want the wrapper to be able to
-    // preserve invariants.
+    // Allow GetInstance access: we want the wrapper to be able to preserve invariants
+    // of a delegates belonging to a single instance (cannot have a delegate passed
+    // to two instances at the same time, because then SetInstance makes no sense).
     friend class detail::InstanceDelegateWrapper;
 };
 


### PR DESCRIPTION
### Summary

https://github.com/project-chip/connectedhomeip/pull/73687#discussion_r3825459164 review essentially was saying that we silently allow same delegate on two instances, which we tried to disallow before.

not a problem in existing (or generally in "correct" code) but we can try to do better, so here we try to do just that: add extra verifyordie to enforce delegate 1:1 instance mapping.

TLDR:
  - we want an invariant preserved of "wrapper::instance == wrapper::delegate::instance"
  - we want to enforce that delegate and instance are 1:1 mapped (no instance belongs to two delegates at the same time)

Added asserts and comments to validate that.

### Testing

Use existing CI: no tests added since codegen does not generally have them, however codegen examples should still pass CI.
