### PR TITLE
Populate the EPALM rating attributes in electrical-protection-app

### DIFF
--- a/examples/electrical-protection-app/electrical-protection-common/src/electrical-protection-alarm-stub.cpp
+++ b/examples/electrical-protection-app/electrical-protection-common/src/electrical-protection-alarm-stub.cpp
@@ -19,6 +19,7 @@
 #include <electrical-protection-alarm-stub.h>
 
 #include <app/clusters/electrical-protection-alarm-server/ElectricalProtectionAlarmTestEventTriggerHandler.h>
+#include <clusters/ElectricalProtectionAlarm/Structs.h>
 #include <lib/support/CodeUtils.h>
 
 #include <memory>
@@ -43,9 +44,113 @@ BitMask<AlarmBitmap> AllSupportedAlarms()
     return bits;
 }
 
-// This app enables every EPALM feature so the full alarm surface can be exercised. Rating
-// attributes are left null (the app performs no real measurement); alarm State starts clear and is
-// driven by the test-event-trigger below.
+// Representative ratings for a 100 A / 240 V residential panel breaker. Currents are amperage-mA
+// and voltages are voltage-mV per the cluster definition; ResponseTime is in nanoseconds. These are
+// illustrative fixed values, not measurements: the point is that every rating attribute encodes a
+// populated struct so the attribute tests exercise their structure validation instead of taking the
+// null path.
+constexpr int64_t kRatedCurrentMa      = 100000;   // 100 A
+constexpr int64_t kUltimateMaxCurrentMa = 10000000; // 10 kA interrupting capacity
+constexpr int64_t kServiceMaxCurrentMa  = 6000000;  // 6 kA service short-circuit rating
+constexpr int64_t kMaxOperatingVoltageMv = 253000;  // 240 V +5%
+constexpr int64_t kOverVoltageTripMv    = 275000;
+constexpr uint64_t kResponseTimeNs      = 25;       // typical MOV clamping response
+constexpr uint64_t kEnergyAbsorptionJ   = 1200;     // surge energy absorption capability
+
+Structs::ArcFaultRatingsStruct::Type MakeArcFaultRating()
+{
+    Structs::ArcFaultRatingsStruct::Type r;
+    r.seriesArcCurrentSensitivity   = MakeOptional<int64_t>(5000);  // 5 A
+    r.parallelArcCurrentSensitivity = MakeOptional<int64_t>(30000); // 30 A
+    BitMask<ArcCauseBitmap> causes;
+    causes.Set(ArcCauseBitmap::kSeries).Set(ArcCauseBitmap::kParallelToNeutral).Set(ArcCauseBitmap::kParallelToGround);
+    r.supportedArcCauses = MakeOptional(causes);
+    return r;
+}
+
+Structs::OverLoadRatingsStruct::Type MakeOverLoadRating()
+{
+    Structs::OverLoadRatingsStruct::Type r;
+    BitMask<CurrentTripMechanismBitmap> mech;
+    mech.Set(CurrentTripMechanismBitmap::kThermal).Set(CurrentTripMechanismBitmap::kMagnetic);
+    r.tripCurrent       = MakeOptional(kRatedCurrentMa);
+    r.tripCurve         = MakeOptional(CurrentTripCurveEnum::kTypeC);
+    r.tripMechanism     = MakeOptional(mech);
+    r.ultimateMaxCurrent = MakeOptional(kUltimateMaxCurrentMa);
+    r.serviceMaxCurrent  = MakeOptional(kServiceMaxCurrentMa);
+    return r;
+}
+
+Structs::OverVoltageRatingsStruct::Type MakeOverVoltageRating()
+{
+    Structs::OverVoltageRatingsStruct::Type r;
+    BitMask<VoltageTripMechanismBitmap> mech;
+    mech.Set(VoltageTripMechanismBitmap::kMov);
+    r.tripMechanism                = MakeOptional(mech);
+    r.tripVoltage                  = MakeOptional(kOverVoltageTripMv);
+    r.maxContinuousOperatingVoltage = MakeOptional(kMaxOperatingVoltageMv);
+    r.responseTime                 = MakeOptional(kResponseTimeNs);
+    return r;
+}
+
+Structs::SurgeProtectionRatingsStruct::Type MakeSurgeProtectionRating()
+{
+    Structs::SurgeProtectionRatingsStruct::Type r;
+    BitMask<VoltageTripMechanismBitmap> mech;
+    mech.Set(VoltageTripMechanismBitmap::kMov);
+    BitMask<SurgeProtectionClassBitmap> cls;
+    cls.Set(SurgeProtectionClassBitmap::kClassII);
+    BitMask<SurgeProtectionTypeBitmap> type;
+    type.Set(SurgeProtectionTypeBitmap::kType2);
+    r.tripMechanism                 = MakeOptional(mech);
+    r.protectionClass               = MakeOptional(cls);
+    r.protectionType                = MakeOptional(type);
+    r.maxContinuousOperatingVoltage = MakeOptional(kOverVoltageTripMv);
+    r.maxVoltageProtection          = MakeOptional<int64_t>(1200000); // 1.2 kV let-through
+    r.maxTemporaryVoltage           = MakeOptional<int64_t>(335000);
+    r.nominalDischargeCurrent       = MakeOptional<int64_t>(20000000); // 20 kA
+    r.maximumDischargeCurrent       = MakeOptional<int64_t>(40000000); // 40 kA
+    r.ratedShortCircuitCurrent      = MakeOptional(kUltimateMaxCurrentMa);
+    r.ratedShortTimeWithstandCurrent = MakeOptional(kServiceMaxCurrentMa);
+    r.energyAbsorptionCapability    = MakeOptional(kEnergyAbsorptionJ);
+    r.responseTime                  = MakeOptional(kResponseTimeNs);
+    return r;
+}
+
+Structs::ShortCircuitRatingsStruct::Type MakeShortCircuitRating()
+{
+    Structs::ShortCircuitRatingsStruct::Type r;
+    BitMask<CurrentTripMechanismBitmap> mech;
+    mech.Set(CurrentTripMechanismBitmap::kMagnetic);
+    r.tripCurrent        = MakeOptional<int64_t>(1000000); // 1 kA magnetic trip
+    r.tripMechanism      = MakeOptional(mech);
+    r.tripCurve          = MakeOptional(CurrentTripCurveEnum::kTypeC);
+    r.ultimateMaxCurrent = MakeOptional(kUltimateMaxCurrentMa);
+    r.serviceMaxCurrent  = MakeOptional(kServiceMaxCurrentMa);
+    r.maxCurrent         = MakeOptional(kUltimateMaxCurrentMa);
+    return r;
+}
+
+Structs::ResidualCurrentFaultRatingsStruct::Type MakeResidualCurrentRating()
+{
+    Structs::ResidualCurrentFaultRatingsStruct::Type r;
+    BitMask<CurrentTripMechanismBitmap> mech;
+    mech.Set(CurrentTripMechanismBitmap::kElectronic);
+    BitMask<TrippingCharacteristicsBitmap> characteristic;
+    characteristic.Set(TrippingCharacteristicsBitmap::kSelective);
+    r.currentSensitivity      = MakeOptional<int64_t>(30); // 30 mA
+    r.tripMechanism           = MakeOptional(mech);
+    r.voltageDependent        = MakeOptional(false);
+    r.groundFaultClass        = MakeOptional(GroundFaultClassEnum::kClassA);
+    r.waveform                = MakeOptional(CurrentWaveformEnum::kAc);
+    r.trippingCharacteristic  = MakeOptional(characteristic);
+    r.ultimateMaxCurrent      = MakeOptional(kUltimateMaxCurrentMa);
+    r.serviceMaxCurrent       = MakeOptional(kServiceMaxCurrentMa);
+    return r;
+}
+
+// This app enables every EPALM feature so the full alarm surface can be exercised. Alarm State
+// starts clear and is driven by the test-event-trigger below.
 ElectricalProtectionAlarmCluster::StartupConfiguration MakeDefaultConfig()
 {
     ElectricalProtectionAlarmCluster::StartupConfiguration config;
@@ -58,6 +163,16 @@ ElectricalProtectionAlarmCluster::StartupConfiguration MakeDefaultConfig()
         .Set(Feature::kSelfTest);
     config.supported = AllSupportedAlarms();
     config.mask      = AllSupportedAlarms();
+
+    BitMask<ArcCauseBitmap> arcCause;
+    arcCause.Set(ArcCauseBitmap::kSeries).Set(ArcCauseBitmap::kParallelToNeutral);
+    config.arcCause              = DataModel::MakeNullable(arcCause);
+    config.overLoadRating        = DataModel::MakeNullable(MakeOverLoadRating());
+    config.overVoltageRating     = DataModel::MakeNullable(MakeOverVoltageRating());
+    config.surgeProtectionRating = DataModel::MakeNullable(MakeSurgeProtectionRating());
+    config.shortCircuitRating    = DataModel::MakeNullable(MakeShortCircuitRating());
+    config.residualCurrentRating = DataModel::MakeNullable(MakeResidualCurrentRating());
+    config.arcFaultRating        = DataModel::MakeNullable(MakeArcFaultRating());
     return config;
 }
 

--- a/examples/electrical-protection-app/electrical-protection-common/src/electrical-protection-alarm-stub.cpp
+++ b/examples/electrical-protection-app/electrical-protection-common/src/electrical-protection-alarm-stub.cpp
@@ -49,13 +49,13 @@ BitMask<AlarmBitmap> AllSupportedAlarms()
 // illustrative fixed values, not measurements: the point is that every rating attribute encodes a
 // populated struct so the attribute tests exercise their structure validation instead of taking the
 // null path.
-constexpr int64_t kRatedCurrentMa      = 100000;   // 100 A
-constexpr int64_t kUltimateMaxCurrentMa = 10000000; // 10 kA interrupting capacity
-constexpr int64_t kServiceMaxCurrentMa  = 6000000;  // 6 kA service short-circuit rating
-constexpr int64_t kMaxOperatingVoltageMv = 253000;  // 240 V +5%
-constexpr int64_t kOverVoltageTripMv    = 275000;
-constexpr uint64_t kResponseTimeNs      = 25;       // typical MOV clamping response
-constexpr uint64_t kEnergyAbsorptionJ   = 1200;     // surge energy absorption capability
+constexpr int64_t kRatedCurrentMa        = 100000;   // 100 A
+constexpr int64_t kUltimateMaxCurrentMa  = 10000000; // 10 kA interrupting capacity
+constexpr int64_t kServiceMaxCurrentMa   = 6000000;  // 6 kA service short-circuit rating
+constexpr int64_t kMaxOperatingVoltageMv = 253000;   // 240 V +5%
+constexpr int64_t kOverVoltageTripMv     = 275000;
+constexpr uint64_t kResponseTimeNs       = 25;   // typical MOV clamping response
+constexpr uint64_t kEnergyAbsorptionJ    = 1200; // surge energy absorption capability
 
 Structs::ArcFaultRatingsStruct::Type MakeArcFaultRating()
 {
@@ -73,9 +73,9 @@ Structs::OverLoadRatingsStruct::Type MakeOverLoadRating()
     Structs::OverLoadRatingsStruct::Type r;
     BitMask<CurrentTripMechanismBitmap> mech;
     mech.Set(CurrentTripMechanismBitmap::kThermal).Set(CurrentTripMechanismBitmap::kMagnetic);
-    r.tripCurrent       = MakeOptional(kRatedCurrentMa);
-    r.tripCurve         = MakeOptional(CurrentTripCurveEnum::kTypeC);
-    r.tripMechanism     = MakeOptional(mech);
+    r.tripCurrent        = MakeOptional(kRatedCurrentMa);
+    r.tripCurve          = MakeOptional(CurrentTripCurveEnum::kTypeC);
+    r.tripMechanism      = MakeOptional(mech);
     r.ultimateMaxCurrent = MakeOptional(kUltimateMaxCurrentMa);
     r.serviceMaxCurrent  = MakeOptional(kServiceMaxCurrentMa);
     return r;
@@ -86,10 +86,10 @@ Structs::OverVoltageRatingsStruct::Type MakeOverVoltageRating()
     Structs::OverVoltageRatingsStruct::Type r;
     BitMask<VoltageTripMechanismBitmap> mech;
     mech.Set(VoltageTripMechanismBitmap::kMov);
-    r.tripMechanism                = MakeOptional(mech);
-    r.tripVoltage                  = MakeOptional(kOverVoltageTripMv);
+    r.tripMechanism                 = MakeOptional(mech);
+    r.tripVoltage                   = MakeOptional(kOverVoltageTripMv);
     r.maxContinuousOperatingVoltage = MakeOptional(kMaxOperatingVoltageMv);
-    r.responseTime                 = MakeOptional(kResponseTimeNs);
+    r.responseTime                  = MakeOptional(kResponseTimeNs);
     return r;
 }
 
@@ -102,18 +102,18 @@ Structs::SurgeProtectionRatingsStruct::Type MakeSurgeProtectionRating()
     cls.Set(SurgeProtectionClassBitmap::kClassII);
     BitMask<SurgeProtectionTypeBitmap> type;
     type.Set(SurgeProtectionTypeBitmap::kType2);
-    r.tripMechanism                 = MakeOptional(mech);
-    r.protectionClass               = MakeOptional(cls);
-    r.protectionType                = MakeOptional(type);
-    r.maxContinuousOperatingVoltage = MakeOptional(kOverVoltageTripMv);
-    r.maxVoltageProtection          = MakeOptional<int64_t>(1200000); // 1.2 kV let-through
-    r.maxTemporaryVoltage           = MakeOptional<int64_t>(335000);
-    r.nominalDischargeCurrent       = MakeOptional<int64_t>(20000000); // 20 kA
-    r.maximumDischargeCurrent       = MakeOptional<int64_t>(40000000); // 40 kA
-    r.ratedShortCircuitCurrent      = MakeOptional(kUltimateMaxCurrentMa);
+    r.tripMechanism                  = MakeOptional(mech);
+    r.protectionClass                = MakeOptional(cls);
+    r.protectionType                 = MakeOptional(type);
+    r.maxContinuousOperatingVoltage  = MakeOptional(kOverVoltageTripMv);
+    r.maxVoltageProtection           = MakeOptional<int64_t>(1200000); // 1.2 kV let-through
+    r.maxTemporaryVoltage            = MakeOptional<int64_t>(335000);
+    r.nominalDischargeCurrent        = MakeOptional<int64_t>(20000000); // 20 kA
+    r.maximumDischargeCurrent        = MakeOptional<int64_t>(40000000); // 40 kA
+    r.ratedShortCircuitCurrent       = MakeOptional(kUltimateMaxCurrentMa);
     r.ratedShortTimeWithstandCurrent = MakeOptional(kServiceMaxCurrentMa);
-    r.energyAbsorptionCapability    = MakeOptional(kEnergyAbsorptionJ);
-    r.responseTime                  = MakeOptional(kResponseTimeNs);
+    r.energyAbsorptionCapability     = MakeOptional(kEnergyAbsorptionJ);
+    r.responseTime                   = MakeOptional(kResponseTimeNs);
     return r;
 }
 
@@ -138,14 +138,14 @@ Structs::ResidualCurrentFaultRatingsStruct::Type MakeResidualCurrentRating()
     mech.Set(CurrentTripMechanismBitmap::kElectronic);
     BitMask<TrippingCharacteristicsBitmap> characteristic;
     characteristic.Set(TrippingCharacteristicsBitmap::kSelective);
-    r.currentSensitivity      = MakeOptional<int64_t>(30); // 30 mA
-    r.tripMechanism           = MakeOptional(mech);
-    r.voltageDependent        = MakeOptional(false);
-    r.groundFaultClass        = MakeOptional(GroundFaultClassEnum::kClassA);
-    r.waveform                = MakeOptional(CurrentWaveformEnum::kAc);
-    r.trippingCharacteristic  = MakeOptional(characteristic);
-    r.ultimateMaxCurrent      = MakeOptional(kUltimateMaxCurrentMa);
-    r.serviceMaxCurrent       = MakeOptional(kServiceMaxCurrentMa);
+    r.currentSensitivity     = MakeOptional<int64_t>(30); // 30 mA
+    r.tripMechanism          = MakeOptional(mech);
+    r.voltageDependent       = MakeOptional(false);
+    r.groundFaultClass       = MakeOptional(GroundFaultClassEnum::kClassA);
+    r.waveform               = MakeOptional(CurrentWaveformEnum::kAc);
+    r.trippingCharacteristic = MakeOptional(characteristic);
+    r.ultimateMaxCurrent     = MakeOptional(kUltimateMaxCurrentMa);
+    r.serviceMaxCurrent      = MakeOptional(kServiceMaxCurrentMa);
     return r;
 }
 


### PR DESCRIPTION
#### Summary

Publishes representative values for the seven EPALM rating attributes in `electrical-protection-app`, so the attribute tests exercise their structure validation.

##### Problem

The app published every rating attribute as null. All seven are nullable, and `TC-EPALM-2.1` guards each check with `if val is not NullValue:`, so on this DUT the structure validation never executed and the steps passed by confirming a null.

Raised by @jamesharrow while approving #73395:

> since everything is nullable the test scripts probably check its a null value (ok that's a pass!)... We really want the python scripts to pick up the detailed structure validation code.

##### Solution

- Populates `ArcCause` and the six `*RatingsStruct` attributes with fixed values representative of a 100 A / 240 V residential panel breaker: thermal-magnetic overload trip on a Type C curve, 10 kA interrupting capacity, 30 mA Class A residual-current sensitivity, Class II / Type 2 surge protection.
- Currents are `amperage-mA` and voltages are `voltage-mV` per the cluster definition, `ResponseTime` is in nanoseconds, and every field satisfies its `min 1` constraint.
- Values are illustrative rather than measured; the app performs no measurement. The alarm surface, feature map and test-event triggers are unchanged.

#### Related issues

Follow-up to #73395, per the review request there.

#### Testing

- Built `chip-electrical-protection-app` and ran `TC-EPALM-2.1` against it on endpoint 1: passes, and the structure-validation branches now execute rather than short-circuiting on null.
- Confirmed the change is what makes them execute: against an out-of-date local Python binding the same run failed *inside* `_check_surge_protection_ratings_struct`, a function that was unreachable while the attribute read as null. With current bindings it passes.
