### PR TITLE
pr_checker_bot: include PR number in auto-merge commit title

### DIFF
--- a/scripts/tools/pr_checker_bot.py
+++ b/scripts/tools/pr_checker_bot.py
@@ -739,7 +739,7 @@ def action_merge_platform(context: PRContext) -> None:
         log.info("Merging PR #%d", context.pr.number)
         context.pr.merge(
             merge_method="squash",
-            commit_title=f"{context.pr.title} (Auto-merged by platform-bot)",
+            commit_title=f"{context.pr.title} (Auto-merged by platform-bot) (#{context.pr.number})",
             sha=context.pr.head.sha,
         )
         log.info("Posting merge explanation comment to PR #%d", context.pr.number)

--- a/scripts/tools/tests/test_pr_checker_bot.py
+++ b/scripts/tools/tests/test_pr_checker_bot.py
@@ -410,7 +410,7 @@ esp32:
 
         mock_pr.merge.assert_called_once_with(
             merge_method="squash",
-            commit_title="Test PR (Auto-merged by platform-bot)",
+            commit_title=f"Test PR (Auto-merged by platform-bot) (#{mock_pr.number})",
             sha="dummy_sha",
         )
 


### PR DESCRIPTION
### Summary

GitHub only appends (#N) to squash commit titles when the default title is used. The bot passes a custom title, so auto-merged commits landed without a PR number reference. Include it explicitly.

### Testing
- ran unit tests locally all pass
```
scripts/tests
python3 -m unittest test_pr_checker_bot -v
```