### PR TITLE
Update secure session peer address only after the message authenticates

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -959,13 +959,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & partialPa
         return;
     }
 
-    Transport::SecureSession * secureSession  = session.Value()->AsSecureSession();
-    Transport::PeerAddress mutablePeerAddress = peerAddress;
-    CorrectPeerAddressInterfaceID(mutablePeerAddress);
-    if (secureSession->GetPeerAddress() != mutablePeerAddress)
-    {
-        secureSession->SetPeerAddress(mutablePeerAddress);
-    }
+    Transport::SecureSession * secureSession = session.Value()->AsSecureSession();
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     // Associate the secure session with the connection, if not done already.
@@ -1055,6 +1049,14 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & partialPa
     }
 
     secureSession->MarkActiveRx();
+
+    // Only update the cached peer address once the message is known to be authentic.
+    Transport::PeerAddress mutablePeerAddress = peerAddress;
+    CorrectPeerAddressInterfaceID(mutablePeerAddress);
+    if (secureSession->GetPeerAddress() != mutablePeerAddress)
+    {
+        secureSession->SetPeerAddress(mutablePeerAddress);
+    }
 
     if (isDuplicate == SessionMessageDelegate::DuplicateMessage::Yes && !payloadHeader.NeedsAck())
     {

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1050,14 +1050,6 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & partialPa
 
     secureSession->MarkActiveRx();
 
-    // Only update the cached peer address once the message is known to be authentic.
-    Transport::PeerAddress mutablePeerAddress = peerAddress;
-    CorrectPeerAddressInterfaceID(mutablePeerAddress);
-    if (secureSession->GetPeerAddress() != mutablePeerAddress)
-    {
-        secureSession->SetPeerAddress(mutablePeerAddress);
-    }
-
     if (isDuplicate == SessionMessageDelegate::DuplicateMessage::Yes && !payloadHeader.NeedsAck())
     {
         // If it's a duplicate message, but doesn't require an ack, let's drop it right here to save CPU
@@ -1068,6 +1060,15 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & partialPa
     if (isDuplicate == SessionMessageDelegate::DuplicateMessage::No)
     {
         secureSession->GetSessionMessageCounter().GetPeerMessageCounter().CommitEncryptedUnicast(packetHeader.GetMessageCounter());
+
+        // Only update the cached peer address for a message that is both authentic
+        // and not a replay of one already received.
+        Transport::PeerAddress mutablePeerAddress = peerAddress;
+        CorrectPeerAddressInterfaceID(mutablePeerAddress);
+        if (secureSession->GetPeerAddress() != mutablePeerAddress)
+        {
+            secureSession->SetPeerAddress(mutablePeerAddress);
+        }
     }
 
     if (mCB != nullptr)

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -832,9 +832,9 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessageChainedBufferFailure)
 }
 #endif // !CHIP_CONFIG_SECURITY_TEST_MODE
 
-// An inbound message that fails to authenticate must not change any state on the
+// A message that fails to decrypt must not update the cached peer address of the
 // session it names.
-TEST_F(TestSessionManagerDispatch, TestUnauthenticMessageDoesNotRebindPeerAddress)
+TEST_F(TestSessionManagerDispatch, TestUndecryptableMessageDoesNotRebindPeerAddress)
 {
     SessionManager sessionManager;
     TestSessionManagerInit(mContext, sessionManager, *mResources);
@@ -879,17 +879,18 @@ TEST_F(TestSessionManagerDispatch, TestUnauthenticMessageDoesNotRebindPeerAddres
 
 // Injects the two halves of a PASE session pair so that a message prepared on
 // `initiator` decrypts on `responder`.
-void InjectSessionPair(SessionManager & sessionManager, SessionHolder & initiator, SessionHolder & responder,
-                       const PeerAddress & peerAddress)
+CHIP_ERROR InjectSessionPair(SessionManager & sessionManager, SessionHolder & initiator, SessionHolder & responder,
+                             const PeerAddress & peerAddress)
 {
-    ASSERT_SUCCESS(sessionManager.InjectPaseSessionWithTestKey(initiator, 2, 0x0000000000000002ULL, 1, kFabricIndex, peerAddress,
-                                                               CryptoContext::SessionRole::kInitiator));
-    ASSERT_SUCCESS(sessionManager.InjectPaseSessionWithTestKey(responder, 1, 0x0000000000000001ULL, 2, kFabricIndex, peerAddress,
-                                                               CryptoContext::SessionRole::kResponder));
+    ReturnErrorOnFailure(sessionManager.InjectPaseSessionWithTestKey(initiator, 2, 0x0000000000000002ULL, 1, kFabricIndex,
+                                                                     peerAddress, CryptoContext::SessionRole::kInitiator));
+    return sessionManager.InjectPaseSessionWithTestKey(responder, 1, 0x0000000000000001ULL, 2, kFabricIndex, peerAddress,
+                                                       CryptoContext::SessionRole::kResponder);
 }
 
 // Prepares an encrypted message on `session` carrying a fixed payload.
-void PrepareTestMessage(SessionManager & sessionManager, const SessionHandle & session, EncryptedPacketBufferHandle & prepared)
+CHIP_ERROR PrepareTestMessage(SessionManager & sessionManager, const SessionHandle & session,
+                              EncryptedPacketBufferHandle & prepared)
 {
     PayloadHeader payloadHeader;
     payloadHeader.SetExchangeID(0);
@@ -898,8 +899,8 @@ void PrepareTestMessage(SessionManager & sessionManager, const SessionHandle & s
 
     const uint8_t kPayload[]           = { 0x11, 0x22, 0x33, 0x44 };
     System::PacketBufferHandle payload = MessagePacketBuffer::NewWithData(kPayload, sizeof(kPayload));
-    ASSERT_FALSE(payload.IsNull());
-    ASSERT_SUCCESS(sessionManager.PrepareMessage(session, payloadHeader, std::move(payload), prepared));
+    VerifyOrReturnError(!payload.IsNull(), CHIP_ERROR_NO_MEMORY);
+    return sessionManager.PrepareMessage(session, payloadHeader, std::move(payload), prepared);
 }
 
 // A replay of an already accepted message is authentic, so it must not be able to
@@ -914,11 +915,12 @@ TEST_F(TestSessionManagerDispatch, TestReplayedMessageDoesNotRebindPeerAddress)
 
     SessionHolder initiator;
     SessionHolder responder;
-    InjectSessionPair(sessionManager, initiator, responder, establishedAddress);
+    ASSERT_SUCCESS(InjectSessionPair(sessionManager, initiator, responder, establishedAddress));
     SecureSession * receiver = responder.Get().Value()->AsSecureSession();
 
     EncryptedPacketBufferHandle prepared;
-    PrepareTestMessage(sessionManager, initiator.Get().Value(), prepared);
+    ASSERT_SUCCESS(PrepareTestMessage(sessionManager, initiator.Get().Value(), prepared));
+    ASSERT_FALSE(prepared.IsNull());
 
     EncryptedPacketBufferHandle firstDelivery = prepared.CloneData();
     sessionManager.OnMessageReceived(establishedAddress, firstDelivery.CastToWritable());
@@ -944,11 +946,12 @@ TEST_F(TestSessionManagerDispatch, TestAcceptedMessageFromNewAddressRebindsPeerA
 
     SessionHolder initiator;
     SessionHolder responder;
-    InjectSessionPair(sessionManager, initiator, responder, establishedAddress);
+    ASSERT_SUCCESS(InjectSessionPair(sessionManager, initiator, responder, establishedAddress));
     SecureSession * receiver = responder.Get().Value()->AsSecureSession();
 
     EncryptedPacketBufferHandle prepared;
-    PrepareTestMessage(sessionManager, initiator.Get().Value(), prepared);
+    ASSERT_SUCCESS(PrepareTestMessage(sessionManager, initiator.Get().Value(), prepared));
+    ASSERT_FALSE(prepared.IsNull());
 
     sessionManager.OnMessageReceived(newAddress, prepared.CastToWritable());
 

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -877,4 +877,86 @@ TEST_F(TestSessionManagerDispatch, TestUnauthenticMessageDoesNotRebindPeerAddres
     sessionManager.Shutdown();
 }
 
+
+
+// Injects the two halves of a PASE session pair so that a message prepared on
+// `initiator` decrypts on `responder`.
+void InjectSessionPair(SessionManager & sessionManager, SessionHolder & initiator, SessionHolder & responder,
+                       const PeerAddress & peerAddress)
+{
+    ASSERT_SUCCESS(sessionManager.InjectPaseSessionWithTestKey(initiator, 2, 0x0000000000000002ULL, 1, kFabricIndex, peerAddress,
+                                                               CryptoContext::SessionRole::kInitiator));
+    ASSERT_SUCCESS(sessionManager.InjectPaseSessionWithTestKey(responder, 1, 0x0000000000000001ULL, 2, kFabricIndex, peerAddress,
+                                                               CryptoContext::SessionRole::kResponder));
+}
+
+// Prepares an encrypted message on `session` carrying a fixed payload.
+void PrepareTestMessage(SessionManager & sessionManager, const SessionHandle & session, EncryptedPacketBufferHandle & prepared)
+{
+    PayloadHeader payloadHeader;
+    payloadHeader.SetExchangeID(0);
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
+    payloadHeader.SetInitiator(true);
+
+    const uint8_t kPayload[]           = { 0x11, 0x22, 0x33, 0x44 };
+    System::PacketBufferHandle payload = MessagePacketBuffer::NewWithData(kPayload, sizeof(kPayload));
+    ASSERT_FALSE(payload.IsNull());
+    ASSERT_SUCCESS(sessionManager.PrepareMessage(session, payloadHeader, std::move(payload), prepared));
+}
+
+// A replay of an already accepted message is authentic, so it must not be able to
+// update the session's cached peer address.
+TEST_F(TestSessionManagerDispatch, TestReplayedMessageDoesNotRebindPeerAddress)
+{
+    SessionManager sessionManager;
+    TestSessionManagerInit(mContext, sessionManager, *mResources);
+
+    const PeerAddress establishedAddress = AddressFromString("fe80::1");
+    const PeerAddress replayAddress      = AddressFromString("fe80::2");
+
+    SessionHolder initiator;
+    SessionHolder responder;
+    InjectSessionPair(sessionManager, initiator, responder, establishedAddress);
+    SecureSession * receiver = responder.Get().Value()->AsSecureSession();
+
+    EncryptedPacketBufferHandle prepared;
+    PrepareTestMessage(sessionManager, initiator.Get().Value(), prepared);
+
+    EncryptedPacketBufferHandle firstDelivery = prepared.CloneData();
+    sessionManager.OnMessageReceived(establishedAddress, firstDelivery.CastToWritable());
+    ASSERT_EQ(receiver->GetPeerAddress(), establishedAddress);
+
+    EncryptedPacketBufferHandle replay = prepared.CloneData();
+    sessionManager.OnMessageReceived(replayAddress, replay.CastToWritable());
+
+    EXPECT_EQ(receiver->GetPeerAddress(), establishedAddress);
+
+    sessionManager.Shutdown();
+}
+
+// A peer that moves to a new address is still tracked: the first message that is
+// authentic and not a replay updates the cached address.
+TEST_F(TestSessionManagerDispatch, TestAcceptedMessageFromNewAddressRebindsPeerAddress)
+{
+    SessionManager sessionManager;
+    TestSessionManagerInit(mContext, sessionManager, *mResources);
+
+    const PeerAddress establishedAddress = AddressFromString("fe80::1");
+    const PeerAddress newAddress         = AddressFromString("fe80::2");
+
+    SessionHolder initiator;
+    SessionHolder responder;
+    InjectSessionPair(sessionManager, initiator, responder, establishedAddress);
+    SecureSession * receiver = responder.Get().Value()->AsSecureSession();
+
+    EncryptedPacketBufferHandle prepared;
+    PrepareTestMessage(sessionManager, initiator.Get().Value(), prepared);
+
+    sessionManager.OnMessageReceived(newAddress, prepared.CastToWritable());
+
+    EXPECT_EQ(receiver->GetPeerAddress(), newAddress);
+
+    sessionManager.Shutdown();
+}
+
 } // namespace

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -38,6 +38,7 @@
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <protocols/interaction_model/Constants.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <transport/SessionManager.h>
@@ -830,5 +831,50 @@ TEST_F(TestSessionManagerDispatch, TestGroupPrepareMessageChainedBufferFailure)
     sessionManager.Shutdown();
 }
 #endif // !CHIP_CONFIG_SECURITY_TEST_MODE
+
+// An inbound message that fails to authenticate must not change any state on the
+// session it names.
+TEST_F(TestSessionManagerDispatch, TestUnauthenticMessageDoesNotRebindPeerAddress)
+{
+    SessionManager sessionManager;
+    TestSessionManagerInit(mContext, sessionManager, *mResources);
+
+    constexpr uint16_t kLocalSessionId   = 0x1234;
+    constexpr NodeId kSessionPeerNodeId  = 0x0000000000000002ULL;
+    const PeerAddress establishedAddress = AddressFromString("fe80::1");
+    const PeerAddress spoofedAddress     = AddressFromString("fe80::2");
+
+    SessionHolder sessionHolder;
+    ASSERT_SUCCESS(sessionManager.InjectPaseSessionWithTestKey(sessionHolder, kLocalSessionId, kSessionPeerNodeId, kLocalSessionId,
+                                                               kFabricIndex, establishedAddress,
+                                                               CryptoContext::SessionRole::kResponder));
+
+    SecureSession * secureSession = sessionHolder.Get().Value()->AsSecureSession();
+    ASSERT_EQ(secureSession->GetPeerAddress(), establishedAddress);
+
+    PayloadHeader payloadHeader;
+    payloadHeader.SetExchangeID(0);
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
+
+    const uint8_t kPayload[]           = { 0x11, 0x22, 0x33, 0x44 };
+    System::PacketBufferHandle payload = MessagePacketBuffer::NewWithData(kPayload, sizeof(kPayload));
+    ASSERT_FALSE(payload.IsNull());
+
+    EncryptedPacketBufferHandle preparedMessage;
+    ASSERT_SUCCESS(sessionManager.PrepareMessage(sessionHolder.Get().Value(), payloadHeader, std::move(payload), preparedMessage));
+
+    // Corrupt the trailing integrity check so the message parses but cannot be
+    // authenticated.
+    System::PacketBufferHandle msg = preparedMessage.CastToWritable();
+    ASSERT_FALSE(msg.IsNull());
+    ASSERT_GT(msg->DataLength(), 0u);
+    msg->Start()[msg->DataLength() - 1] = static_cast<uint8_t>(msg->Start()[msg->DataLength() - 1] ^ 0xff);
+
+    sessionManager.OnMessageReceived(spoofedAddress, std::move(msg));
+
+    EXPECT_EQ(secureSession->GetPeerAddress(), establishedAddress);
+
+    sessionManager.Shutdown();
+}
 
 } // namespace

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -877,8 +877,6 @@ TEST_F(TestSessionManagerDispatch, TestUnauthenticMessageDoesNotRebindPeerAddres
     sessionManager.Shutdown();
 }
 
-
-
 // Injects the two halves of a PASE session pair so that a message prepared on
 // `initiator` decrypts on `responder`.
 void InjectSessionPair(SessionManager & sessionManager, SessionHolder & initiator, SessionHolder & responder,


### PR DESCRIPTION
#### Summary

##### Problem

`SessionManager::SecureUnicastMessageDispatch` updates a secure session's cached peer address before the message that triggered the update has been authenticated:

```
  lookup session by header session id   (cleartext field)
  update cached peer address            <-- committed here
  ...
  SecureMessageCodec::Decrypt           <-- only authentication in the function
  VerifyEncryptedUnicast (counter)
```

-   The session id is a plain header field, so any message naming a live session reaches the update, and the message is only **discarded afterwards** if it fails to decrypt.
-   The cached address is the send destination (`SessionManager.cpp` `destination = &secure->GetPeerAddress()`), so an unauthenticated message changes where the session sends its subsequent messages, including subscription reports and MRP acks.
-   `AllowsMRP()` and `AllowsLargePayload()` derive from the address transport type, so the same update can change MRP and large-payload behaviour on an established session.

This is a regression from `a8cfbac0773` ("TCP connection setup/management and CASESession association", 2024-03-26), which moved the block above the authentication as a side effect of the TCP work. Before that commit it sat after `Decrypt`, `VerifyEncryptedUnicast` and `MarkActiveRx`.

##### Solution

-   Move the `CorrectPeerAddressInterfaceID` / `SetPeerAddress` block below the decryption and message counter checks, into the non-duplicate branch after `CommitEncryptedUnicast`.
-   The duplicate branch is excluded because `VerifyEncryptedUnicast` reports an already-seen counter as `CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED`, which the dispatch converts to success so the duplicate can still be acked; updating the address there would let a resent copy of an accepted message change the destination.
-   A peer that changes address is still tracked: the first message it sends from the new address carries a fresh message counter and takes the non-duplicate path.
-   `Decrypt` does not read the cached peer address and `mutablePeerAddress` has no other use in the function, so a message that is authentic and not a replay updates the address exactly as before.

##### Caveats

-   A duplicate that arrives from a genuinely changed address no longer updates the cached address; the peer's next message with a fresh counter does. This affects only a peer that changes address and then retransmits a message already received, rather than sending a new one.
-   The `SetTCPConnection` association a few lines below, and the equivalent update on the unauthenticated session path in `UnauthenticatedMessageDispatch`, have the same shape and are **not** changed here. They are left for separate changes so the TCP association behaviour `a8cfbac0773` introduced can be considered on its own.

#### Testing

-   Added three tests in `src/transport/tests/TestSessionManagerDispatch.cpp`, each failing before the corresponding change and passing after it:
    -   `TestUndecryptableMessageDoesNotRebindPeerAddress`: a well-formed message with a corrupted integrity check, delivered from a different address, leaves the cached address unchanged. It parses and is rejected by `SecureMessageCodec::Decrypt`, so it constrains the update to sit below authentication rather than merely below header decoding.
    -   `TestReplayedMessageDoesNotRebindPeerAddress`: a copy of an already accepted message, delivered from a different address, leaves the cached address unchanged.
    -   `TestAcceptedMessageFromNewAddressRebindsPeerAddress`: an accepted message from a new address does update the cached address, so the change does not stop a peer from being tracked across an address change.
-   No regressions in `TestSessionManagerDispatch`, `TestSessionManager`, `TestSecureSession`, `TestSecureSessionTable`, `TestTCPConnection`, `TestPeerConnections`, `TestSessionRelease`, `TestCASESession`, `TestPASESession`, `TestExchangeMgr` and `TestReliableMessageProtocol` (built with `linux-x64-tests-asan-clang`).

