### PR TITLE
Fix network config removal when giving up on the primary network

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -536,6 +536,13 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
         return CommissioningStage::kFindOperationalForStayActive;
 #endif
     case CommissioningStage::kPrimaryOperationalNetworkFailed:
+        if (!mWroteNetworkConfig)
+        {
+            // We never got as far as writing a network configuration for the primary network,
+            // so there is nothing on the commissionee to remove. Note that TrySecondaryNetwork()
+            // has already been called by the time we get here, so this selects the secondary network.
+            return GetNextCommissioningStageNetworkSetup(currentStage, lastErr);
+        }
         if (mDeviceCommissioningInfo.network.wifi.endpoint == kRootEndpointId)
         {
             return CommissioningStage::kRemoveWiFiNetworkConfig;
@@ -766,6 +773,7 @@ void AutoCommissioner::CleanupCommissioning()
     mCommissioneeDeviceProxy = nullptr;
     mOperationalDeviceProxy  = OperationalDeviceProxy();
     mDeviceCommissioningInfo = ReadCommissioningInfo();
+    mWroteNetworkConfig      = false;
     mNeedsDST                = false;
     mNeedsNetworkSetup       = false;
     mNeedIcdRegistration     = false;
@@ -832,6 +840,9 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             // TODO: This doesn't actually work, because in order to provide credentials someone
             // had to SetWiFiCredentials() or SetThreadOperationalDataset() on our params, so
             // IsScanNeeded() will no longer test true for that network technology.
+            //
+            // TODO: A retry also has to remove the configuration we just wrote before writing
+            // another one, (unless it is for the same NetworkID).
             if (IsScanNeeded())
             {
                 if (completionStatus.err == CHIP_NO_ERROR)
@@ -1001,6 +1012,14 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             break;
         case CommissioningStage::kICDRegistration:
             // Noting to do. DevicePairingDelegate will handle this.
+            break;
+        case CommissioningStage::kWiFiNetworkSetup:
+        case CommissioningStage::kThreadNetworkSetup:
+            mWroteNetworkConfig = true;
+            break;
+        case CommissioningStage::kRemoveWiFiNetworkConfig:
+        case CommissioningStage::kRemoveThreadNetworkConfig:
+            mWroteNetworkConfig = false;
             break;
         case CommissioningStage::kFindOperationalForStayActive:
         case CommissioningStage::kFindOperationalForCommissioningComplete:

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -147,6 +147,14 @@ private:
 
     NetworkAttemptType mTryingNetworkType = NetworkAttemptType::kSingle;
 
+    // Whether the commissionee is holding a network configuration we wrote, which we would have to
+    // remove before we can put it on a different network. Only set once AddOrUpdateWiFiNetwork or
+    // AddOrUpdateThreadNetwork has actually succeeded: a failed one writes nothing.
+    // Not carried across commissioning attempts: a configuration written by an attempt that we go on
+    // to resume via the breadcrumb is not recorded here, so we will not remove it on our way to the
+    // secondary network, and it may survive if that attempt then succeeds.
+    bool mWroteNetworkConfig = false;
+
     bool mStopCommissioning = false;
 
     DeviceCommissioner * mCommissioner                               = nullptr;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -3131,18 +3131,26 @@ CHIP_ERROR DeviceCommissioner::ICDRegistrationInfoReady()
 void DeviceCommissioner::OnNetworkConfigResponse(void * context,
                                                  const NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & data)
 {
+    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     ChipLogProgress(Controller, "Received NetworkConfig response, networkingStatus=%u", to_underlying(data.networkingStatus));
-    if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatusEnum::kSuccess)
+
+    // A removal is only asking for the configuration to be gone, so accept a kNetworkIDNotFound as success.
+    if ((commissioner->mCommissioningStage == CommissioningStage::kRemoveWiFiNetworkConfig ||
+         commissioner->mCommissioningStage == CommissioningStage::kRemoveThreadNetworkConfig) &&
+        data.networkingStatus == NetworkCommissioning::NetworkCommissioningStatusEnum::kNetworkIDNotFound)
+    {
+        ChipLogDetail(Controller, "Treating NetworkIDNotFound as success for network removal");
+    }
+    else if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatusEnum::kSuccess)
     {
         err = CHIP_ERROR_INTERNAL;
         // Preserve debugText alongside the status enum so callers can distinguish
         // ambiguous statuses (e.g. kAuthFailure: "wrong password" vs "regulatory restriction").
         report.Set<NetworkCommissioningStatusInfo>(data.networkingStatus, data.debugText.ValueOr(CharSpan{}));
     }
-    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(err, report);
 }
 
@@ -3935,6 +3943,12 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         break;
     }
     case CommissioningStage::kRemoveWiFiNetworkConfig: {
+        if (!params.GetWiFiCredentials().HasValue())
+        {
+            ChipLogError(Controller, "No Wi-Fi credentials configured at commissioner!");
+            CommissioningStageComplete(CHIP_ERROR_INVALID_ARGUMENT);
+            return;
+        }
         NetworkCommissioning::Commands::RemoveNetwork::Type request;
         request.networkID = params.GetWiFiCredentials().Value().ssid;
         request.breadcrumb.Emplace(breadcrumb);

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -99,6 +99,8 @@ public:
 
     bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
 
+    bool WroteNetworkConfig() const { return mCommissioner->mWroteNetworkConfig; }
+
 private:
     Controller::AutoCommissioner * mCommissioner = nullptr;
 };

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -54,6 +54,7 @@ chip_test_suite("tests") {
     test_sources += [
       "TestAutoCommissioner.cpp",
       "TestICDManagementResponses.cpp",
+      "TestNetworkConfigResponses.cpp",
       "TestParseICDInfo.cpp",
     ]
   }

--- a/src/controller/tests/DeviceCommissionerTestAccess.h
+++ b/src/controller/tests/DeviceCommissionerTestAccess.h
@@ -19,6 +19,7 @@
 
 #include <app/DeviceProxy.h>
 #include <clusters/IcdManagement/Commands.h>
+#include <clusters/NetworkCommissioning/Commands.h>
 #include <controller/CHIPDeviceController.h>
 
 namespace chip {
@@ -51,6 +52,13 @@ public:
                                       const app::Clusters::IcdManagement::Commands::StayActiveResponse::DecodableType & data)
     {
         Controller::DeviceCommissioner::OnICDManagementStayActiveResponse(commissioner, data);
+    }
+
+    static void
+    OnNetworkConfigResponse(Controller::DeviceCommissioner * commissioner,
+                            const app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & data)
+    {
+        Controller::DeviceCommissioner::OnNetworkConfigResponse(commissioner, data);
     }
 
 private:

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -726,4 +726,127 @@ TEST_F(AutoCommissionerTest, SetCommissioningParametersCopiesSpans)
     EXPECT_NE(storedParams.GetCountryCode().Value().data(), sourceCountryCode.data());
     EXPECT_TRUE(storedParams.GetCountryCode().Value().data_equal(sourceCountryCode));
 }
+
+// ---------------------------------------------------------------------------
+// Failing over from the primary to the secondary network interface
+// ---------------------------------------------------------------------------
+
+// Giving up on the primary network only requires removing its configuration from the commissionee
+// if we actually wrote one. Asking a commissionee to remove a network it does not have fails, which
+// would end the commissioning attempt instead of letting us try the other network technology.
+class AutoCommissionerNetworkFailoverTest : public ::testing::Test
+{
+protected:
+    // A commissionee supporting both Wi-Fi and Thread, with credentials for both, which is what
+    // IsSecondaryNetworkSupported() requires. The interface on the root endpoint is the primary one.
+    void ConfigureDualInterface(EndpointId wifiEndpoint, EndpointId threadEndpoint)
+    {
+        const uint8_t ssid[]       = { 's', 's', 'i', 'd' };
+        const uint8_t passphrase[] = { 'p', 'a', 's', 's' };
+        const uint8_t dataset[]    = { 0x00 };
+
+        CommissioningParameters params;
+        params.SetWiFiCredentials(WiFiCredentials(ByteSpan(ssid), ByteSpan(passphrase)));
+        params.SetThreadOperationalDataset(ByteSpan(dataset));
+        params.SetSupportsConcurrentConnection(true);
+        ASSERT_EQ(mCommissioner.SetCommissioningParameters(params), CHIP_NO_ERROR);
+
+        ReadCommissioningInfo & info = mAccess.GetDeviceCommissioningInfo();
+        info.network.wifi.endpoint   = wifiEndpoint;
+        info.network.thread.endpoint = threadEndpoint;
+        ASSERT_TRUE(mAccess.IsSecondaryNetworkSupported());
+        ASSERT_FALSE(mAccess.WroteNetworkConfig());
+    }
+
+    // Reports a stage as having completed successfully. PerformStep() then fails because this
+    // fixture has no device proxy, by which point everything we care about has already happened.
+    void CompleteStage(CommissioningStage stage)
+    {
+        CommissioningDelegate::CommissioningReport report;
+        report.stageCompleted = stage;
+        EXPECT_EQ(mCommissioner.CommissioningStepFinished(CHIP_NO_ERROR, report), CHIP_ERROR_INCORRECT_STATE);
+    }
+
+    // The stage the flow moves to once the failover has given up on the primary network. Mirrors
+    // what CommissioningStepFinished() does on a network failure: switch, then report the switch.
+    CommissioningStage StageAfterPrimaryNetworkFailed()
+    {
+        mAccess.TrySecondaryNetwork();
+        CHIP_ERROR err          = CHIP_NO_ERROR;
+        CommissioningStage next = mAccess.AccessGetNextCommissioningStageInternal(kPrimaryOperationalNetworkFailed, err);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        return next;
+    }
+
+    AutoCommissioner mCommissioner{};
+    AutoCommissionerTestAccess mAccess{ &mCommissioner };
+};
+
+// AddOrUpdateWiFiNetwork never succeeded, so there is nothing on the commissionee to remove and we
+// go straight to the secondary network.
+TEST_F(AutoCommissionerNetworkFailoverTest, PrimaryWiFiWithoutConfigSkipsRemoval)
+{
+    ConfigureDualInterface(kRootEndpointId, /* threadEndpoint = */ 1);
+
+    EXPECT_EQ(StageAfterPrimaryNetworkFailed(), kThreadNetworkSetup);
+}
+
+// The Wi-Fi configuration was written, so it has to come off before Thread is configured.
+TEST_F(AutoCommissionerNetworkFailoverTest, PrimaryWiFiWithConfigIsRemovedFirst)
+{
+    ConfigureDualInterface(kRootEndpointId, /* threadEndpoint = */ 1);
+    CompleteStage(kWiFiNetworkSetup);
+    ASSERT_TRUE(mAccess.WroteNetworkConfig());
+
+    EXPECT_EQ(StageAfterPrimaryNetworkFailed(), kRemoveWiFiNetworkConfig);
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    EXPECT_EQ(mAccess.AccessGetNextCommissioningStageInternal(kRemoveWiFiNetworkConfig, err), kThreadNetworkSetup);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+}
+
+// The same either way round: Thread on the root endpoint is the primary network.
+TEST_F(AutoCommissionerNetworkFailoverTest, PrimaryThreadWithoutConfigSkipsRemoval)
+{
+    ConfigureDualInterface(/* wifiEndpoint = */ 1, kRootEndpointId);
+
+    EXPECT_EQ(StageAfterPrimaryNetworkFailed(), kWiFiNetworkSetup);
+}
+
+TEST_F(AutoCommissionerNetworkFailoverTest, PrimaryThreadWithConfigIsRemovedFirst)
+{
+    ConfigureDualInterface(/* wifiEndpoint = */ 1, kRootEndpointId);
+    CompleteStage(kThreadNetworkSetup);
+    ASSERT_TRUE(mAccess.WroteNetworkConfig());
+
+    EXPECT_EQ(StageAfterPrimaryNetworkFailed(), kRemoveThreadNetworkConfig);
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    EXPECT_EQ(mAccess.AccessGetNextCommissioningStageInternal(kRemoveThreadNetworkConfig, err), kWiFiNetworkSetup);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+}
+
+// What we track is what the commissionee is actually holding, so a successful removal clears it
+// again. Nothing in the current stage graph asks twice, but the record would otherwise be wrong.
+TEST_F(AutoCommissionerNetworkFailoverTest, RemovingTheConfigClearsTheRecord)
+{
+    ConfigureDualInterface(kRootEndpointId, /* threadEndpoint = */ 1);
+    CompleteStage(kWiFiNetworkSetup);
+    ASSERT_TRUE(mAccess.WroteNetworkConfig());
+
+    CompleteStage(kRemoveWiFiNetworkConfig);
+    EXPECT_FALSE(mAccess.WroteNetworkConfig());
+}
+
+// An AutoCommissioner is reused across commissioning attempts, so a configuration written during
+// one attempt must not be remembered into the next.
+TEST_F(AutoCommissionerNetworkFailoverTest, CleanupClearsTheRecord)
+{
+    ConfigureDualInterface(kRootEndpointId, /* threadEndpoint = */ 1);
+    CompleteStage(kWiFiNetworkSetup);
+    ASSERT_TRUE(mAccess.WroteNetworkConfig());
+
+    mAccess.CleanupCommissioning();
+    EXPECT_FALSE(mAccess.WroteNetworkConfig());
+}
 } // namespace

--- a/src/controller/tests/TestNetworkConfigResponses.cpp
+++ b/src/controller/tests/TestNetworkConfigResponses.cpp
@@ -1,0 +1,141 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// How the commissioner interprets a NetworkConfigResponse. The stage it arrives in matters: the
+// same networkingStatus that fails an AddOrUpdate can be the expected outcome of a RemoveNetwork.
+
+#include <pw_unit_test/framework.h>
+
+#include <app/DeviceProxy.h>
+#include <controller/CHIPDeviceController.h>
+#include <controller/CommissioningDelegate.h>
+#include <controller/DevicePairingDelegate.h>
+#include <controller/tests/DeviceCommissionerTestAccess.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include <clusters/NetworkCommissioning/Commands.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::Controller;
+using namespace chip::Testing;
+
+namespace {
+
+constexpr NodeId kTestNodeId = 0x12344321;
+
+class FakeDeviceProxy : public DeviceProxy
+{
+public:
+    void Disconnect() override {}
+    NodeId GetDeviceId() const override { return kTestNodeId; }
+    Messaging::ExchangeManager * GetExchangeManager() const override { return nullptr; }
+    chip::Optional<SessionHandle> GetSecureSession() const override { return NullOptional; }
+
+protected:
+    bool IsSecureConnected() const override { return false; }
+};
+
+// The commissioner reports the outcome of every stage to the pairing delegate before handing over to
+// the commissioning delegate, which is left unset here so the flow stops after we have observed it.
+class MockPairingDelegate : public DevicePairingDelegate
+{
+public:
+    void OnCommissioningStatusUpdate(PeerId peerId, CommissioningStage stageCompleted, CHIP_ERROR error) override
+    {
+        mStatusUpdateCount++;
+        mLastStageCompleted = stageCompleted;
+        mLastError          = error;
+    }
+
+    int mStatusUpdateCount                 = 0;
+    CommissioningStage mLastStageCompleted = CommissioningStage::kError;
+    CHIP_ERROR mLastError                  = CHIP_NO_ERROR;
+};
+
+class TestNetworkConfigResponses : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+protected:
+    void SetUp() override
+    {
+        mCommissioner.RegisterPairingDelegate(&mDelegate);
+        mAccess.SetDeviceBeingCommissioned(&mDevice);
+    }
+
+    // Delivers a NetworkConfigResponse as though it had arrived during the given stage,
+    // and returns the error the commissioner completed that stage with.
+    CHIP_ERROR DeliverResponse(CommissioningStage stage, NetworkCommissioning::NetworkCommissioningStatusEnum status)
+    {
+        mAccess.SetCommissioningStage(stage);
+
+        NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType data;
+        data.networkingStatus = status;
+        DeviceCommissionerTestAccess::OnNetworkConfigResponse(&mCommissioner, data);
+
+        EXPECT_EQ(mDelegate.mStatusUpdateCount, 1);
+        EXPECT_EQ(mDelegate.mLastStageCompleted, stage);
+        return mDelegate.mLastError;
+    }
+
+    FakeDeviceProxy mDevice;
+    MockPairingDelegate mDelegate;
+    DeviceCommissioner mCommissioner{};
+    DeviceCommissionerTestAccess mAccess{ &mCommissioner };
+};
+
+// Removing a network configuration the commissionee does not have achieves what the removal was
+// asking for, so it must not fail the attempt. We rely on this when giving up on a network
+// technology we never managed to configure, and when the NetworkID we name is stale.
+TEST_F(TestNetworkConfigResponses, RemovingAnAbsentWiFiNetworkSucceeds)
+{
+    EXPECT_EQ(DeliverResponse(kRemoveWiFiNetworkConfig, NetworkCommissioning::NetworkCommissioningStatusEnum::kNetworkIDNotFound),
+              CHIP_NO_ERROR);
+}
+
+TEST_F(TestNetworkConfigResponses, RemovingAnAbsentThreadNetworkSucceeds)
+{
+    EXPECT_EQ(DeliverResponse(kRemoveThreadNetworkConfig, NetworkCommissioning::NetworkCommissioningStatusEnum::kNetworkIDNotFound),
+              CHIP_NO_ERROR);
+}
+
+// "not found" against an AddOrUpdate is still a failure
+TEST_F(TestNetworkConfigResponses, NetworkIdNotFoundStillFailsNetworkSetup)
+{
+    EXPECT_NE(DeliverResponse(kWiFiNetworkSetup, NetworkCommissioning::NetworkCommissioningStatusEnum::kNetworkIDNotFound),
+              CHIP_NO_ERROR);
+}
+
+// Only the "not found" status is forgiven, any other status is still an error.
+TEST_F(TestNetworkConfigResponses, OtherFailuresStillFailARemoval)
+{
+    EXPECT_NE(DeliverResponse(kRemoveWiFiNetworkConfig, NetworkCommissioning::NetworkCommissioningStatusEnum::kUnknownError),
+              CHIP_NO_ERROR);
+}
+
+TEST_F(TestNetworkConfigResponses, SuccessCompletesTheStage)
+{
+    EXPECT_EQ(DeliverResponse(kRemoveWiFiNetworkConfig, NetworkCommissioning::NetworkCommissioningStatusEnum::kSuccess),
+              CHIP_NO_ERROR);
+}
+} // namespace


### PR DESCRIPTION
### Summary

When commissioning gives up on the primary network interface and falls
back to the secondary one, it unconditionally removes the primary
network configuration from the commissionee. But that configuration may
never have been written: the failover also triggers for failures at
kRequestWiFiCredentials, kNeedsNetworkCreds, or an AddOrUpdate*Network
that came back with a failure status. The commissionee then answers
RemoveNetwork with NetworkIDNotFound, we treat that as an error, and the
attempt ends instead of trying the other network technology.

Fix this from both ends:

- A removal is only asking for a configuration to be gone, so a
  commissionee reporting NetworkIDNotFound in response can safely be
  treated as success.  This can happen in the case of a stale NetworkID,
  which is possible because the removal stages derive it from the
  credentials currently held in the CommissioningParameters.

- Track whether AddOrUpdateWiFiNetwork / AddOrUpdateThreadNetwork actually
  succeeded and skip the removal stage entirely if it did not. This avoids a
  pointless round trip, and covers the case where we hold no credentials at
  all and so can't even name a network to remove.

Also add the missing GetWiFiCredentials().HasValue() check to
kRemoveWiFiNetworkConfig, mirroring the existing one on the Thread side;
previously Optional::Value() would have aborted here.

Note that a configuration written by an earlier attempt that we resume via
the breadcrumb is not tracked, so it may be left behind on the commissionee.
Removing the right one requires retaining the NetworkID we configured rather
than deriving it, which also matters for retrying with a different set of
credentials on the same interface; see the TODOs added there.

### Testing

New unit tests.
