### PR TITLE
Initialize CTC_BaseDataClass double-buffered value storage

### DIFF
--- a/src/app/clusters/commodity-tariff-server/CommodityTariffAttrsDataMgmt.h
+++ b/src/app/clusters/commodity-tariff-server/CommodityTariffAttrsDataMgmt.h
@@ -466,7 +466,7 @@ class CTC_BaseDataClass : public CTC_BaseDataClassBase
         kValidated,   // New value validated and ready for commit
     };
 
-    T mValueStorage[2];                                          ///< Double-buffered value storage
+    T mValueStorage[2]{};                                        ///< Double-buffered value storage
     StorageState mHoldState[2] = { StorageState::kEmpty };       ///< Storage state tracking
     std::atomic<UpdateState> mUpdateState{ UpdateState::kIdle }; ///< Current update state
     std::atomic<uint8_t> mActiveValueIdx{ 0 };                   ///< Index of active value storage

--- a/src/app/clusters/commodity-tariff-server/CommodityTariffAttrsDataMgmt.h
+++ b/src/app/clusters/commodity-tariff-server/CommodityTariffAttrsDataMgmt.h
@@ -491,7 +491,7 @@ public:
      * @post Initializes storage based on type:
      * - Nullable types: set to null
      * - List types: initialized as empty list
-     * - Others: default initialized
+     * - Others: value initialized
      * - Update state set to kIdle
      */
     explicit CTC_BaseDataClass(AttributeId aAttrId) : mAttrId(aAttrId)

--- a/src/app/clusters/commodity-tariff-server/tests/TestCommodityTariffBaseDataClass.cpp
+++ b/src/app/clusters/commodity-tariff-server/tests/TestCommodityTariffBaseDataClass.cpp
@@ -127,9 +127,9 @@ TEST_F(TestCommodityTariffBaseDataClass, ScalarValueUpdateFlow)
 
 TEST_F(TestCommodityTariffBaseDataClass, ScalarStorageInitializedOnConstruction)
 {
-    // The double-buffered storage must be initialized by the constructor even when the
-    // object lives in memory that is not zeroed, otherwise the first change detection
-    // compares the incoming value against indeterminate bytes.
+    // A scalar value type's storage must be initialized by the constructor even when
+    // the object lives in memory that is not zeroed, otherwise the first change
+    // detection compares the incoming value against indeterminate bytes.
     constexpr uint8_t kFillByte      = 0xAB;
     constexpr uint32_t kFillAsUint32 = 0xABABABAB;
 
@@ -138,8 +138,8 @@ TEST_F(TestCommodityTariffBaseDataClass, ScalarStorageInitializedOnConstruction)
 
     auto * data = new (storage) CTC_BaseDataClass<uint32_t>(1);
 
-    // The contract itself: construction initializes the active slot, independent
-    // of how change detection later behaves.
+    // Pin the initialization itself rather than only its effect on the update flow:
+    // a value initialized scalar slot reads zero whatever change detection does.
     EXPECT_EQ(data->GetValue(), 0u);
     EXPECT_FALSE(data->HasValue());
 

--- a/src/app/clusters/commodity-tariff-server/tests/TestCommodityTariffBaseDataClass.cpp
+++ b/src/app/clusters/commodity-tariff-server/tests/TestCommodityTariffBaseDataClass.cpp
@@ -28,6 +28,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <new>
 
 #include <lib/support/CodeUtils.h>
 
@@ -121,6 +123,34 @@ TEST_F(TestCommodityTariffBaseDataClass, ScalarValueUpdateFlow)
 
     EXPECT_EQ(data.GetValue(), data_sample_2);
     EXPECT_TRUE(data.HasValue());
+}
+
+TEST_F(TestCommodityTariffBaseDataClass, ScalarStorageInitializedOnConstruction)
+{
+    // The double-buffered storage must be initialized by the constructor even when the
+    // object lives in memory that is not zeroed, otherwise the first change detection
+    // compares the incoming value against indeterminate bytes.
+    constexpr uint8_t kFillByte      = 0xAB;
+    constexpr uint32_t kFillAsUint32 = 0xABABABAB;
+
+    alignas(CTC_BaseDataClass<uint32_t>) uint8_t storage[sizeof(CTC_BaseDataClass<uint32_t>)];
+    memset(storage, kFillByte, sizeof(storage));
+
+    auto * data = new (storage) CTC_BaseDataClass<uint32_t>(1);
+
+    // The contract itself: construction initializes the active slot, independent
+    // of how change detection later behaves.
+    EXPECT_EQ(data->GetValue(), 0u);
+    EXPECT_FALSE(data->HasValue());
+
+    EXPECT_EQ(data->SetNewValue(kFillAsUint32), CHIP_NO_ERROR);
+    EXPECT_EQ(data->UpdateBegin(nullptr), CHIP_NO_ERROR);
+    EXPECT_TRUE(data->UpdateFinish(true));
+
+    EXPECT_TRUE(data->HasValue());
+    EXPECT_EQ(data->GetValue(), kFillAsUint32);
+
+    data->~CTC_BaseDataClass();
 }
 
 TEST_F(TestCommodityTariffBaseDataClass, ScalarValueNoChangeDetection)


### PR DESCRIPTION
#### Summary

##### Problem

`CTC_BaseDataClass` declares `T mValueStorage[2];`, which is default-initialized. The constructor initializes slot 0 only, and only for nullable and list value types, so for a non-nullable `T` both slots hold indeterminate bytes. The first `UpdateFinish()` then reaches `HasChanged()`, which compares the incoming value against the never-written active slot.

- **MSAN failure**: `TestCommodityTariffBaseDataClass.ScalarValueUpdateFlow` reports `use-of-uninitialized-value` at `CommodityTariffAttrsDataMgmt.h:820`.
- **Silently dropped update**: if the stale bytes happen to equal the incoming value, `HasChanged()` returns false, the storage swap is skipped and the attribute's first value is discarded with `HasValue()` still false.
- The constructor's own documentation already claims `Others: default initialized`, which was not the case.

All attributes the cluster currently declares are `Nullable<...>`, whose default constructor initializes both slots, so only the non-nullable instantiations are affected.

##### Solution

Value-initialize both slots at the declaration (`T mValueStorage[2]{};`), covering every value type category rather than the two the constructor special-cases.

#### Testing

- Added `ScalarStorageInitializedOnConstruction` in `src/app/clusters/commodity-tariff-server/tests/TestCommodityTariffBaseDataClass.cpp`. It constructs the object in a buffer filled with a known byte pattern, so the check is deterministic in an ordinary build instead of depending on a sanitizer. Fails without the fix, passes with it.
- `linux-x64-tests-msan-clang`: the reported failure is gone; 19/19 pass. Reverting the one-line change reproduces the original stack.
- `linux-x64-tests-asan-clang`: 19/19 pass.
- `linux-x64-energy-gateway-clang` builds, covering the `Nullable<...>` instantiations used by the cluster.
