### PR TITLE
reject trailing bytes in EcdsaAsn1SignatureToRaw

### DIFF
--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -774,6 +774,9 @@ CHIP_ERROR EcdsaAsn1SignatureToRaw(size_t fe_length_bytes, const ByteSpan & asn1
     // Read S
     ReturnErrorOnFailure(ReadDerUnsignedIntegerIntoRaw(reader, MutableByteSpan{ raw_cursor, fe_length_bytes }));
 
+    // R and S must consume the entire sequence: reject any trailing bytes.
+    VerifyOrReturnError(reader.Remaining() == 0, CHIP_ERROR_INVALID_ARGUMENT);
+
     out_raw_sig = out_raw_sig.SubSpan(0, (2u * fe_length_bytes));
 
     return CHIP_NO_ERROR;

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -783,6 +783,27 @@ TEST_F(TestChipCryptoPAL, TestAsn1Conversions)
     }
 }
 
+TEST_F(TestChipCryptoPAL, TestAsn1SignatureToRawRejectsTrailingData)
+{
+    HeapChecker heapChecker;
+
+    // A minimal well-formed ECDSA signature: SEQUENCE { INTEGER 0x01, INTEGER 0x01 }.
+    // fe_length_bytes of 1 keeps the vector small while exercising the same parser used
+    // for P-256 signatures during attestation and certificate validation.
+    const uint8_t kValidSig[] = { 0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01 };
+    // Same R and S, but the SEQUENCE length (0x07) counts an extra trailing byte that R
+    // and S do not consume. This is malformed DER and must be rejected.
+    const uint8_t kTrailingDataSig[] = { 0x30, 0x07, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x00 };
+
+    uint8_t rawBuf[2] = { 0 };
+
+    MutableByteSpan rawSpan(rawBuf);
+    EXPECT_EQ(EcdsaAsn1SignatureToRaw(1, ByteSpan(kValidSig), rawSpan), CHIP_NO_ERROR);
+
+    rawSpan = MutableByteSpan(rawBuf);
+    EXPECT_EQ(EcdsaAsn1SignatureToRaw(1, ByteSpan(kTrailingDataSig), rawSpan), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
 TEST_F(TestChipCryptoPAL, TestRawIntegerToDerValidCases)
 {
     HeapChecker heapChecker;


### PR DESCRIPTION
### Summary

`EcdsaAsn1SignatureToRaw` already requires the ASN.1 SEQUENCE length to match the whole input buffer (`tag_len == reader.Remaining()`), but it never checks that the `r` and `s` INTEGERs consume that whole sequence, so trailing bytes after `s` inside the SEQUENCE are silently accepted as a valid signature. The signature bytes reach this parser from an untrusted peer during device attestation (`CertificationDeclaration`) and certificate-chain validation, so the tolerance makes DER parsing non-strict on that path. The sibling `VerifyCertificateSigningRequestFormat` in the same file already rejects this kind of trailing garbage; this brings the signature parser in line by returning `CHIP_ERROR_INVALID_ARGUMENT` when bytes remain after `s`.

### Related issues

None.

### Testing

Added a `TestChipCryptoPAL` regression (`TestAsn1SignatureToRawRejectsTrailingData`). A signature whose SEQUENCE length counts one extra byte after `s` (`30 07 02 01 01 02 01 01 00`) is accepted before the change and rejected after, while a well-formed signature (`30 06 02 01 01 02 01 01`) still parses.