### PR TITLE
esp32: add a config option for groupcast feature (Auto-merged by plat…

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -174,9 +174,11 @@ menu "CHIP Core"
 
         config MAX_GROUP_KEYS_PER_FABRIC
             int "Maximum Number of Group Key Sets per Fabric"
-            default 3
+            default 4
             help
                 Specifies the maximum number of group key sets supported per fabric.
+                The default matches the core CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC
+                default (3 key sets + IPK)
 
         config CHIP_DEVICE_ENABLE_DYNAMIC_SERVER
             bool "Enable dynamic server"
@@ -205,6 +207,13 @@ menu "CHIP Core"
                 bool "Default alloc mode"
 
         endchoice # CHIP_MEM_ALLOC_MODE
+
+        config CHIP_ENABLE_GROUPCAST
+            bool "Enable groupcast support"
+            default y
+            help
+                Enables the groupcast feature, which internally enables auxiliary access
+                control feature.
 
     endmenu # "General Options"
 


### PR DESCRIPTION
…form-bot)

* esp32: add a config option for groupcast feature

* esp32: raise default group key sets per fabric to 4 for groupcast

The Groupcast test plan update (#43691) raised the TC_RR_1_1 certification floor for MaxGroupKeysPerFabric to 4, and the core default CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC is already (3 + 1) key sets including the IPK. The ESP32 Kconfig default of 3 silently lowered this below both, leaving devices non-certifiable unless overridden. Align the default with the core value.

### Summary
- Cherry-picking #73712

### Testing
- clean cherry-pick