### PR TITLE
Align TC_PWRTL_2_1.py with the trimmed test plan

### DIFF
--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -85,10 +85,9 @@ class TC_PWRTL_2_1(MatterBaseTest):
             log.info("AvailableEndpoints: %s", avail_eps)
             asserts.assert_less_equal(len(avail_eps), 20,
                                       "AvailableEndpoints exceeds its max 20 constraint")
-        else:
-            self.mark_current_step_skipped()
 
         self.step(3, "TH reads ActiveEndpoints and verifies it is a subset of AvailableEndpoints")
+        active_eps = None
         if await self.attribute_guard(endpoint=endpoint, attribute=attributes.ActiveEndpoints):
             active_eps = await self.read_single_attribute_check_success(
                 endpoint=endpoint,
@@ -105,23 +104,23 @@ class TC_PWRTL_2_1(MatterBaseTest):
             for ep in active_eps:
                 asserts.assert_in(ep, avail_eps,
                                   f"ActiveEndpoint {ep} is not in AvailableEndpoints")
-        else:
-            self.mark_current_step_skipped()
 
         self.step(4, "TH writes each endpoint list attribute - expect UNSUPPORTED_WRITE")
-        wrote_any = False
-        for attribute in (attributes.AvailableEndpoints, attributes.ActiveEndpoints):
-            if not await self.attribute_guard(endpoint=endpoint, attribute=attribute):
-                continue
+        # Availability is already established by steps 2 and 3. attribute_guard is not used here:
+        # it marks the current step skipped on a miss, which would record this step as skipped even
+        # when the other attribute is present and its write was checked.
+        writable = [attr for attr, present in ((attributes.AvailableEndpoints, avail_eps is not None),
+                                               (attributes.ActiveEndpoints, active_eps is not None))
+                    if present]
+        if not writable:
+            self.mark_current_step_skipped()
+        for attribute in writable:
             status = await self.write_single_attribute(
                 attribute_value=attribute([]),
                 endpoint_id=endpoint,
                 expect_success=False)
             asserts.assert_equal(status, Status.UnsupportedWrite,
                                  f"Write to {attribute.__name__} should return UNSUPPORTED_WRITE")
-            wrote_any = True
-        if not wrote_any:
-            self.mark_current_step_skipped()
 
         self.step(5, "TH verifies ElectricalCircuitNodes presence matches the CIRC feature")
         feature_map = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -59,13 +59,13 @@ class TC_PWRTL_2_1(MatterBaseTest):
     async def test_TC_PWRTL_2_1(self):
         """[TC-PWRTL-2.1] Attributes with DUT as Server
 
-        Verify FeatureMap (including the Matter 1.7 CIRC bit 4 with reserved-bit
-        discipline), AttributeList composition based on topology features,
-        AvailableEndpoints and ActiveEndpoints reads, the subset invariant
-        (ActiveEndpoints subset of AvailableEndpoints), read-only access on
-        both endpoint list attributes, and Non-volatile persistence of
-        ActiveEndpoints across reboot (manual-mode only; CI skips the reboot
-        steps via the is_pics_sdk_ci_only dispatch).
+        Verifies the endpoint list attributes: the max-20 constraint on each,
+        ActiveEndpoints being a subset of AvailableEndpoints, and that both are
+        read-only. Also verifies ElectricalCircuitNodes presence against the
+        CIRC feature.
+
+        Feature-choice conformance and AttributeList composition are not checked
+        here; TC_IDM_10_2 evaluates both from the data model.
         """
         endpoint = self.get_endpoint()
         cluster = Clusters.PowerTopology
@@ -74,134 +74,75 @@ class TC_PWRTL_2_1(MatterBaseTest):
 
         self.step(1, "Commissioning, already done", is_commissioning=True)
 
-        self.step(2, "TH reads FeatureMap from DUT")
-        feature_map = await self.read_single_attribute_check_success(
-            endpoint=endpoint,
-            cluster=cluster,
-            attribute=attributes.FeatureMap
-        )
-        log.info("FeatureMap: 0x%08X", feature_map)
-
-        self.step(3, "TH validates O.a conformance (exactly one of NODE/TREE/SET); DYPF implies SET")
-        has_node = bool(feature_map & features.kNodeTopology)
-        has_tree = bool(feature_map & features.kTreeTopology)
-        has_set = bool(feature_map & features.kSetTopology)
-        topology_count = sum([has_node, has_tree, has_set])
-        asserts.assert_equal(topology_count, 1,
-                             f"Exactly one of NODE/TREE/SET must be set, got {topology_count}")
-        has_dypf = bool(feature_map & features.kDynamicPowerFlow)
-        if has_dypf:
-            asserts.assert_true(has_set,
-                                "DynamicPowerFlow (DYPF) requires SetTopology")
-        log.info("Topology: NODE=%s, TREE=%s, SET=%s, DYPF=%s", has_node, has_tree, has_set, has_dypf)
-
-        self.step(4, "TH validates CIRC bit and reserved bits 5..31")
-        has_circ = bool(feature_map & features.kElectricalCircuit)
-        log.info("ElectricalCircuit (CIRC): %s", has_circ)
-        KNOWN_BITS_MASK = (features.kNodeTopology | features.kTreeTopology |
-                           features.kSetTopology | features.kDynamicPowerFlow |
-                           features.kElectricalCircuit)
-        reserved_bits = feature_map & ~KNOWN_BITS_MASK
-        asserts.assert_equal(reserved_bits, 0,
-                             f"Reserved bits set in FeatureMap: 0x{reserved_bits:08X}")
-
-        self.step(5, "TH reads AttributeList; verifies AvailableEndpoints present iff SET, ActiveEndpoints present iff DYPF")
-        attribute_list = await self.read_single_attribute_check_success(
-            endpoint=endpoint,
-            cluster=cluster,
-            attribute=attributes.AttributeList
-        )
-        log.info("AttributeList: %s", attribute_list)
-        avail_ep_id = attributes.AvailableEndpoints.attribute_id
-        active_ep_id = attributes.ActiveEndpoints.attribute_id
-
-        # AvailableEndpoints (0x0000): conformance "SET" — mandatory iff SET feature,
-        # disallowed otherwise (bare-symbol form, not bracketed).
-        if has_set:
-            asserts.assert_in(avail_ep_id, attribute_list,
-                              "AvailableEndpoints must be in AttributeList when SET feature is set")
-        else:
-            asserts.assert_not_in(avail_ep_id, attribute_list,
-                                  "AvailableEndpoints must NOT be in AttributeList when SET feature is not set")
-
-        # ActiveEndpoints (0x0001): conformance "DYPF" — mandatory iff DYPF feature,
-        # disallowed otherwise. DYPF itself requires SET ([SET]), so DYPF implies
-        # AvailableEndpoints is also present.
-        if has_dypf:
-            asserts.assert_in(active_ep_id, attribute_list,
-                              "ActiveEndpoints must be in AttributeList when DYPF feature is set")
-        else:
-            asserts.assert_not_in(active_ep_id, attribute_list,
-                                  "ActiveEndpoints must NOT be in AttributeList when DYPF feature is not set")
-
-        self.step(6, "TH reads AvailableEndpoints (if present in AttributeList)")
+        self.step(2, "TH reads AvailableEndpoints from DUT")
         avail_eps = None
-        if avail_ep_id in attribute_list:
+        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.AvailableEndpoints):
             avail_eps = await self.read_single_attribute_check_success(
                 endpoint=endpoint,
                 cluster=cluster,
                 attribute=attributes.AvailableEndpoints
             )
             log.info("AvailableEndpoints: %s", avail_eps)
+            asserts.assert_less_equal(len(avail_eps), 20,
+                                      "AvailableEndpoints exceeds its max 20 constraint")
         else:
-            log.info("AvailableEndpoints not in AttributeList (SET feature not set)")
             self.mark_current_step_skipped()
 
-        self.step(7, "TH reads ActiveEndpoints (if present in AttributeList)")
-        active_eps = None
-        if active_ep_id in attribute_list:
+        self.step(3, "TH reads ActiveEndpoints and verifies it is a subset of AvailableEndpoints")
+        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.ActiveEndpoints):
             active_eps = await self.read_single_attribute_check_success(
                 endpoint=endpoint,
                 cluster=cluster,
                 attribute=attributes.ActiveEndpoints
             )
             log.info("ActiveEndpoints: %s", active_eps)
-        else:
-            log.info("ActiveEndpoints not in AttributeList (DYPF feature not set)")
-            self.mark_current_step_skipped()
-
-        self.step(8, "TH verifies ActiveEndpoints is a subset of AvailableEndpoints")
-        if avail_eps is not None and active_eps is not None:
+            asserts.assert_less_equal(len(active_eps), 20,
+                                      "ActiveEndpoints exceeds its max 20 constraint")
+            # ActiveEndpoints SHALL be a subset of AvailableEndpoints (11.8.6.2). DYPF
+            # implies SET, so AvailableEndpoints is present whenever ActiveEndpoints is.
+            asserts.assert_is_not_none(avail_eps,
+                                       "ActiveEndpoints present without AvailableEndpoints")
             for ep in active_eps:
                 asserts.assert_in(ep, avail_eps,
-                                  f"ActiveEndpoint {ep} not in AvailableEndpoints")
-            log.info("ActiveEndpoints is a subset of AvailableEndpoints")
+                                  f"ActiveEndpoint {ep} is not in AvailableEndpoints")
         else:
-            log.info("Skipping subset check (endpoint attributes not present)")
             self.mark_current_step_skipped()
 
-        self.step(9, "TH attempts write to AvailableEndpoints - expect UNSUPPORTED_WRITE")
-        if avail_eps is not None:
+        self.step(4, "TH writes each endpoint list attribute - expect UNSUPPORTED_WRITE")
+        wrote_any = False
+        for attribute in (attributes.AvailableEndpoints, attributes.ActiveEndpoints):
+            if not await self.attribute_guard(endpoint=endpoint, attribute=attribute):
+                continue
             status = await self.write_single_attribute(
-                attribute_value=attributes.AvailableEndpoints([]),
+                attribute_value=attribute([]),
                 endpoint_id=endpoint,
                 expect_success=False)
             asserts.assert_equal(status, Status.UnsupportedWrite,
-                                 "Write to AvailableEndpoints should return UNSUPPORTED_WRITE")
-        else:
+                                 f"Write to {attribute.__name__} should return UNSUPPORTED_WRITE")
+            wrote_any = True
+        if not wrote_any:
             self.mark_current_step_skipped()
 
-        self.step(10, "Operator reboots DUT (skipped in CI)")
-        if self.is_pics_sdk_ci_only or active_eps is None:
-            # CI cannot drive an operator reboot, and there are no ActiveEndpoints
-            # to verify Non-volatile persistence against.
-            self.mark_current_step_skipped()
+        self.step(5, "TH verifies ElectricalCircuitNodes presence matches the CIRC feature")
+        feature_map = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=cluster,
+            attribute=attributes.FeatureMap
+        )
+        attribute_list = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=cluster,
+            attribute=attributes.AttributeList
+        )
+        log.info("FeatureMap: 0x%08X, AttributeList: %s", feature_map, attribute_list)
+        has_circ = bool(feature_map & features.kElectricalCircuit)
+        nodes_id = attributes.ElectricalCircuitNodes.attribute_id
+        if has_circ:
+            asserts.assert_in(nodes_id, attribute_list,
+                              "ElectricalCircuitNodes must be present when the CIRC feature is set")
         else:
-            self.wait_for_user_input(
-                prompt_msg="Reboot the DUT and wait for it to rejoin the fabric. Press Enter.")
-
-        self.step(11, "TH verifies ActiveEndpoints persists after reboot - Non-volatile (skipped in CI)")
-        if self.is_pics_sdk_ci_only or active_eps is None:
-            self.mark_current_step_skipped()
-        else:
-            active_eps_post = await self.read_single_attribute_check_success(
-                endpoint=endpoint,
-                cluster=cluster,
-                attribute=attributes.ActiveEndpoints
-            )
-            asserts.assert_equal(sorted(active_eps_post), sorted(active_eps),
-                                 "ActiveEndpoints changed after reboot - violates Non-volatile quality")
-            log.info("ActiveEndpoints persisted across reboot (Non-volatile verified)")
+            asserts.assert_not_in(nodes_id, attribute_list,
+                                  "ElectricalCircuitNodes must be absent when the CIRC feature is not set")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary

Brings `TC_PWRTL_2_1.py` back in line with the test plan, which has been trimmed in CHIP-Specifications/chip-test-plans#6166.

##### Problem

The script implements eleven steps. Three of them duplicate `TC_IDM_10_2`, which already evaluates feature-choice conformance and AttributeList composition from the data model, and the test plan has dropped those steps. Two more drive a DUT reboot, which a test plan is not meant to specify.

One of the removed assertions never worked:

```python
KNOWN_BITS_MASK = (features.kNodeTopology | ... | features.kElectricalCircuit)
reserved_bits = feature_map & ~KNOWN_BITS_MASK
asserts.assert_equal(reserved_bits, 0, ...)
```

`FeatureMap` is an `IntFlag`, so `~KNOWN_BITS_MASK` masks to the class's own bits rather than to 32 bits. With `feature_map = 0xFFFFFFFF` the expression evaluates to `0`, where `int()` arithmetic gives `0xFFFFFFE0`. The assertion could not fail for any input, so the reserved-bit discipline it advertised was never enforced.

##### Solution

- Removes the feature-choice, reserved-bits and AttributeList-composition steps, leaving what `TC_IDM_10_2` does not do: the `max 20` constraint on each endpoint list, and `ActiveEndpoints` being a subset of `AvailableEndpoints`.
- Removes the two reboot steps.
- Writes **both** endpoint list attributes when checking read-only access, not only `AvailableEndpoints`.
- Adds an `ElectricalCircuitNodes` presence check in both directions against the CIRC feature.

Net eleven steps to five, matching the plan one for one.

#### Related issues

Test plan side: CHIP-Specifications/chip-test-plans#6166.

#### Testing

- Ran against a locally built `chip-evse-app` on endpoint 1: passes, with zero steps skipped, so all five executed. That DUT has SET and DYPF set and CIRC clear, which exercises both endpoint list reads, the subset invariant, both write attempts, and the negative direction of the new CIRC check.
- `ruff check` clean.
