### PR TITLE
[Silabs] Fix thermostat example build after code-driven cluster migration

### DIFF
--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -28,12 +28,12 @@
 #include "lcd.h"
 #endif // SL_MATTER_DISPLAY_ENABLED
 
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/clusters/thermostat-server/ThermostatCluster.h>
+#include <app/clusters/thermostat-server/AttributeAccessorShim.h>
+#include <app/clusters/thermostat-server/CodegenIntegration.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 #include <cmsis_os2.h>
@@ -104,9 +104,11 @@ CHIP_ERROR AppTask::AppInit()
     GetLCD().SetCustomUI(ThermostatUI::DrawUI);
 #endif
 
-    using namespace chip::app::Clusters::Thermostat;
-    auto & delegate = ThermostatDelegate::GetInstance();
-    SetDefaultDelegate(kThermostatEndpoint, &delegate);
+    auto status = Thermostat::SetDefaultDelegate(kThermostatEndpoint, &Thermostat::ThermostatDelegate::GetInstance());
+    if (status != Protocols::InteractionModel::Status::Success)
+    {
+        ChipLogError(AppServer, "SetDefaultDelegate failed: 0x%02x", to_underlying(status));
+    }
 
     err = AppInstance().InitThermostat();
     if (err != CHIP_NO_ERROR)

--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -32,6 +32,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/MessageDef/StatusIB.h>
 #include <app/clusters/thermostat-server/AttributeAccessorShim.h>
 #include <app/clusters/thermostat-server/CodegenIntegration.h>
 #include <app/server/Server.h>
@@ -104,10 +105,14 @@ CHIP_ERROR AppTask::AppInit()
     GetLCD().SetCustomUI(ThermostatUI::DrawUI);
 #endif
 
-    auto status = Thermostat::SetDefaultDelegate(kThermostatEndpoint, &Thermostat::ThermostatDelegate::GetInstance());
+    Protocols::InteractionModel::Status status =
+        Thermostat::SetDefaultDelegate(kThermostatEndpoint, &Thermostat::ThermostatDelegate::GetInstance());
     if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(AppServer, "SetDefaultDelegate failed: 0x%02x", to_underlying(status));
+        err = StatusIB(status).ToChipError();
+        appError(err);
+        return err;
     }
 
     err = AppInstance().InitThermostat();


### PR DESCRIPTION
### Summary
Restores the Silabs thermostat example build after the Thermostat cluster moved to the code-driven model.

### Related issues
NA

### Testing
Verified thermostat example builds successfully after the include/API updates.
