### PR TITLE
Fix crash in NXP WiFi diagnostic when STA is not connected

### DIFF
--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.cpp
@@ -269,6 +269,12 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
+bool DiagnosticDataProviderImpl::IsWiFiStaConnected()
+{
+    enum wlan_connection_state state = WLAN_DISCONNECTED;
+    return (wlan_get_connection_state(&state) == WM_SUCCESS && state == WLAN_CONNECTED);
+}
+
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & BssId)
 {
     constexpr size_t bssIdSize = 6;
@@ -336,6 +342,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(app::Clusters::WiFiNetwork
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiChannelNumber(uint16_t & channelNumber)
 {
+    VerifyOrReturnError(IsWiFiStaConnected(), CHIP_ERROR_INCORRECT_STATE);
     channelNumber = wlan_get_current_channel();
     return CHIP_NO_ERROR;
 }
@@ -474,6 +481,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts(void)
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
 {
 #if CONFIG_WIFI_GET_LOG
+    VerifyOrReturnError(IsWiFiStaConnected(), CHIP_ERROR_INCORRECT_STATE);
     wlan_ds_rate ds_rate;
     mlan_bss_type bss_type = MLAN_BSS_TYPE_STA;
 

--- a/src/platform/nxp/common/DiagnosticDataProviderImpl.h
+++ b/src/platform/nxp/common/DiagnosticDataProviderImpl.h
@@ -83,6 +83,11 @@ public:
     CHIP_ERROR GetEthOverrunCount(uint64_t & overrunCount) override;
     CHIP_ERROR ResetEthNetworkDiagnosticsCounts() override;
 #endif
+
+private:
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+    bool IsWiFiStaConnected();
+#endif
 };
 
 /**


### PR DESCRIPTION
WiFi diagnostic functions (GetWiFiChannelNumber, GetWiFiCurrentMaxRate, etc.)
access WLAN state without checking if STA is connected, causing crash when
a wildcard read is performed before the device connects to an AP.

Add IsWiFiStaConnected() guard function and return CHIP_ERROR_INCORRECT_STATE
when WiFi STA is not connected before accessing WLAN diagnostic data.

### Testing

TC-IDM-13.1, TC-IDM-14.1, TC-DESC-2.3 passed, verified on NXP platform.