### PR TITLE
[Silabs] Remove Wi-Fi mUseQuickJoin skip-scan path

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -387,7 +387,7 @@ sl_status_t SetWifiConfigurations()
             .security = security,
             .encryption = SL_WIFI_DEFAULT_ENCRYPTION,
             .client_options = SL_WIFI_JOIN_WITH_SCAN,
-            .credential_id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID,
+            .credential_id = (security == SL_WIFI_OPEN) ? SL_NET_NO_CREDENTIAL_ID : SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID,
             .channel_bitmap = {
                 .channel_bitmap_2_4 = SL_WIFI_DEFAULT_CHANNEL_BITMAP
             },
@@ -662,7 +662,6 @@ sl_status_t WifiInterfaceImpl::JoinWifiNetwork(void)
     ChipLogError(DeviceLayer, "sl_net_up failed: 0x%" PRIx32, static_cast<uint32_t>(status));
 
     wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnecting).Clear(WifiInterface::WifiState::kStationConnected);
-    mUseQuickJoin = !(status == SL_STATUS_SI91X_NO_AP_FOUND);
     ScheduleConnectionAttempt();
 
     return status;
@@ -691,7 +690,6 @@ sl_status_t WifiInterfaceImpl::JoinCallback(sl_wifi_event_t event, char * result
         ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%" PRIx32, status);
         wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnected);
 
-        mInstance.mUseQuickJoin = !(status == SL_STATUS_SI91X_NO_AP_FOUND);
         mInstance.ScheduleConnectionAttempt();
     }
 
@@ -1082,9 +1080,9 @@ CHIP_ERROR WifiInterfaceImpl::ConnectToAccessPoint()
 {
     VerifyOrReturnError(IsWifiProvisioned(), CHIP_ERROR_INCORRECT_STATE);
 
-    ChipLogProgress(DeviceLayer, "%s to access point: %s", mUseQuickJoin ? "quick join" : "connect", wfx_rsi.credentials.ssid);
+    ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.credentials.ssid);
 
-    PostWifiPlatformEvent(mUseQuickJoin ? WifiPlatformEvent::kStationStartJoin : WifiPlatformEvent::kStationStartScan);
+    PostWifiPlatformEvent(WifiPlatformEvent::kStationStartScan);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -414,9 +414,6 @@ sl_status_t SetWifiConfigurations()
         chip::MutableByteSpan bssidSpan(profile.config.bssid.octet, kWiFiBSSIDLength);
         chip::ByteSpan inBssid(wfx_rsi.ap_bssid.data(), kWiFiBSSIDLength);
         TEMPORARY_RETURN_IGNORED chip::CopySpanToMutableSpan(inBssid, bssidSpan);
-        // Enabling quick-join since we have the channel and BSSID
-        // TODO: Uncomment this once the quick-join issue is fixed
-        // join_feature_bitmap |= SL_SI91X_JOIN_FEAT_QUICK_JOIN;
     }
 
     status = sl_wifi_set_join_configuration(SL_WIFI_CLIENT_INTERFACE, join_feature_bitmap);

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
@@ -154,8 +154,6 @@ private:
     void NotifySuccessfulConnection();
 
     bool mHasNotifiedWifiConnectivity = false;
-    bool mUseQuickJoin                = false;
-
     static WifiInterfaceImpl mInstance;
 };
 

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -295,7 +295,6 @@ public:
      *        connection attempt was successful or not.
      *
      *        The returned error code only indicates if the connection attempt was triggered or not.
-     *        On retry after failure, the implementation may use quick join (no scan) when channel/BSSID are known.
      *
      * @return CHIP_ERROR CHIP_NO_ERROR, the connection attempt was succesfully triggered
      *                    CHIP_ERROR_INCORRECT_STATE, the Wi-Fi station does not have any Wi-Fi credentials


### PR DESCRIPTION
### Summary
Removes the SiWx mUseQuickJoin reconnect path that skipped the scan and went
straight to join.

On reconnect after a join failure (when the AP was still considered known), ConnectToAccessPoint() posted kStationStartJoin instead of kStationStartScan via mUseQuickJoin.
That skip-scan path does not help: a direct join still causes the device to scan all networks, so the optimization is ineffective and adds extra state.
Quick join bitmap will help if there was no delay between the scan and join

### Related issues
NA

### Testing
Tested commissioning locally with the 917SoC