### PR TITLE
Tidy up AutoCommissioner::SetCommissioningParameters

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -81,6 +81,7 @@ namespace {
 template <typename T, size_t N>
 CHIP_ERROR RelocateSpan(Span<const T> & inOutSpan, T (&buffer)[N], bool exactSize = false)
 {
+    static_assert(std::is_trivially_copyable_v<T>);
     size_t actualSize = inOutSpan.size();
     VerifyOrReturnError(exactSize ? actualSize == N : actualSize <= N, CHIP_ERROR_INVALID_ARGUMENT);
     if (actualSize > 0) // data() can be nullptr if size() == 0, and memmove(buffer, nullptr, 0) would be UB

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -76,6 +76,22 @@ CHIP_ERROR AutoCommissioner::VerifyICDRegistrationInfo(const CommissioningParame
     return CHIP_NO_ERROR;
 }
 
+namespace {
+// Copies the contents of a Span into our own buffer and updates the Span
+template <typename T, size_t N>
+CHIP_ERROR RelocateSpan(Span<const T> & inOutSpan, T (&buffer)[N], bool exactSize = false)
+{
+    size_t actualSize = inOutSpan.size();
+    VerifyOrReturnError(exactSize ? actualSize == N : actualSize <= N, CHIP_ERROR_INVALID_ARGUMENT);
+    if (actualSize > 0) // data() can be nullptr if size() == 0, and memmove(buffer, nullptr, 0) would be UB
+    {
+        memmove(buffer, inOutSpan.data(), actualSize * sizeof(T));
+    }
+    inOutSpan = Span(buffer, actualSize);
+    return CHIP_NO_ERROR;
+}
+} // namespace
+
 CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParameters & params)
 {
     // Our logic below assumes that we can modify mParams without affecting params.
@@ -92,73 +108,60 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
     if (params.GetThreadOperationalDataset().HasValue())
     {
         ByteSpan dataset = params.GetThreadOperationalDataset().Value();
-        if (dataset.size() > CommissioningParameters::kMaxThreadDatasetLen)
-        {
-            ChipLogError(Controller, "Thread operational data set is too large");
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-        memmove(mThreadOperationalDataset, dataset.data(), dataset.size());
+        ReturnErrorOnFailure(RelocateSpan(dataset, mThreadOperationalDataset),
+                             ChipLogError(Controller, "Thread operational data set is too large"));
         ChipLogProgress(Controller, "Setting thread operational dataset from parameters");
-        mParams.SetThreadOperationalDataset(ByteSpan(mThreadOperationalDataset, dataset.size()));
+        mParams.SetThreadOperationalDataset(dataset);
     }
 
     if (params.GetWiFiCredentials().HasValue())
     {
-        WiFiCredentials creds = params.GetWiFiCredentials().Value();
-        if (creds.ssid.size() > CommissioningParameters::kMaxSsidLen ||
-            creds.credentials.size() > CommissioningParameters::kMaxCredentialsLen)
-        {
-            ChipLogError(Controller, "Wifi credentials are too large");
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-        memmove(mSsid, creds.ssid.data(), creds.ssid.size());
-        memmove(mCredentials, creds.credentials.data(), creds.credentials.size());
+        WiFiCredentials creds = params.GetWiFiCredentials().Value(); // shallow struct copy
+        ReturnErrorOnFailure(RelocateSpan(creds.ssid, mSsid),        //
+                             ChipLogError(Controller, "WiFiCredentials.ssid is too large"));
+        ReturnErrorOnFailure(RelocateSpan(creds.credentials, mCredentials),
+                             ChipLogError(Controller, "WiFiCredentials.credentials is too large"));
         ChipLogProgress(Controller, "Setting wifi credentials from parameters");
-        mParams.SetWiFiCredentials(
-            WiFiCredentials(ByteSpan(mSsid, creds.ssid.size()), ByteSpan(mCredentials, creds.credentials.size())));
+        mParams.SetWiFiCredentials(creds);
     }
 
     if (params.GetCountryCode().HasValue())
     {
-        auto code = params.GetCountryCode().Value();
-        MutableCharSpan copiedCode(mCountryCode);
-        if (CopyCharSpanToMutableCharSpan(code, copiedCode) == CHIP_NO_ERROR)
-        {
-            mParams.SetCountryCode(copiedCode);
-        }
-        else
-        {
-            ChipLogError(Controller, "Country code is too large: %u", static_cast<unsigned>(code.size()));
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
+        CharSpan countryCode = params.GetCountryCode().Value();
+        ReturnErrorOnFailure(RelocateSpan(countryCode, mCountryCode), ChipLogError(Controller, "Country code is too large"));
+        mParams.SetCountryCode(countryCode);
     }
 
     // If the AttestationNonce is passed in, using that else using a random one..
     if (params.GetAttestationNonce().HasValue())
     {
+        ByteSpan attestationNonce = params.GetAttestationNonce().Value();
+        ReturnErrorOnFailure(RelocateSpan(attestationNonce, mAttestationNonce, /* exactSize = */ true),
+                             ChipLogError(Controller, "Attestation nonce length is invalid"));
         ChipLogProgress(Controller, "Setting attestation nonce from parameters");
-        VerifyOrReturnError(params.GetAttestationNonce().Value().size() == sizeof(mAttestationNonce), CHIP_ERROR_INVALID_ARGUMENT);
-        memmove(mAttestationNonce, params.GetAttestationNonce().Value().data(), params.GetAttestationNonce().Value().size());
+        mParams.SetAttestationNonce(attestationNonce);
     }
     else
     {
         ChipLogProgress(Controller, "Setting attestation nonce to random value");
         ReturnErrorOnFailure(Crypto::DRBG_get_bytes(mAttestationNonce, sizeof(mAttestationNonce)));
+        mParams.SetAttestationNonce(ByteSpan(mAttestationNonce));
     }
-    mParams.SetAttestationNonce(ByteSpan(mAttestationNonce, sizeof(mAttestationNonce)));
 
     if (params.GetCSRNonce().HasValue())
     {
+        ByteSpan csrNonce = params.GetCSRNonce().Value();
+        ReturnErrorOnFailure(RelocateSpan(csrNonce, mCSRNonce, /* exactSize = */ true),
+                             ChipLogError(Controller, "CSR nonce length is invalid"));
         ChipLogProgress(Controller, "Setting CSR nonce from parameters");
-        VerifyOrReturnError(params.GetCSRNonce().Value().size() == sizeof(mCSRNonce), CHIP_ERROR_INVALID_ARGUMENT);
-        memmove(mCSRNonce, params.GetCSRNonce().Value().data(), params.GetCSRNonce().Value().size());
+        mParams.SetCSRNonce(csrNonce);
     }
     else
     {
         ChipLogProgress(Controller, "Setting CSR nonce to random value");
         ReturnErrorOnFailure(Crypto::DRBG_get_bytes(mCSRNonce, sizeof(mCSRNonce)));
+        mParams.SetCSRNonce(ByteSpan(mCSRNonce));
     }
-    mParams.SetCSRNonce(ByteSpan(mCSRNonce, sizeof(mCSRNonce)));
 
     if (params.GetDSTOffsets().HasValue())
     {

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -688,4 +688,42 @@ TEST_F(AutoCommissionerTest, IsSecondaryNetworkSupportedCombinations)
         EXPECT_EQ(result, c.isSecondaryNetworkSupported);
     }
 }
+
+TEST_F(AutoCommissionerTest, SetCommissioningParametersCopiesSpans)
+{
+    uint8_t source[32]{ 0xde, 0xad }; // length 32 is valid for all these except country code
+    ByteSpan sourceSpan32(source);
+    CharSpan sourceCountryCode = "XX"_span;
+
+    CommissioningParameters params{};
+    params.SetAttestationNonce(sourceSpan32);
+    params.SetCSRNonce(sourceSpan32);
+    params.SetThreadOperationalDataset(sourceSpan32);
+    params.SetWiFiCredentials(WiFiCredentials(sourceSpan32, sourceSpan32));
+    params.SetCountryCode(sourceCountryCode);
+    EXPECT_EQ(mCommissioner.SetCommissioningParameters(params), CHIP_NO_ERROR);
+
+    CommissioningParameters storedParams = mCommissioner.GetCommissioningParameters();
+    ASSERT_TRUE(storedParams.GetAttestationNonce().HasValue());
+    EXPECT_NE(storedParams.GetAttestationNonce().Value().data(), sourceSpan32.data());
+    EXPECT_TRUE(storedParams.GetAttestationNonce().Value().data_equal(sourceSpan32));
+
+    ASSERT_TRUE(storedParams.GetCSRNonce().HasValue());
+    EXPECT_NE(storedParams.GetCSRNonce().Value().data(), sourceSpan32.data());
+    EXPECT_TRUE(storedParams.GetCSRNonce().Value().data_equal(sourceSpan32));
+
+    ASSERT_TRUE(storedParams.GetThreadOperationalDataset().HasValue());
+    EXPECT_NE(storedParams.GetThreadOperationalDataset().Value().data(), sourceSpan32.data());
+    EXPECT_TRUE(storedParams.GetThreadOperationalDataset().Value().data_equal(sourceSpan32));
+
+    ASSERT_TRUE(storedParams.GetWiFiCredentials().HasValue());
+    EXPECT_NE(storedParams.GetWiFiCredentials().Value().ssid.data(), sourceSpan32.data());
+    EXPECT_TRUE(storedParams.GetWiFiCredentials().Value().ssid.data_equal(sourceSpan32));
+    EXPECT_NE(storedParams.GetWiFiCredentials().Value().credentials.data(), sourceSpan32.data());
+    EXPECT_TRUE(storedParams.GetWiFiCredentials().Value().credentials.data_equal(sourceSpan32));
+
+    ASSERT_TRUE(storedParams.GetCountryCode().HasValue());
+    EXPECT_NE(storedParams.GetCountryCode().Value().data(), sourceCountryCode.data());
+    EXPECT_TRUE(storedParams.GetCountryCode().Value().data_equal(sourceCountryCode));
+}
 } // namespace


### PR DESCRIPTION
### Summary

Factor out the logic for checking the size of a source Span and copying
it into a member buffer into a RelocateSpan helper.

Also avoid "copying" the WiFiCredentials struct a second time via the
manual constructor invocation; the `creds` local is already a copy.

### Testing

Add a new unit test.
