### PR TITLE
esp32: add a config option for groupcast feature

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -206,6 +206,13 @@ menu "CHIP Core"
 
         endchoice # CHIP_MEM_ALLOC_MODE
 
+        config CHIP_ENABLE_GROUPCAST
+            bool "Enable groupcast support"
+            default y
+            help
+                Enables the groupcast feature, which internally enables auxiliary access
+                control feature.
+
     endmenu # "General Options"
 
     menu "Networking Options"

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -174,9 +174,11 @@ menu "CHIP Core"
 
         config MAX_GROUP_KEYS_PER_FABRIC
             int "Maximum Number of Group Key Sets per Fabric"
-            default 3
+            default 4
             help
                 Specifies the maximum number of group key sets supported per fabric.
+                The default matches the core CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC
+                default (3 key sets + IPK)
 
         config CHIP_DEVICE_ENABLE_DYNAMIC_SERVER
             bool "Enable dynamic server"


### PR DESCRIPTION
### Summary
- Plumbing is already present in CMakeLists.txt but option is missing.

https://github.com/project-chip/connectedhomeip/blob/9fe1837d9454cd562f7fc0e76fe2ad490efe8741/config/esp32/components/chip/CMakeLists.txt#L364-L366

- Also, since groupcast is non provisional need to bump the `MAX_GROUP_KEYS_PER_FABRIC` to 4

- [ ] Needs v1.6.1 cherry-pick

### Related issues
- Plumbing was done in #71439

### Testing
- Tested building the app and running `TC_DeviceBasicComposition.py` test locally (for newly added `CONFIG_CHIP_ENABLE_GROUPCAST`)
- Ran `TC-RR-1-1` locally and verified it passes (This is for `MAX_GROUP_KEYS_PER_FABRIC` change)