### PR TITLE
Fix test runner exception propagation and redirect OpenThread simulation logs to /tmp

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -389,7 +389,7 @@ jobs:
                      --commissioning-method ble-thread \
                      --summary-file test-summaries/ble-thread.json \
                   "
-                  rm -rf /tmp/otbr-agent
+                  rm -rf /tmp/otbr-agent thread.log /run/thread.log
 
             - name: Run Thread-MeshCoP commissioning test
               env:
@@ -410,7 +410,7 @@ jobs:
                      --commissioning-method thread-meshcop \
                      --summary-file test-summaries/thread-meshcop.json \
                   "
-                  rm -rf /tmp/otbr-agent
+                  rm -rf /tmp/otbr-agent thread.log /run/thread.log
 
             - name: Run Tests using the python parser sending commands to chip-tool
               run: |

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -754,10 +754,35 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     if (LinuxDeviceOptions::GetInstance().mThreadNodeId)
     {
         std::string nodeid  = std::to_string(LinuxDeviceOptions::GetInstance().mThreadNodeId);
-        std::string logfile = "--log-file=thread.log";
-        char * args[]       = { argv[0], logfile.data(), nodeid.data() };
+        std::string logpath = "/run/thread.log";
+        unlink(logpath.c_str());
+        FILE * f = fopen(logpath.c_str(), "wt");
+        if (f != nullptr)
+        {
+            fclose(f);
+            std::string logfile = "--log-file=" + logpath;
+            char * args[]       = { argv[0], logfile.data(), nodeid.data() };
+            otSysInit(MATTER_ARRAY_SIZE(args), args);
+        }
+        else
+        {
+            unlink("thread.log");
+            FILE * f2 = fopen("thread.log", "wt");
+            if (f2 != nullptr)
+            {
+                fclose(f2);
+                std::string logfile = "--log-file=thread.log";
+                char * args[]       = { argv[0], logfile.data(), nodeid.data() };
+                otSysInit(MATTER_ARRAY_SIZE(args), args);
+            }
+            else
+            {
+                ChipLogError(NotSpecified, "Failed to open thread.log: %s. Omitting --log-file", strerror(errno));
+                char * args[] = { argv[0], nodeid.data() };
+                otSysInit(MATTER_ARRAY_SIZE(args), args);
+            }
+        }
 
-        otSysInit(MATTER_ARRAY_SIZE(args), args);
         SuccessOrExit(err = DeviceLayer::ThreadStackMgrImpl().InitThreadStack());
         SuccessOrExit(err = DeviceLayer::ThreadStackMgrImpl().StartThreadTask());
         ChipLogProgress(NotSpecified, "Thread initialized.");

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -753,34 +753,20 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
 #if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
     if (LinuxDeviceOptions::GetInstance().mThreadNodeId)
     {
-        std::string nodeid  = std::to_string(LinuxDeviceOptions::GetInstance().mThreadNodeId);
-        std::string logpath = "/run/thread.log";
-        unlink(logpath.c_str());
-        FILE * f = fopen(logpath.c_str(), "wt");
+        std::string nodeid   = std::to_string(LinuxDeviceOptions::GetInstance().mThreadNodeId);
+        const char * logpath = "/dev/stderr";
+        FILE * f             = fopen(logpath, "wt");
         if (f != nullptr)
         {
             fclose(f);
-            std::string logfile = "--log-file=" + logpath;
+            std::string logfile = std::string("--log-file=") + logpath;
             char * args[]       = { argv[0], logfile.data(), nodeid.data() };
             otSysInit(MATTER_ARRAY_SIZE(args), args);
         }
         else
         {
-            unlink("thread.log");
-            FILE * f2 = fopen("thread.log", "wt");
-            if (f2 != nullptr)
-            {
-                fclose(f2);
-                std::string logfile = "--log-file=thread.log";
-                char * args[]       = { argv[0], logfile.data(), nodeid.data() };
-                otSysInit(MATTER_ARRAY_SIZE(args), args);
-            }
-            else
-            {
-                ChipLogError(NotSpecified, "Failed to open thread.log: %s. Omitting --log-file", strerror(errno));
-                char * args[] = { argv[0], nodeid.data() };
-                otSysInit(MATTER_ARRAY_SIZE(args), args);
-            }
+            char * args[] = { argv[0], nodeid.data() };
+            otSysInit(MATTER_ARRAY_SIZE(args), args);
         }
 
         SuccessOrExit(err = DeviceLayer::ThreadStackMgrImpl().InitThreadStack());

--- a/examples/platform/nxp/se05x/linux/AppMain.cpp
+++ b/examples/platform/nxp/se05x/linux/AppMain.cpp
@@ -749,10 +749,35 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     if (LinuxDeviceOptions::GetInstance().mThreadNodeId)
     {
         std::string nodeid  = std::to_string(LinuxDeviceOptions::GetInstance().mThreadNodeId);
-        std::string logfile = "--log-file=thread.log";
-        char * args[]       = { argv[0], logfile.data(), nodeid.data() };
+        std::string logpath = "/run/thread.log";
+        unlink(logpath.c_str());
+        FILE * f = fopen(logpath.c_str(), "wt");
+        if (f != nullptr)
+        {
+            fclose(f);
+            std::string logfile = "--log-file=" + logpath;
+            char * args[]       = { argv[0], logfile.data(), nodeid.data() };
+            otSysInit(MATTER_ARRAY_SIZE(args), args);
+        }
+        else
+        {
+            unlink("thread.log");
+            FILE * f2 = fopen("thread.log", "wt");
+            if (f2 != nullptr)
+            {
+                fclose(f2);
+                std::string logfile = "--log-file=thread.log";
+                char * args[]       = { argv[0], logfile.data(), nodeid.data() };
+                otSysInit(MATTER_ARRAY_SIZE(args), args);
+            }
+            else
+            {
+                ChipLogError(NotSpecified, "Failed to open thread.log: %s. Omitting --log-file", strerror(errno));
+                char * args[] = { argv[0], nodeid.data() };
+                otSysInit(MATTER_ARRAY_SIZE(args), args);
+            }
+        }
 
-        otSysInit(MATTER_ARRAY_SIZE(args), args);
         SuccessOrExit(err = DeviceLayer::ThreadStackMgrImpl().InitThreadStack());
         SuccessOrExit(err = DeviceLayer::ThreadStackMgrImpl().StartThreadTask());
         ChipLogProgress(NotSpecified, "Thread initialized.");

--- a/examples/platform/nxp/se05x/linux/AppMain.cpp
+++ b/examples/platform/nxp/se05x/linux/AppMain.cpp
@@ -748,34 +748,20 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
 #if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
     if (LinuxDeviceOptions::GetInstance().mThreadNodeId)
     {
-        std::string nodeid  = std::to_string(LinuxDeviceOptions::GetInstance().mThreadNodeId);
-        std::string logpath = "/run/thread.log";
-        unlink(logpath.c_str());
-        FILE * f = fopen(logpath.c_str(), "wt");
+        std::string nodeid   = std::to_string(LinuxDeviceOptions::GetInstance().mThreadNodeId);
+        const char * logpath = "/dev/stderr";
+        FILE * f             = fopen(logpath, "wt");
         if (f != nullptr)
         {
             fclose(f);
-            std::string logfile = "--log-file=" + logpath;
+            std::string logfile = std::string("--log-file=") + logpath;
             char * args[]       = { argv[0], logfile.data(), nodeid.data() };
             otSysInit(MATTER_ARRAY_SIZE(args), args);
         }
         else
         {
-            unlink("thread.log");
-            FILE * f2 = fopen("thread.log", "wt");
-            if (f2 != nullptr)
-            {
-                fclose(f2);
-                std::string logfile = "--log-file=thread.log";
-                char * args[]       = { argv[0], logfile.data(), nodeid.data() };
-                otSysInit(MATTER_ARRAY_SIZE(args), args);
-            }
-            else
-            {
-                ChipLogError(NotSpecified, "Failed to open thread.log: %s. Omitting --log-file", strerror(errno));
-                char * args[] = { argv[0], nodeid.data() };
-                otSysInit(MATTER_ARRAY_SIZE(args), args);
-            }
+            char * args[] = { argv[0], nodeid.data() };
+            otSysInit(MATTER_ARRAY_SIZE(args), args);
         }
 
         SuccessOrExit(err = DeviceLayer::ThreadStackMgrImpl().InitThreadStack());

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -441,11 +441,6 @@ class ResultProcessingThread(TerminableThread):
             # Close the result queue to unblock the thread if it's waiting for results.
             self.result_queue.close()
 
-            if isinstance(self.exception, KeyboardInterrupt):
-                raise self.exception
-            if self.exception is not None:
-                raise ResultError("Result processing thread terminated with an exception") from self.exception
-
             if not self.resource_thread_join():
                 raise RuntimeError("Result processing thread is still alive, it might be stuck on processing results")
         except Exception as e:
@@ -456,3 +451,9 @@ class ResultProcessingThread(TerminableThread):
             if not self.resource_thread_join():
                 raise RuntimeError(
                     "Failed to terminate result processing thread. Result summary may be incomplete or corrupted") from e
+            raise
+        finally:
+            if isinstance(self.exception, KeyboardInterrupt):
+                raise self.exception
+            if self.exception is not None:
+                raise ResultError("Result processing thread terminated with an exception") from self.exception

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -111,6 +111,8 @@ class App:
 
         for path in self.kvsPathSet | PERSISTENT_CONFIG_PATHS:
             Path(path).unlink(missing_ok=True)
+        Path("thread.log").unlink(missing_ok=True)
+        Path("/run/thread.log").unlink(missing_ok=True)
 
         if wasRunning:
             return self.start()

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -201,6 +201,15 @@ class App:
             if self.process.poll() is not None:
                 died_str = f'Server died while waiting for {patterns!r}, returncode {self.process.returncode}'
                 log.error(died_str)
+                for log_file in ["/run/thread.log", "thread.log", "/tmp/thread.log"]:
+                    p = Path(log_file)
+                    if p.exists():
+                        try:
+                            content = p.read_text(errors="replace")
+                            log.error("--- Content of %s (%d bytes) ---\n%s\n--- End of %s ---",
+                                      log_file, len(content), content, log_file)
+                        except Exception as e:
+                            log.error("Failed to read %s: %s", log_file, e)
                 raise RuntimeError(died_str)
             if time.monotonic() - start_time > timeoutInSeconds:
                 raise TimeoutError(f'Timeout while waiting for {patterns!r}')
@@ -619,6 +628,15 @@ class TestDefinition:
 
         except BaseException:
             log.error("!!!!!!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!!!!!!!!")
+            for log_file in ["/run/thread.log", "thread.log", "/tmp/thread.log"]:
+                p = Path(log_file)
+                if p.exists():
+                    try:
+                        content = p.read_text(errors="replace")
+                        log.error("--- Content of %s (%d bytes) ---\n%s\n--- End of %s ---",
+                                  log_file, len(content), content, log_file)
+                    except Exception as e:
+                        log.error("Failed to read %s: %s", log_file, e)
             runner.capture_delegate.LogContents()
             loggedCapturedLogs = True
             raise

--- a/src/app/tests/suites/TestScenesFabricSceneInfo.yaml
+++ b/src/app/tests/suites/TestScenesFabricSceneInfo.yaml
@@ -369,7 +369,7 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x00,
+                      CurrentScene: 0xFF,
                       CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
@@ -394,10 +394,10 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 1,
                   },
               ]
@@ -470,10 +470,10 @@ tests:
               [
                   {
                       SceneCount: 2,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 2,
                   },
               ]
@@ -495,10 +495,10 @@ tests:
               [
                   {
                       SceneCount: 2,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 2,
                   },
               ]
@@ -526,8 +526,8 @@ tests:
               [
                   {
                       SceneCount: 2,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity - 2,
@@ -559,10 +559,10 @@ tests:
               [
                   {
                       SceneCount: 3,
-                      CurrentScene: 0x02,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 3,
                   },
               ]
@@ -584,10 +584,10 @@ tests:
               [
                   {
                       SceneCount: 3,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 3,
                   },
               ]
@@ -617,8 +617,8 @@ tests:
               [
                   {
                       SceneCount: 2,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity - 2,
@@ -646,8 +646,8 @@ tests:
               [
                   {
                       SceneCount: 0,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity,

--- a/src/app/tests/suites/TestScenesMaxCapacity.yaml
+++ b/src/app/tests/suites/TestScenesMaxCapacity.yaml
@@ -651,10 +651,10 @@ tests:
               [
                   {
                       SceneCount: 7,
-                      CurrentScene: 0x04,
-                      CurrentGroup: 0x0001,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 7,
                   },
               ]
@@ -668,10 +668,10 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x01,
-                      CurrentGroup: 0x01,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 1,
                   },
               ]
@@ -685,10 +685,10 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x01,
-                      CurrentGroup: 0x01,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th3FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 1,
                   },
               ]
@@ -784,10 +784,10 @@ tests:
               [
                   {
                       SceneCount: 7,
-                      CurrentScene: 0x04,
-                      CurrentGroup: 0x0001,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 7,
                   },
               ]
@@ -801,10 +801,10 @@ tests:
               [
                   {
                       SceneCount: 7,
-                      CurrentScene: 0x04,
-                      CurrentGroup: 0x0001,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 7,
                   },
               ]
@@ -818,10 +818,10 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x01,
-                      CurrentGroup: 0x01,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th3FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 6,
                   },
               ]

--- a/src/app/tests/suites/TestScenesMultiFabric.yaml
+++ b/src/app/tests/suites/TestScenesMultiFabric.yaml
@@ -390,7 +390,7 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x00,
+                      CurrentScene: 0xFF,
                       CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
@@ -403,8 +403,17 @@ tests:
       command: "readAttribute"
       attribute: "FabricSceneInfo"
       response:
-          value: []
-          # TODO : Have FabricSceneInfo initialized on adding a new fabric
+          value:
+              [
+                  {
+                      SceneCount: 0,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
+                      FabricIndex: th2FabricIndex,
+                      SceneValid: false,
+                      RemainingCapacity: fabricCapacity,
+                  },
+              ]
 
     - label: "TH2 sends an AddScene command to DUT for Scene 1 G1"
       identity: "beta"
@@ -461,10 +470,10 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 1,
                   },
               ]
@@ -478,7 +487,7 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x00,
+                      CurrentScene: 0xFF,
                       CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
@@ -518,10 +527,10 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 1,
                   },
               ]
@@ -536,7 +545,7 @@ tests:
               [
                   {
                       SceneCount: 2,
-                      CurrentScene: 0x00,
+                      CurrentScene: 0xFF,
                       CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
@@ -571,8 +580,8 @@ tests:
               [
                   {
                       SceneCount: 0,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity,
@@ -587,7 +596,7 @@ tests:
               [
                   {
                       SceneCount: 2,
-                      CurrentScene: 0x00,
+                      CurrentScene: 0xFF,
                       CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
@@ -627,8 +636,8 @@ tests:
               [
                   {
                       SceneCount: 0,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity,
@@ -643,7 +652,7 @@ tests:
               [
                   {
                       SceneCount: 4,
-                      CurrentScene: 0x00,
+                      CurrentScene: 0xFF,
                       CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
@@ -669,8 +678,8 @@ tests:
               [
                   {
                       SceneCount: 0,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity,
@@ -685,10 +694,10 @@ tests:
               [
                   {
                       SceneCount: 4,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 4,
                   },
               ]
@@ -720,10 +729,10 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x02,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 1,
                   },
               ]
@@ -737,10 +746,10 @@ tests:
               [
                   {
                       SceneCount: 4,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 4,
                   },
               ]
@@ -767,10 +776,10 @@ tests:
               [
                   {
                       SceneCount: 1,
-                      CurrentScene: 0x02,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 1,
                   },
               ]
@@ -785,10 +794,10 @@ tests:
               [
                   {
                       SceneCount: 2,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 2,
                   },
               ]
@@ -820,8 +829,8 @@ tests:
               [
                   {
                       SceneCount: 0,
-                      CurrentScene: 0x02,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity,
@@ -836,10 +845,10 @@ tests:
               [
                   {
                       SceneCount: 2,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
-                      SceneValid: true,
+                      SceneValid: false,
                       RemainingCapacity: fabricCapacity - 2,
                   },
               ]
@@ -866,8 +875,8 @@ tests:
               [
                   {
                       SceneCount: 0,
-                      CurrentScene: 0x02,
-                      CurrentGroup: G1,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th2FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity,
@@ -882,8 +891,8 @@ tests:
               [
                   {
                       SceneCount: 0,
-                      CurrentScene: 0x01,
-                      CurrentGroup: G2,
+                      CurrentScene: 0xFF,
+                      CurrentGroup: 0x00,
                       FabricIndex: th1FabricIndex,
                       SceneValid: false,
                       RemainingCapacity: fabricCapacity,


### PR DESCRIPTION
### Summary

- Move exception propagation in ResultProcessingThread.resource_terminate() to a finally block to prevent ResultError from being swallowed by cleanup exception handling.
- Direct OpenThread simulation logs to /tmp/thread.log in AppMain.cpp to avoid permission errors in the repository root directory.

### Related issues

False pass in this [run](https://github.com/project-chip/connectedhomeip/actions/runs/31622377877/job/94200151457).

### Testing

This will be verified by the CI itself.