### PR TITLE
humidistat: tie MistType lifecycle to SystemState per spec

### DIFF
--- a/src/app/clusters/humidistat-server/HumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.cpp
@@ -103,6 +103,25 @@ Humidistat::SystemStateEnum DefaultSystemStateForMode(Humidistat::ModeEnum mode)
     }
 }
 
+void ApplyDefaultMistTypeFromFeatures(BitFlags<Humidistat::Feature> features,
+                                      DataModel::Nullable<chip::BitMask<MistTypeBitmap>> & mistType)
+{
+    if (!mistType.IsNull() && mistType.Value().HasAny())
+    {
+        return;
+    }
+
+    mistType = DataModel::NullNullable;
+    if (features.Has(Feature::kColdMist))
+    {
+        mistType.SetNonNull(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold));
+    }
+    else if (features.Has(Feature::kWarmMist))
+    {
+        mistType.SetNonNull(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistWarm));
+    }
+}
+
 CHIP_ERROR EncodeSupportedModes(BitFlags<Humidistat::Feature> features, const AttributeValueEncoder::ListEncodeHelper & encoder)
 {
     if (features.Has(Feature::kHumidifier))
@@ -144,18 +163,13 @@ HumidistatCluster::HumidistatCluster(EndpointId endpointId, BitFlags<Humidistat:
 {
     VerifyOrDie(IsFeatureConfigurationValid(mFeatures));
 
-    if ((mMode == ModeEnum::kHumidifier) && (mMistType.IsNull() || !mMistType.Value().HasAny()))
+    if (mSystemState == SystemStateEnum::kHumidifying)
     {
-        ChipLogDetail(Zcl, "Humidistat: Startup MistType null/empty in Humidifier mode, applying feature default");
-        mMistType.SetNonNull();
-        if (mFeatures.Has(Feature::kColdMist))
-        {
-            mMistType.Value().Set(MistTypeBitmap::kMistCold);
-        }
-        else if (mFeatures.Has(Feature::kWarmMist))
-        {
-            mMistType.Value().Set(MistTypeBitmap::kMistWarm);
-        }
+        ApplyDefaultMistTypeFromFeatures(mFeatures, mMistType);
+    }
+    else
+    {
+        mMistType = DataModel::NullNullable;
     }
 
     // Spec constraints on Quality F (fixed) setpoint attributes.
@@ -164,7 +178,7 @@ HumidistatCluster::HumidistatCluster(EndpointId endpointId, BitFlags<Humidistat:
     VerifyOrDie(config.step >= 1 && config.step <= static_cast<chip::Percent>(config.maxSetpoint - config.minSetpoint));
     VerifyOrDie((config.maxSetpoint - config.minSetpoint) % config.step == 0);
     VerifyOrDie(IsMistTypeSupportable(mMistType));
-    VerifyOrDie(IsMistTypeConsistentWithMode(mMode, mMistType));
+    VerifyOrDie(IsMistTypeConsistentWithSystemState(mSystemState, mMistType));
 
     // Snap initial setpoints to the valid step grid.
     mUserSetpoint   = SnapToNearestStep(mUserSetpoint);
@@ -252,18 +266,15 @@ void HumidistatCluster::LoadPersistentAttributes()
         {
             loadedMistType.Value().Clear(MistTypeBitmap::kMistWarm);
         }
-        // Spec: MistType SHALL be zero when Mode is not Humidifier.
-        if (mMode != ModeEnum::kHumidifier)
+        // Spec: MistType SHALL be null when SystemState is not Humidifying.
+        if (mSystemState != SystemStateEnum::kHumidifying)
         {
-            if (!loadedMistType.IsNull())
-            {
-                loadedMistType.Value().ClearAll();
-            }
+            loadedMistType = DataModel::NullNullable;
         }
         else if (loadedMistType.IsNull() || !loadedMistType.Value().HasAny())
         {
-            ChipLogDetail(Zcl, "Humidistat: Loaded null/empty MistType in Humidifier mode, using startup default");
-            loadedMistType = mMistType;
+            ChipLogDetail(Zcl, "Humidistat: Loaded null/empty MistType in Humidifying state, using feature default");
+            ApplyDefaultMistTypeFromFeatures(mFeatures, loadedMistType);
         }
         mMistType = loadedMistType;
     }
@@ -356,20 +367,15 @@ bool HumidistatCluster::IsSystemStateSupported(Humidistat::SystemStateEnum syste
     }
 }
 
-bool HumidistatCluster::IsMistTypeConsistentWithMode(Humidistat::ModeEnum mode,
-                                                     DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const
+bool HumidistatCluster::IsMistTypeConsistentWithSystemState(
+    Humidistat::SystemStateEnum systemState, DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const
 {
-    if (mistType.IsNull())
+    if (systemState == SystemStateEnum::kHumidifying)
     {
-        return true;
+        return !mistType.IsNull() && mistType.Value().HasAny();
     }
 
-    if (mode == ModeEnum::kHumidifier)
-    {
-        return mistType.Value().HasAny();
-    }
-
-    return !mistType.Value().HasAny();
+    return mistType.IsNull();
 }
 
 bool HumidistatCluster::ShouldTargetSetpointMatchUserSetpoint() const
@@ -462,9 +468,6 @@ CHIP_ERROR HumidistatCluster::SetMode(Humidistat::ModeEnum mode)
 {
     VerifyOrReturnError(IsModeSupported(mode), CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
-    const bool shouldClearMistType =
-        mFeatures.Has(Feature::kHumidifier) && (mode != ModeEnum::kHumidifier) && !mMistType.IsNull() && mMistType.Value().HasAny();
-
     if (SetAttributeValue(mMode, mode, Mode::Id))
     {
         if (mContext != nullptr)
@@ -480,10 +483,7 @@ CHIP_ERROR HumidistatCluster::SetMode(Humidistat::ModeEnum mode)
         }
     }
 
-    VerifyOrReturnValue(shouldClearMistType, CHIP_NO_ERROR);
-
-    // Spec: "If the value of Mode is not set to Humidifier, all bits of MistType SHALL be set to zero."
-    return SetMistType(chip::BitMask<MistTypeBitmap>{});
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR HumidistatCluster::SetSystemState(Humidistat::SystemStateEnum systemState)
@@ -501,6 +501,19 @@ CHIP_ERROR HumidistatCluster::SetSystemState(Humidistat::SystemStateEnum systemS
     if (mDelegate != nullptr)
     {
         mDelegate->OnSystemStateChanged(mSystemState);
+    }
+
+    if (mFeatures.Has(Feature::kHumidifier) && (mSystemState != SystemStateEnum::kHumidifying))
+    {
+        return SetMistType(DataModel::NullNullable);
+    }
+
+    if (mFeatures.Has(Feature::kHumidifier) && (mSystemState == SystemStateEnum::kHumidifying) &&
+        (mMistType.IsNull() || !mMistType.Value().HasAny()))
+    {
+        DataModel::Nullable<chip::BitMask<MistTypeBitmap>> defaultMistType = DataModel::NullNullable;
+        ApplyDefaultMistTypeFromFeatures(mFeatures, defaultMistType);
+        return SetMistType(defaultMistType);
     }
 
     return CHIP_NO_ERROR;
@@ -558,7 +571,7 @@ CHIP_ERROR HumidistatCluster::SetUserSetpoint(chip::Percent userSetpoint)
 CHIP_ERROR HumidistatCluster::SetMistType(DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType)
 {
     VerifyOrReturnError(mFeatures.Has(Feature::kHumidifier), CHIP_IM_GLOBAL_STATUS(ConstraintError));
-    VerifyOrReturnError(IsMistTypeConsistentWithMode(mMode, mistType), CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    VerifyOrReturnError(IsMistTypeConsistentWithSystemState(mSystemState, mistType), CHIP_IM_GLOBAL_STATUS(ConstraintError));
     VerifyOrReturnError(IsMistTypeSupportable(mistType), CHIP_IM_GLOBAL_STATUS(InvalidInState));
 
     if (mistType.IsNull())
@@ -888,17 +901,15 @@ DataModel::ActionReturnStatus HumidistatCluster::HandleSetSettings(chip::TLV::TL
     Commands::SetSettings::DecodableType commandData;
     ReturnErrorOnFailure(commandData.Decode(input_arguments));
 
-    ModeEnum effectiveMode = mMode;
     if (commandData.mode.HasValue())
     {
         VerifyOrReturnError(IsModeSupported(commandData.mode.Value()), CHIP_IM_GLOBAL_STATUS(ConstraintError));
-        effectiveMode = commandData.mode.Value();
     }
 
-    // Spec: "If the value of Mode is not set to Humidifier, all bits of MistType SHALL be set to zero."
+    // Spec: MistType SHALL be null when SystemState is not Humidifying.
     if (commandData.mistType.HasValue() && mFeatures.Has(Feature::kHumidifier))
     {
-        VerifyOrReturnError(IsMistTypeConsistentWithMode(effectiveMode, commandData.mistType.Value()),
+        VerifyOrReturnError(IsMistTypeConsistentWithSystemState(mSystemState, commandData.mistType.Value()),
                             CHIP_IM_GLOBAL_STATUS(ConstraintError));
         // Spec: unsupported bits SHALL result in INVALID_IN_STATE.
         VerifyOrReturnError(IsMistTypeSupportable(commandData.mistType.Value()), CHIP_IM_GLOBAL_STATUS(InvalidInState));

--- a/src/app/clusters/humidistat-server/HumidistatCluster.h
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.h
@@ -123,7 +123,7 @@ public:
         chip::Percent maxSetpoint               = 100;
         chip::Percent step                      = 1;
         chip::Percent targetSetpoint            = 50;
-        DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType{ chip::BitMask<Humidistat::MistTypeBitmap>{ 0 } };
+        DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType = DataModel::NullNullable;
         bool continuous = false;
         bool sleep      = false;
         bool optimal    = false;
@@ -225,8 +225,8 @@ private:
 
     bool IsModeSupported(Humidistat::ModeEnum mode) const;
     bool IsSystemStateSupported(Humidistat::SystemStateEnum systemState) const;
-    bool IsMistTypeConsistentWithMode(Humidistat::ModeEnum mode,
-                                      DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const;
+    bool IsMistTypeConsistentWithSystemState(Humidistat::SystemStateEnum systemState,
+                                             DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const;
     bool ShouldTargetSetpointMatchUserSetpoint() const;
     void SyncTargetSetpointToUserSetpoint();
     bool IsMistTypeSupportable(DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const;

--- a/src/app/clusters/humidistat-server/HumidistatCluster.h
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.h
@@ -116,17 +116,17 @@ public:
 
     struct StartupConfiguration
     {
-        Humidistat::ModeEnum mode               = Humidistat::ModeEnum::kAuto;
-        Humidistat::SystemStateEnum systemState = Humidistat::SystemStateEnum::kIdle;
-        chip::Percent userSetpoint              = 50;
-        chip::Percent minSetpoint               = 0;
-        chip::Percent maxSetpoint               = 100;
-        chip::Percent step                      = 1;
-        chip::Percent targetSetpoint            = 50;
+        Humidistat::ModeEnum mode                                               = Humidistat::ModeEnum::kAuto;
+        Humidistat::SystemStateEnum systemState                                 = Humidistat::SystemStateEnum::kIdle;
+        chip::Percent userSetpoint                                              = 50;
+        chip::Percent minSetpoint                                               = 0;
+        chip::Percent maxSetpoint                                               = 100;
+        chip::Percent step                                                      = 1;
+        chip::Percent targetSetpoint                                            = 50;
         DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType = DataModel::NullNullable;
-        bool continuous = false;
-        bool sleep      = false;
-        bool optimal    = false;
+        bool continuous                                                         = false;
+        bool sleep                                                              = false;
+        bool optimal                                                            = false;
     };
 
     /**

--- a/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
@@ -396,6 +396,7 @@ TEST_F(TestHumidistatCluster, WriteAttributes)
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
     EXPECT_EQ(tester.WriteAttribute(Mode::Id, ModeEnum::kHumidifier), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
     EXPECT_EQ(tester.WriteAttribute(UserSetpoint::Id, static_cast<chip::Percent>(60)), CHIP_NO_ERROR);
     EXPECT_EQ(tester.WriteAttribute(UserSetpoint::Id, static_cast<chip::Percent>(81)),
               CHIP_IM_GLOBAL_STATUS(ConstraintError)); // out of range
@@ -818,24 +819,27 @@ TEST_F(TestHumidistatCluster, TestPersistence)
     }
 }
 
-TEST_F(TestHumidistatCluster, SetModeClearsMistType)
+TEST_F(TestHumidistatCluster, SetSystemStateClearsMistTypeToNull)
 {
-    // Spec: "If the value of Mode is not set to Humidifier, all bits of MistType SHALL be set to zero."
+    // Spec: MistType SHALL be null when SystemState is not Humidifying.
     const BitFlags<Feature> features{ Feature::kHumidifier, Feature::kDehumidifier, Feature::kColdMist, Feature::kSensor };
     HumidistatCluster cluster(kTestEndpointId, features, {});
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
-    // Set mode to Humidifier and set MistType
-    ASSERT_EQ(cluster.SetMode(ModeEnum::kHumidifier), CHIP_NO_ERROR);
+    // Set state to Humidifying and set MistType.
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
     ASSERT_EQ(cluster.SetMistType(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold)), CHIP_NO_ERROR);
     EXPECT_EQ(cluster.GetMistType().Raw(), chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold).Raw());
 
     tester.GetDirtyList().clear();
 
-    // Change mode away from Humidifier — MistType must be cleared.
-    ASSERT_EQ(cluster.SetMode(ModeEnum::kDehumidifier), CHIP_NO_ERROR);
-    EXPECT_EQ(cluster.GetMistType().Raw(), 0u);
+    // Change state away from Humidifying — MistType must be null.
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kIdle), CHIP_NO_ERROR);
+
+    DataModel::Nullable<chip::BitMask<MistTypeBitmap>> readMistType;
+    ASSERT_EQ(tester.ReadAttribute(MistType::Id, readMistType), CHIP_NO_ERROR);
+    EXPECT_TRUE(readMistType.IsNull());
     EXPECT_TRUE(tester.IsAttributeDirty(MistType::Id));
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);


### PR DESCRIPTION
### Summary

The MistType attribute was handled according to an outdated version of the spec. The current spec requires:

MistType SHALL represent the mist type currently in use when SystemState is Humidifying. If SystemState is not Humidifying, MistType SHALL be null.

The cluster was instead tracking MistType based on the Mode attribute, which no longer matches the spec.

Updated the cluster to manage MistType based on SystemState rather than Mode, in line with the current spec.

### Related issues

N/A

### Testing
Unit testing and manual cluster test using chip tool
