### PR TITLE
[Fix] Enforce constraint when writing the DefaultOpenLevel attribute of the Valve Configuration and Control cluster.

### DIFF
--- a/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.cpp
@@ -176,6 +176,9 @@ DataModel::ActionReturnStatus ValveConfigurationAndControlCluster::WriteImpl(con
     {
         Percent defaultOpenLevel;
         ReturnErrorOnFailure(decoder.Decode(defaultOpenLevel));
+        // DefaultOpenLevel is constrained to 1 to 100; Percent decodes as a plain uint8 and enforces neither bound.
+        VerifyOrReturnError(defaultOpenLevel >= kMinLevelValuePercent && defaultOpenLevel <= kMaxLevelValuePercent,
+                            CHIP_IM_GLOBAL_STATUS(ConstraintError));
         VerifyOrReturnValue(defaultOpenLevel != mDefaultOpenLevel, DataModel::ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
         // TODO(#40708): Currently the `DecodeAndStoreNativeEndianValue` function doesn't allow performing specific checks
         // on provided values; update this logic once a fix for

--- a/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.cpp
@@ -178,7 +178,7 @@ DataModel::ActionReturnStatus ValveConfigurationAndControlCluster::WriteImpl(con
         ReturnErrorOnFailure(decoder.Decode(defaultOpenLevel));
         // DefaultOpenLevel is constrained to 1 to 100; Percent decodes as a plain uint8 and enforces neither bound.
         VerifyOrReturnError(defaultOpenLevel >= kMinLevelValuePercent && defaultOpenLevel <= kMaxLevelValuePercent,
-                            CHIP_IM_GLOBAL_STATUS(ConstraintError));
+                            Status::ConstraintError);
         VerifyOrReturnValue(defaultOpenLevel != mDefaultOpenLevel, DataModel::ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
         // TODO(#40708): Currently the `DecodeAndStoreNativeEndianValue` function doesn't allow performing specific checks
         // on provided values; update this logic once a fix for

--- a/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.h
+++ b/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.h
@@ -36,6 +36,7 @@ class ValveConfigurationAndControlCluster : public DefaultServerCluster
 public:
     static constexpr uint8_t kDefaultOpenLevel     = 100u;
     static constexpr uint8_t kDefaultLevelStep     = 1u;
+    static constexpr uint8_t kMinLevelValuePercent = 1u;
     static constexpr uint8_t kMaxLevelValuePercent = 100u;
 
     using OptionalAttributeSet = chip::app::OptionalAttributeSet<ValveConfigurationAndControl::Attributes::DefaultOpenLevel::Id,

--- a/src/app/clusters/valve-configuration-and-control-server/tests/TestValveConfigurationAndControlCluster.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/tests/TestValveConfigurationAndControlCluster.cpp
@@ -324,6 +324,47 @@ TEST_F(TestValveConfigurationAndControlCluster, ReadAttributeTestDefaultOpenLeve
     valveCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
+// DefaultOpenLevel is constrained to 1 to 100 by the spec. Percent decodes as a plain uint8, so the
+// cluster is responsible for rejecting values outside that range.
+TEST_F(TestValveConfigurationAndControlCluster, WriteAttributeTestDefaultOpenLevelOutOfRange)
+{
+    ValveConfigurationAndControlCluster::OptionalAttributeSet optionalAttributeSet;
+    optionalAttributeSet.Set<DefaultOpenLevel::Id>();
+    const BitFlags<Feature> features{ Feature::kLevel };
+    ValveConfigurationAndControlCluster::StartupConfiguration config{ DataModel::NullNullable,
+                                                                      ValveConfigurationAndControlCluster::kDefaultOpenLevel,
+                                                                      ValveConfigurationAndControlCluster::kDefaultLevelStep };
+    ValveConfigurationAndControlCluster::ValveContext context = {
+        .features             = features,
+        .optionalAttributeSet = optionalAttributeSet,
+        .config               = config,
+        .tsTracker            = &timeSyncTracker,
+        .delegate             = &delegate,
+    };
+    ValveConfigurationAndControlCluster valveCluster(kRootEndpointId, context);
+    ASSERT_EQ(valveCluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(valveCluster);
+
+    constexpr Percent kBelowMin = ValveConfigurationAndControlCluster::kMinLevelValuePercent - 1;
+    constexpr Percent kAboveMax = ValveConfigurationAndControlCluster::kMaxLevelValuePercent + 1;
+    EXPECT_EQ(tester.WriteAttribute(DefaultOpenLevel::Id, kBelowMin), Status::ConstraintError);
+    EXPECT_EQ(tester.WriteAttribute(DefaultOpenLevel::Id, kAboveMax), Status::ConstraintError);
+
+    // A rejected write must leave the attribute unchanged.
+    Percent defaultOpenLevel{};
+    ASSERT_EQ(tester.ReadAttribute(DefaultOpenLevel::Id, defaultOpenLevel), CHIP_NO_ERROR);
+    EXPECT_EQ(defaultOpenLevel, ValveConfigurationAndControlCluster::kDefaultOpenLevel);
+
+    // A value inside the range is still accepted.
+    constexpr Percent kInRange = 50;
+    ASSERT_EQ(tester.WriteAttribute(DefaultOpenLevel::Id, kInRange), CHIP_NO_ERROR);
+    ASSERT_EQ(tester.ReadAttribute(DefaultOpenLevel::Id, defaultOpenLevel), CHIP_NO_ERROR);
+    EXPECT_EQ(defaultOpenLevel, kInRange);
+
+    valveCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
 // Reading with optional ValveFault attribute
 TEST_F(TestValveConfigurationAndControlCluster, ReadAttributeTestValveFault)
 {


### PR DESCRIPTION
### Summary

Enforces the spec-defined 1 to 100 constraint when writing the DefaultOpenLevel attribute of the Valve Configuration and Control cluster.

##### Problem

-   ValveConfigurationAndControlCluster::WriteImpl never range-checks the decoded DefaultOpenLevel value:
    -  Percent is a uint8_t typedef, so the **decoder enforces neither bound**.
    -  The only validation applied is ValueCompliesWithLevelStep(), which is a **step check, not a range check**: it accepts any multiple of LevelStep, including 0, and returns true unconditionally when the optional LevelStep attribute is not implemented.
-   Out-of-range writes are therefore accepted with `SUCCESS` and **persisted**, leaving the attribute holding a value the spec disallows.

##### Solution

-   Validate the decoded value against the attribute's 1 to 100 bounds before any other handling, returning `CONSTRAINT_ERROR` for violations.
-   The check runs ahead of the unchanged-value short-circuit and the LevelStep check, so an out-of-range write is rejected on the bound it actually violates rather than depending on LevelStep arithmetic. The two checks remain independent: in-range values that are not LevelStep multiples are still rejected by ValueCompliesWithLevelStep().
-  Adds kMinLevelValuePercent alongside the existing kMaxLevelValuePercent so both bounds are named constants.

This mirrors the explicit minimum check already present for the sibling DefaultOpenDuration attribute which was changed in Fix [43715](https://github.com/project-chip/connectedhomeip/pull/43715)

### Related issues

Fixes [#73755](https://github.com/project-chip/connectedhomeip/issues/73755)

### Testing

-  Verified with TC_IDM_9_1.py step 2 from PR [73066](https://github.com/project-chip/connectedhomeip/pull/73066), which writes an under-minimum value to every writable attribute carrying a spec constraint. Before the change the DUT returned SUCCESS for DefaultOpenLevel = 0 and the attribute read back as 0; after the change it returns CONSTRAINT_ERROR and retains its prior value.
