### PR TITLE
[ESALM] Add Electrical Alarm (0x00A1) cluster server

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -82,6 +82,7 @@ if (chip_build_tests) {
       "${chip_root}/src/app/clusters/descriptor/tests",
       "${chip_root}/src/app/clusters/device-energy-management-server/tests",
       "${chip_root}/src/app/clusters/dynamic-lighting-server/tests",
+      "${chip_root}/src/app/clusters/electrical-alarm-server/tests",
       "${chip_root}/src/app/clusters/electrical-distribution-server/tests",
       "${chip_root}/src/app/clusters/electrical-energy-measurement-server/tests",
       "${chip_root}/src/app/clusters/electrical-power-measurement-server/tests",

--- a/src/app/clusters/BUILD.gn
+++ b/src/app/clusters/BUILD.gn
@@ -42,6 +42,7 @@ source_set("clusters") {
     "diagnostic-logs-server",
     "dishwasher-alarm-server",
     "dynamic-lighting-server",
+    "electrical-alarm-server",
     "electrical-distribution-server",
     "electrical-energy-measurement-server",
     "electrical-power-measurement-server",

--- a/src/app/clusters/electrical-alarm-server/BUILD.gn
+++ b/src/app/clusters/electrical-alarm-server/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+source_set("electrical-alarm-server") {
+  sources = [
+    "CodegenIntegration.cpp",
+    "CodegenIntegration.h",
+    "ElectricalAlarmCluster.cpp",
+    "ElectricalAlarmCluster.h",
+    "electrical-alarm-delegate.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app/data-model-provider",
+    "${chip_root}/src/app/server",
+    "${chip_root}/src/app/server-cluster",
+    "${chip_root}/zzz_generated/app-common/clusters/ElectricalAlarm",
+  ]
+}

--- a/src/app/clusters/electrical-alarm-server/BUILD.gn
+++ b/src/app/clusters/electrical-alarm-server/BUILD.gn
@@ -16,8 +16,6 @@ import("//build_overrides/chip.gni")
 
 source_set("electrical-alarm-server") {
   sources = [
-    "CodegenIntegration.cpp",
-    "CodegenIntegration.h",
     "ElectricalAlarmCluster.cpp",
     "ElectricalAlarmCluster.h",
     "electrical-alarm-delegate.h",
@@ -27,6 +25,7 @@ source_set("electrical-alarm-server") {
     "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/server-cluster",
+    "${chip_root}/src/lib/support",
     "${chip_root}/zzz_generated/app-common/clusters/ElectricalAlarm",
   ]
 }

--- a/src/app/clusters/electrical-alarm-server/CodegenIntegration.cpp
+++ b/src/app/clusters/electrical-alarm-server/CodegenIntegration.cpp
@@ -26,15 +26,23 @@ namespace ElectricalAlarm {
 
 CHIP_ERROR Instance::Init()
 {
-    return CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
+    VerifyOrReturnError(!mRegistered, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration()));
+    mRegistered = true;
+    return CHIP_NO_ERROR;
 }
 
 void Instance::Shutdown()
 {
+    VerifyOrReturn(mRegistered);
+    mRegistered = false;
+
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&mCluster.Cluster());
     if (err != CHIP_NO_ERROR)
     {
+#if CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
         ChipLogError(AppServer, "Failed to unregister Electrical Alarm cluster: %" CHIP_ERROR_FORMAT, err.Format());
+#endif // CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
     }
 }
 

--- a/src/app/clusters/electrical-alarm-server/CodegenIntegration.cpp
+++ b/src/app/clusters/electrical-alarm-server/CodegenIntegration.cpp
@@ -1,0 +1,48 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/electrical-alarm-server/CodegenIntegration.h>
+
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalAlarm {
+
+CHIP_ERROR Instance::Init()
+{
+    return CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
+}
+
+void Instance::Shutdown()
+{
+    CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&mCluster.Cluster());
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "Failed to unregister Electrical Alarm cluster: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
+
+} // namespace ElectricalAlarm
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
+void MatterElectricalAlarmClusterInitCallback(chip::EndpointId endpoint) {}
+
+void MatterElectricalAlarmClusterShutdownCallback(chip::EndpointId endpoint, MatterClusterShutdownType) {}

--- a/src/app/clusters/electrical-alarm-server/CodegenIntegration.cpp
+++ b/src/app/clusters/electrical-alarm-server/CodegenIntegration.cpp
@@ -18,6 +18,7 @@
 #include <app/clusters/electrical-alarm-server/CodegenIntegration.h>
 
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
+#include <data-model-providers/codegen/CodegenProcessingConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/clusters/electrical-alarm-server/CodegenIntegration.cpp
+++ b/src/app/clusters/electrical-alarm-server/CodegenIntegration.cpp
@@ -43,6 +43,8 @@ void Instance::Shutdown()
 } // namespace app
 } // namespace chip
 
-void MatterElectricalAlarmClusterInitCallback(chip::EndpointId endpoint) {}
-
-void MatterElectricalAlarmClusterShutdownCallback(chip::EndpointId endpoint, MatterClusterShutdownType) {}
+// Weak stubs — an app that registers ESALM imperatively provides strong overrides.
+__attribute__((weak)) void MatterElectricalAlarmPluginServerInitCallback() {}
+__attribute__((weak)) void MatterElectricalAlarmPluginServerShutdownCallback() {}
+__attribute__((weak)) void MatterElectricalAlarmClusterInitCallback(chip::EndpointId) {}
+__attribute__((weak)) void MatterElectricalAlarmClusterShutdownCallback(chip::EndpointId, MatterClusterShutdownType) {}

--- a/src/app/clusters/electrical-alarm-server/CodegenIntegration.h
+++ b/src/app/clusters/electrical-alarm-server/CodegenIntegration.h
@@ -38,11 +38,19 @@ public:
     {}
     ~Instance() { Shutdown(); }
 
+    Instance(const Instance &)             = delete;
+    Instance(Instance &&)                  = delete;
+    Instance & operator=(const Instance &) = delete;
+    Instance & operator=(Instance &&)      = delete;
+
     CHIP_ERROR Init();
     void Shutdown();
 
+    ElectricalAlarmCluster & Cluster() { return mCluster.Cluster(); }
+
 private:
     RegisteredServerCluster<ElectricalAlarmCluster> mCluster;
+    bool mRegistered = false;
 };
 
 } // namespace ElectricalAlarm

--- a/src/app/clusters/electrical-alarm-server/CodegenIntegration.h
+++ b/src/app/clusters/electrical-alarm-server/CodegenIntegration.h
@@ -29,7 +29,7 @@ namespace ElectricalAlarm {
 class Instance
 {
 public:
-    Instance(EndpointId aEndpointId, Delegate & aDelegate, BitMask<Feature> aFeatures) :
+    Instance(EndpointId aEndpointId, Delegate * aDelegate, BitMask<Feature> aFeatures) :
         mCluster(ElectricalAlarmCluster::Config{
             .endpointId = aEndpointId,
             .delegate   = aDelegate,

--- a/src/app/clusters/electrical-alarm-server/CodegenIntegration.h
+++ b/src/app/clusters/electrical-alarm-server/CodegenIntegration.h
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h>
+#include <app/clusters/electrical-alarm-server/electrical-alarm-delegate.h>
+#include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalAlarm {
+
+class Instance
+{
+public:
+    Instance(EndpointId aEndpointId, Delegate & aDelegate, BitMask<Feature> aFeatures) :
+        mCluster(ElectricalAlarmCluster::Config{
+            .endpointId = aEndpointId,
+            .delegate   = aDelegate,
+            .features   = aFeatures,
+        })
+    {}
+    ~Instance() { Shutdown(); }
+
+    CHIP_ERROR Init();
+    void Shutdown();
+
+private:
+    RegisteredServerCluster<ElectricalAlarmCluster> mCluster;
+};
+
+} // namespace ElectricalAlarm
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -90,61 +90,61 @@ DataModel::ActionReturnStatus ElectricalAlarmCluster::ReadAttribute(const DataMo
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mOverVoltageThreshold.value());
+        return encoder.Encode(mOverVoltageThreshold);
     case Attributes::UnderVoltageThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderVoltage))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mUnderVoltageThreshold.value());
+        return encoder.Encode(mUnderVoltageThreshold);
     case Attributes::OverFrequencyThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverFrequency))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mOverFrequencyThreshold.value());
+        return encoder.Encode(mOverFrequencyThreshold);
     case Attributes::UnderFrequencyThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderFrequency))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mUnderFrequencyThreshold.value());
+        return encoder.Encode(mUnderFrequencyThreshold);
     case Attributes::OverPowerThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverPower))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mOverPowerThreshold.value());
+        return encoder.Encode(mOverPowerThreshold);
     case Attributes::UnderPowerThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderPower))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mUnderPowerThreshold.value());
+        return encoder.Encode(mUnderPowerThreshold);
     case Attributes::OverCurrentThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverCurrent))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mOverCurrentThreshold.value());
+        return encoder.Encode(mOverCurrentThreshold);
     case Attributes::UnderCurrentThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderCurrent))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mUnderCurrentThreshold.value());
+        return encoder.Encode(mUnderCurrentThreshold);
     case Attributes::PowerImportThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kPowerImport))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mPowerImportThreshold.value());
+        return encoder.Encode(mPowerImportThreshold);
     case Attributes::PowerExportThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kPowerExport))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mPowerExportThreshold.value());
+        return encoder.Encode(mPowerExportThreshold);
     default:
         return Status::UnsupportedAttribute;
     }
@@ -347,7 +347,7 @@ Status ElectricalAlarmCluster::ResetLatchedAlarms(BitMask<AlarmBitmap> alarms)
 Status ElectricalAlarmCluster::SetOverVoltageThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverVoltage), Status::UnsupportedAttribute);
-    if (!mOverVoltageThreshold.has_value() || *mOverVoltageThreshold != value)
+    if (mOverVoltageThreshold != value)
     {
         mOverVoltageThreshold = value;
         NotifyAttributeChanged(Attributes::OverVoltageThreshold::Id);
@@ -358,7 +358,7 @@ Status ElectricalAlarmCluster::SetOverVoltageThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetUnderVoltageThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderVoltage), Status::UnsupportedAttribute);
-    if (!mUnderVoltageThreshold.has_value() || *mUnderVoltageThreshold != value)
+    if (mUnderVoltageThreshold != value)
     {
         mUnderVoltageThreshold = value;
         NotifyAttributeChanged(Attributes::UnderVoltageThreshold::Id);
@@ -369,7 +369,7 @@ Status ElectricalAlarmCluster::SetUnderVoltageThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetOverFrequencyThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverFrequency), Status::UnsupportedAttribute);
-    if (!mOverFrequencyThreshold.has_value() || *mOverFrequencyThreshold != value)
+    if (mOverFrequencyThreshold != value)
     {
         mOverFrequencyThreshold = value;
         NotifyAttributeChanged(Attributes::OverFrequencyThreshold::Id);
@@ -380,7 +380,7 @@ Status ElectricalAlarmCluster::SetOverFrequencyThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetUnderFrequencyThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderFrequency), Status::UnsupportedAttribute);
-    if (!mUnderFrequencyThreshold.has_value() || *mUnderFrequencyThreshold != value)
+    if (mUnderFrequencyThreshold != value)
     {
         mUnderFrequencyThreshold = value;
         NotifyAttributeChanged(Attributes::UnderFrequencyThreshold::Id);
@@ -391,7 +391,7 @@ Status ElectricalAlarmCluster::SetUnderFrequencyThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetOverPowerThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverPower), Status::UnsupportedAttribute);
-    if (!mOverPowerThreshold.has_value() || *mOverPowerThreshold != value)
+    if (mOverPowerThreshold != value)
     {
         mOverPowerThreshold = value;
         NotifyAttributeChanged(Attributes::OverPowerThreshold::Id);
@@ -402,7 +402,7 @@ Status ElectricalAlarmCluster::SetOverPowerThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetUnderPowerThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderPower), Status::UnsupportedAttribute);
-    if (!mUnderPowerThreshold.has_value() || *mUnderPowerThreshold != value)
+    if (mUnderPowerThreshold != value)
     {
         mUnderPowerThreshold = value;
         NotifyAttributeChanged(Attributes::UnderPowerThreshold::Id);
@@ -413,7 +413,7 @@ Status ElectricalAlarmCluster::SetUnderPowerThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetOverCurrentThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverCurrent), Status::UnsupportedAttribute);
-    if (!mOverCurrentThreshold.has_value() || *mOverCurrentThreshold != value)
+    if (mOverCurrentThreshold != value)
     {
         mOverCurrentThreshold = value;
         NotifyAttributeChanged(Attributes::OverCurrentThreshold::Id);
@@ -424,7 +424,7 @@ Status ElectricalAlarmCluster::SetOverCurrentThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetUnderCurrentThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderCurrent), Status::UnsupportedAttribute);
-    if (!mUnderCurrentThreshold.has_value() || *mUnderCurrentThreshold != value)
+    if (mUnderCurrentThreshold != value)
     {
         mUnderCurrentThreshold = value;
         NotifyAttributeChanged(Attributes::UnderCurrentThreshold::Id);
@@ -435,7 +435,7 @@ Status ElectricalAlarmCluster::SetUnderCurrentThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetPowerImportThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kPowerImport), Status::UnsupportedAttribute);
-    if (!mPowerImportThreshold.has_value() || *mPowerImportThreshold != value)
+    if (mPowerImportThreshold != value)
     {
         mPowerImportThreshold = value;
         NotifyAttributeChanged(Attributes::PowerImportThreshold::Id);
@@ -446,7 +446,7 @@ Status ElectricalAlarmCluster::SetPowerImportThreshold(int64_t value)
 Status ElectricalAlarmCluster::SetPowerExportThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kPowerExport), Status::UnsupportedAttribute);
-    if (!mPowerExportThreshold.has_value() || *mPowerExportThreshold != value)
+    if (mPowerExportThreshold != value)
     {
         mPowerExportThreshold = value;
         NotifyAttributeChanged(Attributes::PowerExportThreshold::Id);
@@ -548,26 +548,26 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
     };
 
     Status s;
-    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold.value(),
-                       mFeatureFlags.Has(Feature::kOverVoltage), mUnderVoltageThreshold.value(),
+    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold,
+                       mFeatureFlags.Has(Feature::kOverVoltage), mUnderVoltageThreshold,
                        mFeatureFlags.Has(Feature::kUnderVoltage))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold, mOverFrequencyThreshold.value(),
-                       mFeatureFlags.Has(Feature::kOverFrequency), mUnderFrequencyThreshold.value(),
+    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold, mOverFrequencyThreshold,
+                       mFeatureFlags.Has(Feature::kOverFrequency), mUnderFrequencyThreshold,
                        mFeatureFlags.Has(Feature::kUnderFrequency))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold.value(),
-                       mFeatureFlags.Has(Feature::kOverPower), mUnderPowerThreshold.value(),
+    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold,
+                       mFeatureFlags.Has(Feature::kOverPower), mUnderPowerThreshold,
                        mFeatureFlags.Has(Feature::kUnderPower))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, mOverCurrentThreshold.value(),
-                       mFeatureFlags.Has(Feature::kOverCurrent), mUnderCurrentThreshold.value(),
+    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, mOverCurrentThreshold,
+                       mFeatureFlags.Has(Feature::kOverCurrent), mUnderCurrentThreshold,
                        mFeatureFlags.Has(Feature::kUnderCurrent))) != Status::Success)
     {
         return s;
@@ -575,8 +575,8 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
     // PowerImport/Export: (0, 0) is valid quiescent state; otherwise import must be > export.
     if (data.powerImportThreshold.HasValue() || data.powerExportThreshold.HasValue())
     {
-        int64_t resolvedImport = data.powerImportThreshold.ValueOr(mPowerImportThreshold.value());
-        int64_t resolvedExport = data.powerExportThreshold.ValueOr(mPowerExportThreshold.value());
+        int64_t resolvedImport = data.powerImportThreshold.ValueOr(mPowerImportThreshold);
+        int64_t resolvedExport = data.powerExportThreshold.ValueOr(mPowerExportThreshold);
         if (!(resolvedImport == 0 && resolvedExport == 0) && resolvedImport <= resolvedExport)
         {
             return Status::ConstraintError;

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -561,8 +561,8 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
         return s;
     }
     if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold,
-                       mFeatureFlags.Has(Feature::kOverPower), mUnderPowerThreshold,
-                       mFeatureFlags.Has(Feature::kUnderPower))) != Status::Success)
+                       mFeatureFlags.Has(Feature::kOverPower), mUnderPowerThreshold, mFeatureFlags.Has(Feature::kUnderPower))) !=
+        Status::Success)
     {
         return s;
     }

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -497,6 +497,23 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
         return Status::UnsupportedCommand;
     }
 
+    // Validate that every supplied field targets a feature that is present. Do this before any
+    // constraint check or state mutation so the command is either fully accepted or fully rejected —
+    // applying some fields and then failing on a later one would leave state partially mutated.
+    if ((data.overVoltageThreshold.HasValue() && !mFeatureFlags.Has(Feature::kOverVoltage)) ||
+        (data.underVoltageThreshold.HasValue() && !mFeatureFlags.Has(Feature::kUnderVoltage)) ||
+        (data.overFrequencyThreshold.HasValue() && !mFeatureFlags.Has(Feature::kOverFrequency)) ||
+        (data.underFrequencyThreshold.HasValue() && !mFeatureFlags.Has(Feature::kUnderFrequency)) ||
+        (data.overPowerThreshold.HasValue() && !mFeatureFlags.Has(Feature::kOverPower)) ||
+        (data.underPowerThreshold.HasValue() && !mFeatureFlags.Has(Feature::kUnderPower)) ||
+        (data.overCurrentThreshold.HasValue() && !mFeatureFlags.Has(Feature::kOverCurrent)) ||
+        (data.underCurrentThreshold.HasValue() && !mFeatureFlags.Has(Feature::kUnderCurrent)) ||
+        (data.powerImportThreshold.HasValue() && !mFeatureFlags.Has(Feature::kPowerImport)) ||
+        (data.powerExportThreshold.HasValue() && !mFeatureFlags.Has(Feature::kPowerExport)))
+    {
+        return Status::InvalidCommand;
+    }
+
     // Validate absolute per-field constraints before cross-pair ordering.
     // PowerImportThreshold min 0, PowerExportThreshold max 0 (from spec and XML).
     if (data.powerImportThreshold.HasValue() && data.powerImportThreshold.Value() < 0)
@@ -572,66 +589,47 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
         return Status::Failure;
     }
 
-    // Persist each present field via the setter so SetAttributeValue fires for subscriptions.
-    // If a field is present in the command but the corresponding alarm-class feature is absent,
-    // the setter returns UnsupportedAttribute — treat that as InvalidCommand so the caller
-    // knows the field was not accepted rather than silently dropping it.
-    auto applyThreshold = [](Status result) -> Status {
-        if (result == Status::UnsupportedAttribute)
-        {
-            return Status::InvalidCommand;
-        }
-        return result;
-    };
+    // Commit: all fields have been validated; apply each present field. Feature presence was
+    // already checked above so each setter returns Success.
     if (data.overVoltageThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetOverVoltageThreshold(data.overVoltageThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetOverVoltageThreshold(data.overVoltageThreshold.Value());
     }
     if (data.underVoltageThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetUnderVoltageThreshold(data.underVoltageThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetUnderVoltageThreshold(data.underVoltageThreshold.Value());
     }
     if (data.overFrequencyThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetOverFrequencyThreshold(data.overFrequencyThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetOverFrequencyThreshold(data.overFrequencyThreshold.Value());
     }
     if (data.underFrequencyThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetUnderFrequencyThreshold(data.underFrequencyThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetUnderFrequencyThreshold(data.underFrequencyThreshold.Value());
     }
     if (data.overPowerThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetOverPowerThreshold(data.overPowerThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetOverPowerThreshold(data.overPowerThreshold.Value());
     }
     if (data.underPowerThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetUnderPowerThreshold(data.underPowerThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetUnderPowerThreshold(data.underPowerThreshold.Value());
     }
     if (data.overCurrentThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetOverCurrentThreshold(data.overCurrentThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetOverCurrentThreshold(data.overCurrentThreshold.Value());
     }
     if (data.underCurrentThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetUnderCurrentThreshold(data.underCurrentThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetUnderCurrentThreshold(data.underCurrentThreshold.Value());
     }
     if (data.powerImportThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetPowerImportThreshold(data.powerImportThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetPowerImportThreshold(data.powerImportThreshold.Value());
     }
     if (data.powerExportThreshold.HasValue())
     {
-        VerifyOrReturnValue(applyThreshold(SetPowerExportThreshold(data.powerExportThreshold.Value())) == Status::Success,
-                            Status::InvalidCommand);
+        SetPowerExportThreshold(data.powerExportThreshold.Value());
     }
 
     return Status::Success;

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -40,6 +40,12 @@ namespace ElectricalAlarm {
 
 CHIP_ERROR ElectricalAlarmCluster::Startup(ServerClusterContext & context)
 {
+    if (mDelegate == nullptr)
+    {
+        ChipLogError(Zcl, "ElectricalAlarm ep %u: no delegate set — ModifyEnabledAlarms and Reset commands will be auto-approved",
+                     static_cast<unsigned>(mPath.mEndpointId));
+    }
+
     // ADJUST feature is only meaningful when at least one alarm-class feature is present.
     if (mFeatureFlags.Has(Feature::kAdjustableThresholds))
     {
@@ -234,20 +240,22 @@ std::optional<DataModel::ActionReturnStatus> ElectricalAlarmCluster::InvokeComma
 
 Status ElectricalAlarmCluster::SetSupportedValue(BitMask<AlarmBitmap> supported)
 {
-    SetAttributeValue(mSupported, supported, Attributes::Supported::Id);
-
-    // Latch must be a subset of Supported.
+    // Narrow Latch and Mask before committing Supported so the cascade path (SetMaskValue →
+    // SetStateValue) always sees a consistent mSupported. The narrowed arguments are strict
+    // subsets of the new Supported value, so neither cascade call can fail its subset guards.
     if (mFeatureFlags.Has(Feature::kReset) && !supported.HasAll(mLatch))
     {
         SetAttributeValue(mLatch, mLatch & supported, Attributes::Latch::Id);
     }
 
-    // Mask must be a subset of Supported; cascade to State.
     if (!supported.HasAll(mMask))
     {
-        // SetMaskValue cascades to State — call it to get the cascade.
+        // SetMaskValue validates mask ⊆ mSupported; update mSupported first so the check passes.
+        SetAttributeValue(mSupported, supported, Attributes::Supported::Id);
         return SetMaskValue(mMask & supported);
     }
+
+    SetAttributeValue(mSupported, supported, Attributes::Supported::Id);
     return Status::Success;
 }
 
@@ -308,7 +316,7 @@ Status ElectricalAlarmCluster::SetStateValue(BitMask<AlarmBitmap> newState, bool
     BitMask<AlarmBitmap> becameInactive;
     becameInactive.Set(mState).Clear(finalNewState);
 
-    mState = finalNewState;
+    SetAttributeValue(mState, finalNewState, Attributes::State::Id);
     if (becameActive.HasAny() || becameInactive.HasAny())
     {
         SendNotifyEvent(becameActive, becameInactive, mState, mMask);
@@ -318,6 +326,10 @@ Status ElectricalAlarmCluster::SetStateValue(BitMask<AlarmBitmap> newState, bool
 
 Status ElectricalAlarmCluster::ResetLatchedAlarms(BitMask<AlarmBitmap> alarms)
 {
+    if (!mFeatureFlags.Has(Feature::kReset))
+    {
+        return Status::UnsupportedCommand;
+    }
     if (!mSupported.HasAll(alarms))
     {
         ChipLogProgress(Zcl, "ElectricalAlarm: Reset bitmap contains unsupported alarms");
@@ -335,70 +347,80 @@ Status ElectricalAlarmCluster::ResetLatchedAlarms(BitMask<AlarmBitmap> alarms)
 Status ElectricalAlarmCluster::SetOverVoltageThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverVoltage), Status::UnsupportedAttribute);
-    mOverVoltageThreshold = value;
+    SetAttributeValue(mOverVoltageThreshold, value, Attributes::OverVoltageThreshold::Id);
+    mOverVoltageThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetUnderVoltageThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderVoltage), Status::UnsupportedAttribute);
-    mUnderVoltageThreshold = value;
+    SetAttributeValue(mUnderVoltageThreshold, value, Attributes::UnderVoltageThreshold::Id);
+    mUnderVoltageThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetOverFrequencyThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverFrequency), Status::UnsupportedAttribute);
-    mOverFrequencyThreshold = value;
+    SetAttributeValue(mOverFrequencyThreshold, value, Attributes::OverFrequencyThreshold::Id);
+    mOverFrequencyThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetUnderFrequencyThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderFrequency), Status::UnsupportedAttribute);
-    mUnderFrequencyThreshold = value;
+    SetAttributeValue(mUnderFrequencyThreshold, value, Attributes::UnderFrequencyThreshold::Id);
+    mUnderFrequencyThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetOverPowerThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverPower), Status::UnsupportedAttribute);
-    mOverPowerThreshold = value;
+    SetAttributeValue(mOverPowerThreshold, value, Attributes::OverPowerThreshold::Id);
+    mOverPowerThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetUnderPowerThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderPower), Status::UnsupportedAttribute);
-    mUnderPowerThreshold = value;
+    SetAttributeValue(mUnderPowerThreshold, value, Attributes::UnderPowerThreshold::Id);
+    mUnderPowerThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetOverCurrentThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverCurrent), Status::UnsupportedAttribute);
-    mOverCurrentThreshold = value;
+    SetAttributeValue(mOverCurrentThreshold, value, Attributes::OverCurrentThreshold::Id);
+    mOverCurrentThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetUnderCurrentThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderCurrent), Status::UnsupportedAttribute);
-    mUnderCurrentThreshold = value;
+    SetAttributeValue(mUnderCurrentThreshold, value, Attributes::UnderCurrentThreshold::Id);
+    mUnderCurrentThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetPowerImportThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kPowerImport), Status::UnsupportedAttribute);
-    mPowerImportThreshold = value;
+    SetAttributeValue(mPowerImportThreshold, value, Attributes::PowerImportThreshold::Id);
+    mPowerImportThresholdSet = true;
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetPowerExportThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kPowerExport), Status::UnsupportedAttribute);
-    mPowerExportThreshold = value;
+    SetAttributeValue(mPowerExportThreshold, value, Attributes::PowerExportThreshold::Id);
+    mPowerExportThresholdSet = true;
     return Status::Success;
 }
 
@@ -412,7 +434,7 @@ Status ElectricalAlarmCluster::HandleModifyEnabledAlarms(BitMask<AlarmBitmap> ma
     {
         return Status::InvalidCommand;
     }
-    if (!mDelegate.ModifyEnabledAlarmsCallback(mask))
+    if (mDelegate != nullptr && !mDelegate->ModifyEnabledAlarmsCallback(mask))
     {
         ChipLogProgress(Zcl, "ElectricalAlarm: delegate rejected ModifyEnabledAlarms");
         return Status::Failure;
@@ -426,7 +448,7 @@ Status ElectricalAlarmCluster::HandleReset(BitMask<AlarmBitmap> alarms)
     {
         return Status::UnsupportedCommand;
     }
-    if (!mDelegate.ResetAlarmsCallback(alarms))
+    if (mDelegate != nullptr && !mDelegate->ResetAlarmsCallback(alarms))
     {
         ChipLogProgress(Zcl, "ElectricalAlarm: delegate rejected Reset");
         return Status::Failure;
@@ -441,109 +463,125 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
         return Status::UnsupportedCommand;
     }
 
-    // Validate cross-pair ordering: Over must be > Under for each measurement type.
-    // The check is only applied when both sides are known: either supplied in this command
-    // or previously persisted (non-zero stored value). When only one side is provided and
-    // the other side's stored value is still at the default (0), there is no baseline to
-    // compare against, so we skip the cross-pair constraint for that direction.
+    // Validate cross-pair ordering. Both the incoming optional value AND any previously-persisted
+    // value count as a known baseline. mXxxThresholdSet flags distinguish an explicit zero from
+    // "not yet set" (0 is a valid threshold value per the spec).
+    //
+    // strictOver=true:  over must be strictly > under (voltage, frequency, power, current pairs).
+    // strictOver=false: over must be >= under (import/export — both may be 0 simultaneously, since
+    //                   import=0 and export=0 is a valid quiescent state per attribute constraints).
     auto checkPair = [&](const Optional<int64_t> & over, const Optional<int64_t> & under, int64_t storedOver,
-                         int64_t storedUnder) -> Status {
+                         bool storedOverSet, int64_t storedUnder, bool storedUnderSet, bool strictOver = true) -> Status {
         if (!over.HasValue() && !under.HasValue())
         {
             return Status::Success;
         }
-        // Skip cross-pair check when only one side is supplied and the other has no stored baseline.
-        const bool overKnown  = over.HasValue() || (storedOver != 0);
-        const bool underKnown = under.HasValue() || (storedUnder != 0);
+        const bool overKnown  = over.HasValue() || storedOverSet;
+        const bool underKnown = under.HasValue() || storedUnderSet;
         if (!overKnown || !underKnown)
         {
             return Status::Success;
         }
         int64_t resolvedOver  = over.ValueOr(storedOver);
         int64_t resolvedUnder = under.ValueOr(storedUnder);
-        if (resolvedOver <= resolvedUnder)
-        {
-            return Status::ConstraintError;
-        }
-        return Status::Success;
+        const bool violated   = strictOver ? (resolvedOver <= resolvedUnder) : (resolvedOver < resolvedUnder);
+        return violated ? Status::ConstraintError : Status::Success;
     };
 
     Status s;
-    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold, mUnderVoltageThreshold)) !=
-        Status::Success)
+    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold,
+                       mOverVoltageThresholdSet, mUnderVoltageThreshold, mUnderVoltageThresholdSet)) != Status::Success)
     {
         return s;
     }
     if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold, mOverFrequencyThreshold,
-                       mUnderFrequencyThreshold)) != Status::Success)
+                       mOverFrequencyThresholdSet, mUnderFrequencyThreshold, mUnderFrequencyThresholdSet)) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold, mUnderPowerThreshold)) !=
-        Status::Success)
+    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold, mOverPowerThresholdSet,
+                       mUnderPowerThreshold, mUnderPowerThresholdSet)) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, mOverCurrentThreshold, mUnderCurrentThreshold)) !=
-        Status::Success)
+    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, mOverCurrentThreshold, mOverCurrentThresholdSet,
+                       mUnderCurrentThreshold, mUnderCurrentThresholdSet)) != Status::Success)
     {
         return s;
     }
-    // PowerImport >= 0 and PowerExport <= 0 are enforced by attribute min/max in ZAP;
-    // the import/export pair uses minOf/maxOf so only validate when both are supplied.
-    if (data.powerImportThreshold.HasValue() && data.powerExportThreshold.HasValue())
+    // PowerImport >= 0 and PowerExport <= 0 by attribute min/max in ZAP. Import=0 and export=0 is a
+    // valid quiescent state (no power flowing), so use strictOver=false (>= rather than >).
+    if ((s = checkPair(data.powerImportThreshold, data.powerExportThreshold, mPowerImportThreshold, mPowerImportThresholdSet,
+                       mPowerExportThreshold, mPowerExportThresholdSet, /*strictOver=*/false)) != Status::Success)
     {
-        if (data.powerImportThreshold.Value() <= data.powerExportThreshold.Value())
-        {
-            return Status::ConstraintError;
-        }
+        return s;
     }
 
-    if (!mDelegate.SetElectricalAlarmThresholdsCallback(data))
+    if (mDelegate != nullptr && !mDelegate->SetElectricalAlarmThresholdsCallback(data))
     {
         return Status::Failure;
     }
 
-    // Persist each present field.
+    // Persist each present field via the setter so SetAttributeValue fires for subscriptions.
+    // If a field is present in the command but the corresponding alarm-class feature is absent,
+    // the setter returns UnsupportedAttribute — treat that as InvalidCommand so the caller
+    // knows the field was not accepted rather than silently dropping it.
+    auto applyThreshold = [](Status result) -> Status {
+        if (result == Status::UnsupportedAttribute)
+        {
+            return Status::InvalidCommand;
+        }
+        return result;
+    };
     if (data.overVoltageThreshold.HasValue())
     {
-        mOverVoltageThreshold = data.overVoltageThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetOverVoltageThreshold(data.overVoltageThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.underVoltageThreshold.HasValue())
     {
-        mUnderVoltageThreshold = data.underVoltageThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetUnderVoltageThreshold(data.underVoltageThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.overFrequencyThreshold.HasValue())
     {
-        mOverFrequencyThreshold = data.overFrequencyThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetOverFrequencyThreshold(data.overFrequencyThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.underFrequencyThreshold.HasValue())
     {
-        mUnderFrequencyThreshold = data.underFrequencyThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetUnderFrequencyThreshold(data.underFrequencyThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.overPowerThreshold.HasValue())
     {
-        mOverPowerThreshold = data.overPowerThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetOverPowerThreshold(data.overPowerThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.underPowerThreshold.HasValue())
     {
-        mUnderPowerThreshold = data.underPowerThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetUnderPowerThreshold(data.underPowerThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.overCurrentThreshold.HasValue())
     {
-        mOverCurrentThreshold = data.overCurrentThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetOverCurrentThreshold(data.overCurrentThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.underCurrentThreshold.HasValue())
     {
-        mUnderCurrentThreshold = data.underCurrentThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetUnderCurrentThreshold(data.underCurrentThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.powerImportThreshold.HasValue())
     {
-        mPowerImportThreshold = data.powerImportThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetPowerImportThreshold(data.powerImportThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
     if (data.powerExportThreshold.HasValue())
     {
-        mPowerExportThreshold = data.powerExportThreshold.Value();
+        VerifyOrReturnValue(applyThreshold(SetPowerExportThreshold(data.powerExportThreshold.Value())) == Status::Success,
+                            Status::InvalidCommand);
     }
 
     return Status::Success;

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -513,9 +513,8 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
     //
     // For voltage/frequency/power/current pairs: over must be strictly > under (over >= under + 1).
     // For import/export: (0, 0) is the valid quiescent state; otherwise over must be > under.
-    auto checkPair = [&](const Optional<int64_t> & over, const Optional<int64_t> & under,
-                         int64_t storedOver, bool overFeatureEnabled,
-                         int64_t storedUnder, bool underFeatureEnabled) -> Status {
+    auto checkPair = [&](const Optional<int64_t> & over, const Optional<int64_t> & under, int64_t storedOver,
+                         bool overFeatureEnabled, int64_t storedUnder, bool underFeatureEnabled) -> Status {
         if (!over.HasValue() && !under.HasValue())
         {
             return Status::Success;
@@ -532,27 +531,27 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
     };
 
     Status s;
-    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold,
-                       *mOverVoltageThreshold, mFeatureFlags.Has(Feature::kOverVoltage),
-                       *mUnderVoltageThreshold, mFeatureFlags.Has(Feature::kUnderVoltage))) != Status::Success)
+    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, *mOverVoltageThreshold,
+                       mFeatureFlags.Has(Feature::kOverVoltage), *mUnderVoltageThreshold,
+                       mFeatureFlags.Has(Feature::kUnderVoltage))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold,
-                       *mOverFrequencyThreshold, mFeatureFlags.Has(Feature::kOverFrequency),
-                       *mUnderFrequencyThreshold, mFeatureFlags.Has(Feature::kUnderFrequency))) != Status::Success)
+    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold, *mOverFrequencyThreshold,
+                       mFeatureFlags.Has(Feature::kOverFrequency), *mUnderFrequencyThreshold,
+                       mFeatureFlags.Has(Feature::kUnderFrequency))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold,
-                       *mOverPowerThreshold, mFeatureFlags.Has(Feature::kOverPower),
-                       *mUnderPowerThreshold, mFeatureFlags.Has(Feature::kUnderPower))) != Status::Success)
+    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, *mOverPowerThreshold,
+                       mFeatureFlags.Has(Feature::kOverPower), *mUnderPowerThreshold, mFeatureFlags.Has(Feature::kUnderPower))) !=
+        Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold,
-                       *mOverCurrentThreshold, mFeatureFlags.Has(Feature::kOverCurrent),
-                       *mUnderCurrentThreshold, mFeatureFlags.Has(Feature::kUnderCurrent))) != Status::Success)
+    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, *mOverCurrentThreshold,
+                       mFeatureFlags.Has(Feature::kOverCurrent), *mUnderCurrentThreshold,
+                       mFeatureFlags.Has(Feature::kUnderCurrent))) != Status::Success)
     {
         return s;
     }

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -49,13 +49,13 @@ CHIP_ERROR ElectricalAlarmCluster::Startup(ServerClusterContext & context)
     // ADJUST feature is only meaningful when at least one alarm-class feature is present.
     if (mFeatureFlags.Has(Feature::kAdjustableThresholds))
     {
-        const bool hasAlarmClass = mFeatureFlags.HasAny(Feature::kOverVoltage, Feature::kUnderVoltage, Feature::kOverFrequency,
-                                                        Feature::kUnderFrequency, Feature::kOverPower, Feature::kUnderPower,
-                                                        Feature::kOverCurrent, Feature::kUnderCurrent, Feature::kPowerImport,
-                                                        Feature::kPowerExport);
+        const bool hasAlarmClass = mFeatureFlags.HasAny(
+            Feature::kOverVoltage, Feature::kUnderVoltage, Feature::kOverFrequency, Feature::kUnderFrequency, Feature::kOverPower,
+            Feature::kUnderPower, Feature::kOverCurrent, Feature::kUnderCurrent, Feature::kPowerImport, Feature::kPowerExport);
         VerifyOrReturnError(hasAlarmClass, CHIP_ERROR_INCORRECT_STATE,
-                            ChipLogError(Zcl, "ElectricalAlarm: AdjustableThresholds feature requires at least one alarm-class "
-                                              "feature to be enabled"));
+                            ChipLogError(Zcl,
+                                         "ElectricalAlarm: AdjustableThresholds feature requires at least one alarm-class "
+                                         "feature to be enabled"));
     }
     return DefaultServerCluster::Startup(context);
 }
@@ -470,8 +470,8 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
     // strictOver=true:  over must be strictly > under (voltage, frequency, power, current pairs).
     // strictOver=false: over must be >= under (import/export — both may be 0 simultaneously, since
     //                   import=0 and export=0 is a valid quiescent state per attribute constraints).
-    auto checkPair = [&](const Optional<int64_t> & over, const Optional<int64_t> & under, int64_t storedOver,
-                         bool storedOverSet, int64_t storedUnder, bool storedUnderSet, bool strictOver = true) -> Status {
+    auto checkPair = [&](const Optional<int64_t> & over, const Optional<int64_t> & under, int64_t storedOver, bool storedOverSet,
+                         int64_t storedUnder, bool storedUnderSet, bool strictOver = true) -> Status {
         if (!over.HasValue() && !under.HasValue())
         {
             return Status::Success;
@@ -489,8 +489,8 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
     };
 
     Status s;
-    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold,
-                       mOverVoltageThresholdSet, mUnderVoltageThreshold, mUnderVoltageThresholdSet)) != Status::Success)
+    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold, mOverVoltageThresholdSet,
+                       mUnderVoltageThreshold, mUnderVoltageThresholdSet)) != Status::Success)
     {
         return s;
     }

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -1,0 +1,570 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h>
+
+#include <app/server-cluster/AttributeListBuilder.h>
+#include <clusters/ElectricalAlarm/Metadata.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::ElectricalAlarm;
+using namespace chip::app::Clusters::ElectricalAlarm::Attributes;
+using namespace chip::app::Clusters::ElectricalAlarm::Commands;
+
+using chip::Protocols::InteractionModel::Status;
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalAlarm {
+
+// ---------------------------------------------------------------------------
+// Startup: validate feature constraints
+// ---------------------------------------------------------------------------
+
+CHIP_ERROR ElectricalAlarmCluster::Startup(ServerClusterContext & context)
+{
+    // ADJUST feature is only meaningful when at least one alarm-class feature is present.
+    if (mFeatureFlags.Has(Feature::kAdjustableThresholds))
+    {
+        const bool hasAlarmClass = mFeatureFlags.HasAny(Feature::kOverVoltage, Feature::kUnderVoltage, Feature::kOverFrequency,
+                                                        Feature::kUnderFrequency, Feature::kOverPower, Feature::kUnderPower,
+                                                        Feature::kOverCurrent, Feature::kUnderCurrent, Feature::kPowerImport,
+                                                        Feature::kPowerExport);
+        VerifyOrReturnError(hasAlarmClass, CHIP_ERROR_INCORRECT_STATE,
+                            ChipLogError(Zcl, "ElectricalAlarm: AdjustableThresholds feature requires at least one alarm-class "
+                                              "feature to be enabled"));
+    }
+    return DefaultServerCluster::Startup(context);
+}
+
+// ---------------------------------------------------------------------------
+// ReadAttribute
+// ---------------------------------------------------------------------------
+
+DataModel::ActionReturnStatus ElectricalAlarmCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                                    AttributeValueEncoder & encoder)
+{
+    switch (request.path.mAttributeId)
+    {
+    case Attributes::FeatureMap::Id:
+        return encoder.Encode(mFeatureFlags);
+    case Attributes::ClusterRevision::Id:
+        return encoder.Encode(kRevision);
+    case Attributes::Mask::Id:
+        return encoder.Encode(mMask);
+    case Attributes::State::Id:
+        return encoder.Encode(mState);
+    case Attributes::Supported::Id:
+        return encoder.Encode(mSupported);
+    case Attributes::Latch::Id:
+        if (!mFeatureFlags.Has(Feature::kReset))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mLatch);
+    case Attributes::OverVoltageThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kOverVoltage))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mOverVoltageThreshold);
+    case Attributes::UnderVoltageThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kUnderVoltage))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mUnderVoltageThreshold);
+    case Attributes::OverFrequencyThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kOverFrequency))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mOverFrequencyThreshold);
+    case Attributes::UnderFrequencyThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kUnderFrequency))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mUnderFrequencyThreshold);
+    case Attributes::OverPowerThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kOverPower))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mOverPowerThreshold);
+    case Attributes::UnderPowerThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kUnderPower))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mUnderPowerThreshold);
+    case Attributes::OverCurrentThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kOverCurrent))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mOverCurrentThreshold);
+    case Attributes::UnderCurrentThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kUnderCurrent))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mUnderCurrentThreshold);
+    case Attributes::PowerImportThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kPowerImport))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mPowerImportThreshold);
+    case Attributes::PowerExportThreshold::Id:
+        if (!mFeatureFlags.Has(Feature::kPowerExport))
+        {
+            return Status::UnsupportedAttribute;
+        }
+        return encoder.Encode(mPowerExportThreshold);
+    default:
+        return Status::UnsupportedAttribute;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Attributes
+// ---------------------------------------------------------------------------
+
+CHIP_ERROR ElectricalAlarmCluster::Attributes(const ConcreteClusterPath & path,
+                                              ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
+{
+    const AttributeListBuilder::OptionalAttributeEntry optionalAttributes[] = {
+        { mFeatureFlags.Has(Feature::kReset), Attributes::Latch::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kOverVoltage), Attributes::OverVoltageThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kUnderVoltage), Attributes::UnderVoltageThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kOverFrequency), Attributes::OverFrequencyThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kUnderFrequency), Attributes::UnderFrequencyThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kOverPower), Attributes::OverPowerThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kUnderPower), Attributes::UnderPowerThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kOverCurrent), Attributes::OverCurrentThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kUnderCurrent), Attributes::UnderCurrentThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kPowerImport), Attributes::PowerImportThreshold::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kPowerExport), Attributes::PowerExportThreshold::kMetadataEntry },
+    };
+
+    AttributeListBuilder listBuilder(builder);
+    return listBuilder.Append(Span(Attributes::kMandatoryMetadata), Span(optionalAttributes));
+}
+
+// ---------------------------------------------------------------------------
+// AcceptedCommands
+// ---------------------------------------------------------------------------
+
+CHIP_ERROR ElectricalAlarmCluster::AcceptedCommands(const ConcreteClusterPath & path,
+                                                    ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
+{
+    // ModifyEnabledAlarms is always available (spec: optionalConform with no feature gate).
+    ReturnErrorOnFailure(builder.AppendElements({ Commands::ModifyEnabledAlarms::kMetadataEntry }));
+    if (mFeatureFlags.Has(Feature::kReset))
+    {
+        ReturnErrorOnFailure(builder.AppendElements({ Commands::Reset::kMetadataEntry }));
+    }
+    if (mFeatureFlags.Has(Feature::kAdjustableThresholds))
+    {
+        ReturnErrorOnFailure(builder.AppendElements({ Commands::SetElectricalAlarmThresholds::kMetadataEntry }));
+    }
+    return CHIP_NO_ERROR;
+}
+
+// ---------------------------------------------------------------------------
+// InvokeCommand
+// ---------------------------------------------------------------------------
+
+std::optional<DataModel::ActionReturnStatus> ElectricalAlarmCluster::InvokeCommand(const DataModel::InvokeRequest & request,
+                                                                                   TLV::TLVReader & input_arguments,
+                                                                                   CommandHandler * handler)
+{
+    switch (request.path.mCommandId)
+    {
+    case Commands::Reset::Id: {
+        Commands::Reset::DecodableType data;
+        if (data.Decode(input_arguments) != CHIP_NO_ERROR)
+        {
+            return Status::InvalidCommand;
+        }
+        return HandleReset(data.alarms);
+    }
+    case Commands::ModifyEnabledAlarms::Id: {
+        Commands::ModifyEnabledAlarms::DecodableType data;
+        if (data.Decode(input_arguments) != CHIP_NO_ERROR)
+        {
+            return Status::InvalidCommand;
+        }
+        return HandleModifyEnabledAlarms(data.mask);
+    }
+    case Commands::SetElectricalAlarmThresholds::Id: {
+        Commands::SetElectricalAlarmThresholds::DecodableType data;
+        if (data.Decode(input_arguments) != CHIP_NO_ERROR)
+        {
+            return Status::InvalidCommand;
+        }
+        return HandleSetThresholds(data);
+    }
+    default:
+        return Status::UnsupportedCommand;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Alarm Base attribute setters
+// ---------------------------------------------------------------------------
+
+Status ElectricalAlarmCluster::SetSupportedValue(BitMask<AlarmBitmap> supported)
+{
+    SetAttributeValue(mSupported, supported, Attributes::Supported::Id);
+
+    // Latch must be a subset of Supported.
+    if (mFeatureFlags.Has(Feature::kReset) && !supported.HasAll(mLatch))
+    {
+        SetAttributeValue(mLatch, mLatch & supported, Attributes::Latch::Id);
+    }
+
+    // Mask must be a subset of Supported; cascade to State.
+    if (!supported.HasAll(mMask))
+    {
+        // SetMaskValue cascades to State — call it to get the cascade.
+        return SetMaskValue(mMask & supported);
+    }
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetMaskValue(BitMask<AlarmBitmap> mask)
+{
+    if (!mSupported.HasAll(mask))
+    {
+        ChipLogProgress(Zcl, "ElectricalAlarm: Mask contains unsupported bits");
+        return Status::Failure;
+    }
+    SetAttributeValue(mMask, mask, Attributes::Mask::Id);
+
+    // State must be a subset of Mask; trim newly-suppressed alarms.
+    if (!mask.HasAll(mState))
+    {
+        return SetStateValue(mState & mask, /*ignoreLatchState=*/true);
+    }
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetLatchValue(BitMask<AlarmBitmap> latch)
+{
+    if (!mFeatureFlags.Has(Feature::kReset))
+    {
+        return Status::UnsupportedAttribute;
+    }
+    if (!mSupported.HasAll(latch))
+    {
+        ChipLogProgress(Zcl, "ElectricalAlarm: Latch contains unsupported bits");
+        return Status::Failure;
+    }
+    SetAttributeValue(mLatch, latch, Attributes::Latch::Id);
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetStateValue(BitMask<AlarmBitmap> newState, bool ignoreLatchState)
+{
+    if (!mSupported.HasAll(newState))
+    {
+        ChipLogProgress(Zcl, "ElectricalAlarm: Alarm is not supported");
+        return Status::Failure;
+    }
+    if (!mMask.HasAll(newState))
+    {
+        ChipLogProgress(Zcl, "ElectricalAlarm: Alarm is suppressed");
+        return Status::Failure;
+    }
+
+    BitMask<AlarmBitmap> finalNewState = newState;
+    if (!ignoreLatchState && mFeatureFlags.Has(Feature::kReset))
+    {
+        // Preserve bits that are currently latched active.
+        finalNewState.Set(mLatch & mState);
+    }
+
+    BitMask<AlarmBitmap> becameActive;
+    becameActive.Set(finalNewState).Clear(mState);
+    BitMask<AlarmBitmap> becameInactive;
+    becameInactive.Set(mState).Clear(finalNewState);
+
+    mState = finalNewState;
+    if (becameActive.HasAny() || becameInactive.HasAny())
+    {
+        SendNotifyEvent(becameActive, becameInactive, mState, mMask);
+    }
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::ResetLatchedAlarms(BitMask<AlarmBitmap> alarms)
+{
+    if (!mSupported.HasAll(alarms))
+    {
+        ChipLogProgress(Zcl, "ElectricalAlarm: Reset bitmap contains unsupported alarms");
+        return Status::Failure;
+    }
+    BitMask<AlarmBitmap> newState = mState;
+    newState.Clear(alarms);
+    return SetStateValue(newState, /*ignoreLatchState=*/true);
+}
+
+// ---------------------------------------------------------------------------
+// Threshold setters
+// ---------------------------------------------------------------------------
+
+Status ElectricalAlarmCluster::SetOverVoltageThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverVoltage), Status::UnsupportedAttribute);
+    mOverVoltageThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetUnderVoltageThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderVoltage), Status::UnsupportedAttribute);
+    mUnderVoltageThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetOverFrequencyThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverFrequency), Status::UnsupportedAttribute);
+    mOverFrequencyThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetUnderFrequencyThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderFrequency), Status::UnsupportedAttribute);
+    mUnderFrequencyThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetOverPowerThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverPower), Status::UnsupportedAttribute);
+    mOverPowerThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetUnderPowerThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderPower), Status::UnsupportedAttribute);
+    mUnderPowerThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetOverCurrentThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverCurrent), Status::UnsupportedAttribute);
+    mOverCurrentThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetUnderCurrentThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderCurrent), Status::UnsupportedAttribute);
+    mUnderCurrentThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetPowerImportThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kPowerImport), Status::UnsupportedAttribute);
+    mPowerImportThreshold = value;
+    return Status::Success;
+}
+
+Status ElectricalAlarmCluster::SetPowerExportThreshold(int64_t value)
+{
+    VerifyOrReturnValue(mFeatureFlags.Has(Feature::kPowerExport), Status::UnsupportedAttribute);
+    mPowerExportThreshold = value;
+    return Status::Success;
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers
+// ---------------------------------------------------------------------------
+
+Status ElectricalAlarmCluster::HandleModifyEnabledAlarms(BitMask<AlarmBitmap> mask)
+{
+    if (!mSupported.HasAll(mask))
+    {
+        return Status::InvalidCommand;
+    }
+    if (!mDelegate.ModifyEnabledAlarmsCallback(mask))
+    {
+        ChipLogProgress(Zcl, "ElectricalAlarm: delegate rejected ModifyEnabledAlarms");
+        return Status::Failure;
+    }
+    return SetMaskValue(mask);
+}
+
+Status ElectricalAlarmCluster::HandleReset(BitMask<AlarmBitmap> alarms)
+{
+    if (!mFeatureFlags.Has(Feature::kReset))
+    {
+        return Status::UnsupportedCommand;
+    }
+    if (!mDelegate.ResetAlarmsCallback(alarms))
+    {
+        ChipLogProgress(Zcl, "ElectricalAlarm: delegate rejected Reset");
+        return Status::Failure;
+    }
+    return ResetLatchedAlarms(alarms);
+}
+
+Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectricalAlarmThresholds::DecodableType & data)
+{
+    if (!mFeatureFlags.Has(Feature::kAdjustableThresholds))
+    {
+        return Status::UnsupportedCommand;
+    }
+
+    // Validate cross-pair ordering: Over must be > Under for each measurement type.
+    // The check is only applied when both sides are known: either supplied in this command
+    // or previously persisted (non-zero stored value). When only one side is provided and
+    // the other side's stored value is still at the default (0), there is no baseline to
+    // compare against, so we skip the cross-pair constraint for that direction.
+    auto checkPair = [&](const Optional<int64_t> & over, const Optional<int64_t> & under, int64_t storedOver,
+                         int64_t storedUnder) -> Status {
+        if (!over.HasValue() && !under.HasValue())
+        {
+            return Status::Success;
+        }
+        // Skip cross-pair check when only one side is supplied and the other has no stored baseline.
+        const bool overKnown  = over.HasValue() || (storedOver != 0);
+        const bool underKnown = under.HasValue() || (storedUnder != 0);
+        if (!overKnown || !underKnown)
+        {
+            return Status::Success;
+        }
+        int64_t resolvedOver  = over.ValueOr(storedOver);
+        int64_t resolvedUnder = under.ValueOr(storedUnder);
+        if (resolvedOver <= resolvedUnder)
+        {
+            return Status::ConstraintError;
+        }
+        return Status::Success;
+    };
+
+    Status s;
+    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold, mUnderVoltageThreshold)) !=
+        Status::Success)
+    {
+        return s;
+    }
+    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold, mOverFrequencyThreshold,
+                       mUnderFrequencyThreshold)) != Status::Success)
+    {
+        return s;
+    }
+    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold, mUnderPowerThreshold)) !=
+        Status::Success)
+    {
+        return s;
+    }
+    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, mOverCurrentThreshold, mUnderCurrentThreshold)) !=
+        Status::Success)
+    {
+        return s;
+    }
+    // PowerImport >= 0 and PowerExport <= 0 are enforced by attribute min/max in ZAP;
+    // the import/export pair uses minOf/maxOf so only validate when both are supplied.
+    if (data.powerImportThreshold.HasValue() && data.powerExportThreshold.HasValue())
+    {
+        if (data.powerImportThreshold.Value() <= data.powerExportThreshold.Value())
+        {
+            return Status::ConstraintError;
+        }
+    }
+
+    if (!mDelegate.SetElectricalAlarmThresholdsCallback(data))
+    {
+        return Status::Failure;
+    }
+
+    // Persist each present field.
+    if (data.overVoltageThreshold.HasValue())
+    {
+        mOverVoltageThreshold = data.overVoltageThreshold.Value();
+    }
+    if (data.underVoltageThreshold.HasValue())
+    {
+        mUnderVoltageThreshold = data.underVoltageThreshold.Value();
+    }
+    if (data.overFrequencyThreshold.HasValue())
+    {
+        mOverFrequencyThreshold = data.overFrequencyThreshold.Value();
+    }
+    if (data.underFrequencyThreshold.HasValue())
+    {
+        mUnderFrequencyThreshold = data.underFrequencyThreshold.Value();
+    }
+    if (data.overPowerThreshold.HasValue())
+    {
+        mOverPowerThreshold = data.overPowerThreshold.Value();
+    }
+    if (data.underPowerThreshold.HasValue())
+    {
+        mUnderPowerThreshold = data.underPowerThreshold.Value();
+    }
+    if (data.overCurrentThreshold.HasValue())
+    {
+        mOverCurrentThreshold = data.overCurrentThreshold.Value();
+    }
+    if (data.underCurrentThreshold.HasValue())
+    {
+        mUnderCurrentThreshold = data.underCurrentThreshold.Value();
+    }
+    if (data.powerImportThreshold.HasValue())
+    {
+        mPowerImportThreshold = data.powerImportThreshold.Value();
+    }
+    if (data.powerExportThreshold.HasValue())
+    {
+        mPowerExportThreshold = data.powerExportThreshold.Value();
+    }
+
+    return Status::Success;
+}
+
+// ---------------------------------------------------------------------------
+// Event
+// ---------------------------------------------------------------------------
+
+void ElectricalAlarmCluster::SendNotifyEvent(BitMask<AlarmBitmap> becameActive, BitMask<AlarmBitmap> becameInactive,
+                                             BitMask<AlarmBitmap> newState, BitMask<AlarmBitmap> mask)
+{
+    if (mContext == nullptr)
+    {
+        return;
+    }
+    Events::Notify::Type event{ .active = becameActive, .inactive = becameInactive, .state = newState, .mask = mask };
+    mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
+}
+
+} // namespace ElectricalAlarm
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -90,61 +90,61 @@ DataModel::ActionReturnStatus ElectricalAlarmCluster::ReadAttribute(const DataMo
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mOverVoltageThreshold);
+        return encoder.Encode(mOverVoltageThreshold.value());
     case Attributes::UnderVoltageThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderVoltage))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mUnderVoltageThreshold);
+        return encoder.Encode(mUnderVoltageThreshold.value());
     case Attributes::OverFrequencyThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverFrequency))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mOverFrequencyThreshold);
+        return encoder.Encode(mOverFrequencyThreshold.value());
     case Attributes::UnderFrequencyThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderFrequency))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mUnderFrequencyThreshold);
+        return encoder.Encode(mUnderFrequencyThreshold.value());
     case Attributes::OverPowerThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverPower))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mOverPowerThreshold);
+        return encoder.Encode(mOverPowerThreshold.value());
     case Attributes::UnderPowerThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderPower))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mUnderPowerThreshold);
+        return encoder.Encode(mUnderPowerThreshold.value());
     case Attributes::OverCurrentThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverCurrent))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mOverCurrentThreshold);
+        return encoder.Encode(mOverCurrentThreshold.value());
     case Attributes::UnderCurrentThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderCurrent))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mUnderCurrentThreshold);
+        return encoder.Encode(mUnderCurrentThreshold.value());
     case Attributes::PowerImportThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kPowerImport))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mPowerImportThreshold);
+        return encoder.Encode(mPowerImportThreshold.value());
     case Attributes::PowerExportThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kPowerExport))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(*mPowerExportThreshold);
+        return encoder.Encode(mPowerExportThreshold.value());
     default:
         return Status::UnsupportedAttribute;
     }
@@ -548,26 +548,26 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
     };
 
     Status s;
-    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, *mOverVoltageThreshold,
-                       mFeatureFlags.Has(Feature::kOverVoltage), *mUnderVoltageThreshold,
+    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold.value(),
+                       mFeatureFlags.Has(Feature::kOverVoltage), mUnderVoltageThreshold.value(),
                        mFeatureFlags.Has(Feature::kUnderVoltage))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold, *mOverFrequencyThreshold,
-                       mFeatureFlags.Has(Feature::kOverFrequency), *mUnderFrequencyThreshold,
+    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold, mOverFrequencyThreshold.value(),
+                       mFeatureFlags.Has(Feature::kOverFrequency), mUnderFrequencyThreshold.value(),
                        mFeatureFlags.Has(Feature::kUnderFrequency))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, *mOverPowerThreshold,
-                       mFeatureFlags.Has(Feature::kOverPower), *mUnderPowerThreshold, mFeatureFlags.Has(Feature::kUnderPower))) !=
+    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold.value(),
+                       mFeatureFlags.Has(Feature::kOverPower), mUnderPowerThreshold.value(), mFeatureFlags.Has(Feature::kUnderPower))) !=
         Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, *mOverCurrentThreshold,
-                       mFeatureFlags.Has(Feature::kOverCurrent), *mUnderCurrentThreshold,
+    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, mOverCurrentThreshold.value(),
+                       mFeatureFlags.Has(Feature::kOverCurrent), mUnderCurrentThreshold.value(),
                        mFeatureFlags.Has(Feature::kUnderCurrent))) != Status::Success)
     {
         return s;
@@ -575,8 +575,8 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
     // PowerImport/Export: (0, 0) is valid quiescent state; otherwise import must be > export.
     if (data.powerImportThreshold.HasValue() || data.powerExportThreshold.HasValue())
     {
-        int64_t resolvedImport = data.powerImportThreshold.ValueOr(*mPowerImportThreshold);
-        int64_t resolvedExport = data.powerExportThreshold.ValueOr(*mPowerExportThreshold);
+        int64_t resolvedImport = data.powerImportThreshold.ValueOr(mPowerImportThreshold.value());
+        int64_t resolvedExport = data.powerExportThreshold.ValueOr(mPowerExportThreshold.value());
         if (!(resolvedImport == 0 && resolvedExport == 0) && resolvedImport <= resolvedExport)
         {
             return Status::ConstraintError;

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -90,61 +90,61 @@ DataModel::ActionReturnStatus ElectricalAlarmCluster::ReadAttribute(const DataMo
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mOverVoltageThreshold);
+        return encoder.Encode(*mOverVoltageThreshold);
     case Attributes::UnderVoltageThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderVoltage))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mUnderVoltageThreshold);
+        return encoder.Encode(*mUnderVoltageThreshold);
     case Attributes::OverFrequencyThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverFrequency))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mOverFrequencyThreshold);
+        return encoder.Encode(*mOverFrequencyThreshold);
     case Attributes::UnderFrequencyThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderFrequency))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mUnderFrequencyThreshold);
+        return encoder.Encode(*mUnderFrequencyThreshold);
     case Attributes::OverPowerThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverPower))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mOverPowerThreshold);
+        return encoder.Encode(*mOverPowerThreshold);
     case Attributes::UnderPowerThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderPower))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mUnderPowerThreshold);
+        return encoder.Encode(*mUnderPowerThreshold);
     case Attributes::OverCurrentThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kOverCurrent))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mOverCurrentThreshold);
+        return encoder.Encode(*mOverCurrentThreshold);
     case Attributes::UnderCurrentThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kUnderCurrent))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mUnderCurrentThreshold);
+        return encoder.Encode(*mUnderCurrentThreshold);
     case Attributes::PowerImportThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kPowerImport))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mPowerImportThreshold);
+        return encoder.Encode(*mPowerImportThreshold);
     case Attributes::PowerExportThreshold::Id:
         if (!mFeatureFlags.Has(Feature::kPowerExport))
         {
             return Status::UnsupportedAttribute;
         }
-        return encoder.Encode(mPowerExportThreshold);
+        return encoder.Encode(*mPowerExportThreshold);
     default:
         return Status::UnsupportedAttribute;
     }
@@ -347,80 +347,110 @@ Status ElectricalAlarmCluster::ResetLatchedAlarms(BitMask<AlarmBitmap> alarms)
 Status ElectricalAlarmCluster::SetOverVoltageThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverVoltage), Status::UnsupportedAttribute);
-    SetAttributeValue(mOverVoltageThreshold, value, Attributes::OverVoltageThreshold::Id);
-    mOverVoltageThresholdSet = true;
+    if (!mOverVoltageThreshold.has_value() || *mOverVoltageThreshold != value)
+    {
+        mOverVoltageThreshold = value;
+        NotifyAttributeChanged(Attributes::OverVoltageThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetUnderVoltageThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderVoltage), Status::UnsupportedAttribute);
-    SetAttributeValue(mUnderVoltageThreshold, value, Attributes::UnderVoltageThreshold::Id);
-    mUnderVoltageThresholdSet = true;
+    if (!mUnderVoltageThreshold.has_value() || *mUnderVoltageThreshold != value)
+    {
+        mUnderVoltageThreshold = value;
+        NotifyAttributeChanged(Attributes::UnderVoltageThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetOverFrequencyThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverFrequency), Status::UnsupportedAttribute);
-    SetAttributeValue(mOverFrequencyThreshold, value, Attributes::OverFrequencyThreshold::Id);
-    mOverFrequencyThresholdSet = true;
+    if (!mOverFrequencyThreshold.has_value() || *mOverFrequencyThreshold != value)
+    {
+        mOverFrequencyThreshold = value;
+        NotifyAttributeChanged(Attributes::OverFrequencyThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetUnderFrequencyThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderFrequency), Status::UnsupportedAttribute);
-    SetAttributeValue(mUnderFrequencyThreshold, value, Attributes::UnderFrequencyThreshold::Id);
-    mUnderFrequencyThresholdSet = true;
+    if (!mUnderFrequencyThreshold.has_value() || *mUnderFrequencyThreshold != value)
+    {
+        mUnderFrequencyThreshold = value;
+        NotifyAttributeChanged(Attributes::UnderFrequencyThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetOverPowerThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverPower), Status::UnsupportedAttribute);
-    SetAttributeValue(mOverPowerThreshold, value, Attributes::OverPowerThreshold::Id);
-    mOverPowerThresholdSet = true;
+    if (!mOverPowerThreshold.has_value() || *mOverPowerThreshold != value)
+    {
+        mOverPowerThreshold = value;
+        NotifyAttributeChanged(Attributes::OverPowerThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetUnderPowerThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderPower), Status::UnsupportedAttribute);
-    SetAttributeValue(mUnderPowerThreshold, value, Attributes::UnderPowerThreshold::Id);
-    mUnderPowerThresholdSet = true;
+    if (!mUnderPowerThreshold.has_value() || *mUnderPowerThreshold != value)
+    {
+        mUnderPowerThreshold = value;
+        NotifyAttributeChanged(Attributes::UnderPowerThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetOverCurrentThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kOverCurrent), Status::UnsupportedAttribute);
-    SetAttributeValue(mOverCurrentThreshold, value, Attributes::OverCurrentThreshold::Id);
-    mOverCurrentThresholdSet = true;
+    if (!mOverCurrentThreshold.has_value() || *mOverCurrentThreshold != value)
+    {
+        mOverCurrentThreshold = value;
+        NotifyAttributeChanged(Attributes::OverCurrentThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetUnderCurrentThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kUnderCurrent), Status::UnsupportedAttribute);
-    SetAttributeValue(mUnderCurrentThreshold, value, Attributes::UnderCurrentThreshold::Id);
-    mUnderCurrentThresholdSet = true;
+    if (!mUnderCurrentThreshold.has_value() || *mUnderCurrentThreshold != value)
+    {
+        mUnderCurrentThreshold = value;
+        NotifyAttributeChanged(Attributes::UnderCurrentThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetPowerImportThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kPowerImport), Status::UnsupportedAttribute);
-    SetAttributeValue(mPowerImportThreshold, value, Attributes::PowerImportThreshold::Id);
-    mPowerImportThresholdSet = true;
+    if (!mPowerImportThreshold.has_value() || *mPowerImportThreshold != value)
+    {
+        mPowerImportThreshold = value;
+        NotifyAttributeChanged(Attributes::PowerImportThreshold::Id);
+    }
     return Status::Success;
 }
 
 Status ElectricalAlarmCluster::SetPowerExportThreshold(int64_t value)
 {
     VerifyOrReturnValue(mFeatureFlags.Has(Feature::kPowerExport), Status::UnsupportedAttribute);
-    SetAttributeValue(mPowerExportThreshold, value, Attributes::PowerExportThreshold::Id);
-    mPowerExportThresholdSet = true;
+    if (!mPowerExportThreshold.has_value() || *mPowerExportThreshold != value)
+    {
+        mPowerExportThreshold = value;
+        NotifyAttributeChanged(Attributes::PowerExportThreshold::Id);
+    }
     return Status::Success;
 }
 
@@ -448,6 +478,10 @@ Status ElectricalAlarmCluster::HandleReset(BitMask<AlarmBitmap> alarms)
     {
         return Status::UnsupportedCommand;
     }
+    if (!mSupported.HasAll(alarms))
+    {
+        return Status::InvalidCommand;
+    }
     if (mDelegate != nullptr && !mDelegate->ResetAlarmsCallback(alarms))
     {
         ChipLogProgress(Zcl, "ElectricalAlarm: delegate rejected Reset");
@@ -463,58 +497,74 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
         return Status::UnsupportedCommand;
     }
 
-    // Validate cross-pair ordering. Both the incoming optional value AND any previously-persisted
-    // value count as a known baseline. mXxxThresholdSet flags distinguish an explicit zero from
-    // "not yet set" (0 is a valid threshold value per the spec).
+    // Validate absolute per-field constraints before cross-pair ordering.
+    // PowerImportThreshold min 0, PowerExportThreshold max 0 (from spec and XML).
+    if (data.powerImportThreshold.HasValue() && data.powerImportThreshold.Value() < 0)
+    {
+        return Status::ConstraintError;
+    }
+    if (data.powerExportThreshold.HasValue() && data.powerExportThreshold.Value() > 0)
+    {
+        return Status::ConstraintError;
+    }
+
+    // Validate cross-pair ordering. If a feature is enabled, the stored Fallback value is always
+    // a valid baseline — use feature presence rather than a "has been explicitly written" flag.
     //
-    // strictOver=true:  over must be strictly > under (voltage, frequency, power, current pairs).
-    // strictOver=false: over must be >= under (import/export — both may be 0 simultaneously, since
-    //                   import=0 and export=0 is a valid quiescent state per attribute constraints).
-    auto checkPair = [&](const Optional<int64_t> & over, const Optional<int64_t> & under, int64_t storedOver, bool storedOverSet,
-                         int64_t storedUnder, bool storedUnderSet, bool strictOver = true) -> Status {
+    // For voltage/frequency/power/current pairs: over must be strictly > under (over >= under + 1).
+    // For import/export: (0, 0) is the valid quiescent state; otherwise over must be > under.
+    auto checkPair = [&](const Optional<int64_t> & over, const Optional<int64_t> & under,
+                         int64_t storedOver, bool overFeatureEnabled,
+                         int64_t storedUnder, bool underFeatureEnabled) -> Status {
         if (!over.HasValue() && !under.HasValue())
         {
             return Status::Success;
         }
-        const bool overKnown  = over.HasValue() || storedOverSet;
-        const bool underKnown = under.HasValue() || storedUnderSet;
+        const bool overKnown  = over.HasValue() || overFeatureEnabled;
+        const bool underKnown = under.HasValue() || underFeatureEnabled;
         if (!overKnown || !underKnown)
         {
             return Status::Success;
         }
         int64_t resolvedOver  = over.ValueOr(storedOver);
         int64_t resolvedUnder = under.ValueOr(storedUnder);
-        const bool violated   = strictOver ? (resolvedOver <= resolvedUnder) : (resolvedOver < resolvedUnder);
-        return violated ? Status::ConstraintError : Status::Success;
+        return (resolvedOver <= resolvedUnder) ? Status::ConstraintError : Status::Success;
     };
 
     Status s;
-    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold, mOverVoltageThreshold, mOverVoltageThresholdSet,
-                       mUnderVoltageThreshold, mUnderVoltageThresholdSet)) != Status::Success)
+    if ((s = checkPair(data.overVoltageThreshold, data.underVoltageThreshold,
+                       *mOverVoltageThreshold, mFeatureFlags.Has(Feature::kOverVoltage),
+                       *mUnderVoltageThreshold, mFeatureFlags.Has(Feature::kUnderVoltage))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold, mOverFrequencyThreshold,
-                       mOverFrequencyThresholdSet, mUnderFrequencyThreshold, mUnderFrequencyThresholdSet)) != Status::Success)
+    if ((s = checkPair(data.overFrequencyThreshold, data.underFrequencyThreshold,
+                       *mOverFrequencyThreshold, mFeatureFlags.Has(Feature::kOverFrequency),
+                       *mUnderFrequencyThreshold, mFeatureFlags.Has(Feature::kUnderFrequency))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold, mOverPowerThresholdSet,
-                       mUnderPowerThreshold, mUnderPowerThresholdSet)) != Status::Success)
+    if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold,
+                       *mOverPowerThreshold, mFeatureFlags.Has(Feature::kOverPower),
+                       *mUnderPowerThreshold, mFeatureFlags.Has(Feature::kUnderPower))) != Status::Success)
     {
         return s;
     }
-    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold, mOverCurrentThreshold, mOverCurrentThresholdSet,
-                       mUnderCurrentThreshold, mUnderCurrentThresholdSet)) != Status::Success)
+    if ((s = checkPair(data.overCurrentThreshold, data.underCurrentThreshold,
+                       *mOverCurrentThreshold, mFeatureFlags.Has(Feature::kOverCurrent),
+                       *mUnderCurrentThreshold, mFeatureFlags.Has(Feature::kUnderCurrent))) != Status::Success)
     {
         return s;
     }
-    // PowerImport >= 0 and PowerExport <= 0 by attribute min/max in ZAP. Import=0 and export=0 is a
-    // valid quiescent state (no power flowing), so use strictOver=false (>= rather than >).
-    if ((s = checkPair(data.powerImportThreshold, data.powerExportThreshold, mPowerImportThreshold, mPowerImportThresholdSet,
-                       mPowerExportThreshold, mPowerExportThresholdSet, /*strictOver=*/false)) != Status::Success)
+    // PowerImport/Export: (0, 0) is valid quiescent state; otherwise import must be > export.
+    if (data.powerImportThreshold.HasValue() || data.powerExportThreshold.HasValue())
     {
-        return s;
+        int64_t resolvedImport = data.powerImportThreshold.ValueOr(*mPowerImportThreshold);
+        int64_t resolvedExport = data.powerExportThreshold.ValueOr(*mPowerExportThreshold);
+        if (!(resolvedImport == 0 && resolvedExport == 0) && resolvedImport <= resolvedExport)
+        {
+            return Status::ConstraintError;
+        }
     }
 
     if (mDelegate != nullptr && !mDelegate->SetElectricalAlarmThresholdsCallback(data))

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.cpp
@@ -561,8 +561,8 @@ Status ElectricalAlarmCluster::HandleSetThresholds(const Commands::SetElectrical
         return s;
     }
     if ((s = checkPair(data.overPowerThreshold, data.underPowerThreshold, mOverPowerThreshold.value(),
-                       mFeatureFlags.Has(Feature::kOverPower), mUnderPowerThreshold.value(), mFeatureFlags.Has(Feature::kUnderPower))) !=
-        Status::Success)
+                       mFeatureFlags.Has(Feature::kOverPower), mUnderPowerThreshold.value(),
+                       mFeatureFlags.Has(Feature::kUnderPower))) != Status::Success)
     {
         return s;
     }

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
@@ -118,21 +118,20 @@ private:
     BitMask<AlarmBitmap> mLatch;
 
     // Threshold attribute state — seeded to spec Fallback values so the boot state is always
-    // valid (e.g. OVT > UVT when both features are present). std::optional is used per SDK
-    // convention; values are always present after construction.
+    // valid (e.g. OVT > UVT when both features are present).
     static constexpr int64_t kOverThresholdDefault  = 4611686018427387904LL;  // 2^62
     static constexpr int64_t kUnderThresholdDefault = -4611686018427387904LL; // -(2^62)
 
-    std::optional<int64_t> mOverVoltageThreshold    = kOverThresholdDefault;
-    std::optional<int64_t> mUnderVoltageThreshold   = 0;
-    std::optional<int64_t> mOverFrequencyThreshold  = 1000000;
-    std::optional<int64_t> mUnderFrequencyThreshold = 0;
-    std::optional<int64_t> mOverPowerThreshold      = kOverThresholdDefault;
-    std::optional<int64_t> mUnderPowerThreshold     = kUnderThresholdDefault;
-    std::optional<int64_t> mOverCurrentThreshold    = kOverThresholdDefault;
-    std::optional<int64_t> mUnderCurrentThreshold   = kUnderThresholdDefault;
-    std::optional<int64_t> mPowerImportThreshold    = kOverThresholdDefault;
-    std::optional<int64_t> mPowerExportThreshold    = kUnderThresholdDefault;
+    int64_t mOverVoltageThreshold    = kOverThresholdDefault;
+    int64_t mUnderVoltageThreshold   = 0;
+    int64_t mOverFrequencyThreshold  = 1000000;
+    int64_t mUnderFrequencyThreshold = 0;
+    int64_t mOverPowerThreshold      = kOverThresholdDefault;
+    int64_t mUnderPowerThreshold     = kUnderThresholdDefault;
+    int64_t mOverCurrentThreshold    = kOverThresholdDefault;
+    int64_t mUnderCurrentThreshold   = kUnderThresholdDefault;
+    int64_t mPowerImportThreshold    = kOverThresholdDefault;
+    int64_t mPowerExportThreshold    = kUnderThresholdDefault;
 };
 
 } // namespace ElectricalAlarm

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <app/clusters/electrical-alarm-server/electrical-alarm-delegate.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/ElectricalAlarm/AttributeIds.h>
@@ -115,29 +117,22 @@ private:
     BitMask<AlarmBitmap> mSupported;
     BitMask<AlarmBitmap> mLatch;
 
-    // Threshold attribute state (valid only when the corresponding feature is present)
-    int64_t mOverVoltageThreshold    = 0;
-    int64_t mUnderVoltageThreshold   = 0;
-    int64_t mOverFrequencyThreshold  = 0;
-    int64_t mUnderFrequencyThreshold = 0;
-    int64_t mOverPowerThreshold      = 0;
-    int64_t mUnderPowerThreshold     = 0;
-    int64_t mOverCurrentThreshold    = 0;
-    int64_t mUnderCurrentThreshold   = 0;
-    int64_t mPowerImportThreshold    = 0;
-    int64_t mPowerExportThreshold    = 0;
+    // Threshold attribute state — seeded to spec Fallback values so the boot state is always
+    // valid (e.g. OVT > UVT when both features are present). std::optional is used per SDK
+    // convention; values are always present after construction.
+    static constexpr int64_t kOverThresholdDefault  = 4611686018427387904LL;  // 2^62
+    static constexpr int64_t kUnderThresholdDefault = -4611686018427387904LL; // -(2^62)
 
-    // Tracks whether each threshold has been explicitly set (0 is a valid threshold value).
-    bool mOverVoltageThresholdSet    = false;
-    bool mUnderVoltageThresholdSet   = false;
-    bool mOverFrequencyThresholdSet  = false;
-    bool mUnderFrequencyThresholdSet = false;
-    bool mOverPowerThresholdSet      = false;
-    bool mUnderPowerThresholdSet     = false;
-    bool mOverCurrentThresholdSet    = false;
-    bool mUnderCurrentThresholdSet   = false;
-    bool mPowerImportThresholdSet    = false;
-    bool mPowerExportThresholdSet    = false;
+    std::optional<int64_t> mOverVoltageThreshold    = kOverThresholdDefault;
+    std::optional<int64_t> mUnderVoltageThreshold   = 0;
+    std::optional<int64_t> mOverFrequencyThreshold  = 1000000;
+    std::optional<int64_t> mUnderFrequencyThreshold = 0;
+    std::optional<int64_t> mOverPowerThreshold      = kOverThresholdDefault;
+    std::optional<int64_t> mUnderPowerThreshold     = kUnderThresholdDefault;
+    std::optional<int64_t> mOverCurrentThreshold    = kOverThresholdDefault;
+    std::optional<int64_t> mUnderCurrentThreshold   = kUnderThresholdDefault;
+    std::optional<int64_t> mPowerImportThreshold    = kOverThresholdDefault;
+    std::optional<int64_t> mPowerExportThreshold    = kUnderThresholdDefault;
 };
 
 } // namespace ElectricalAlarm

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
@@ -30,6 +30,18 @@ namespace app {
 namespace Clusters {
 namespace ElectricalAlarm {
 
+/// Server for the Electrical Alarm cluster (0x00A1).
+///
+/// ESALM is an Alarm Base derived cluster for electrical measurement threshold alarms
+/// (over/under voltage, frequency, power, current, and import/export power). It supports three
+/// command groups: ModifyEnabledAlarms (mask control, always available), Reset (RST feature —
+/// latching alarm acknowledgement), and SetElectricalAlarmThresholds (ADJT feature — writable
+/// thresholds for up to 10 measurement types). The mandatory Notify event is emitted on every
+/// State transition.
+///
+/// Alarm State is driven by the device's own measurement hardware via SetStateValue(),
+/// SetSupportedValue(), and SetMaskValue(). For conformance testing, State can be driven through
+/// General Diagnostics test-event-triggers via ElectricalAlarmTestEventTriggerHandler.
 class ElectricalAlarmCluster : public DefaultServerCluster
 {
 public:

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
@@ -41,8 +41,7 @@ public:
     };
 
     explicit ElectricalAlarmCluster(const Config & config) :
-        DefaultServerCluster({ config.endpointId, ElectricalAlarm::Id }), mDelegate(config.delegate),
-        mFeatureFlags(config.features)
+        DefaultServerCluster({ config.endpointId, ElectricalAlarm::Id }), mDelegate(config.delegate), mFeatureFlags(config.features)
     {}
 
     void SetDelegate(Delegate * delegate) { mDelegate = delegate; }
@@ -50,14 +49,12 @@ public:
     // DefaultServerCluster overrides
     CHIP_ERROR Startup(ServerClusterContext & context) override;
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
-                                               AttributeValueEncoder & encoder) override;
-    CHIP_ERROR Attributes(const ConcreteClusterPath & path,
-                          ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
+                                                AttributeValueEncoder & encoder) override;
+    CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
     CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
                                 ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
     std::optional<DataModel::ActionReturnStatus> InvokeCommand(const DataModel::InvokeRequest & request,
-                                                               TLV::TLVReader & input_arguments,
-                                                               CommandHandler * handler) override;
+                                                               TLV::TLVReader & input_arguments, CommandHandler * handler) override;
 
     // Alarm Base attribute setters — callable by the application
     // A change in Supported narrows Latch, then Mask, then State.

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
@@ -1,0 +1,123 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/electrical-alarm-server/electrical-alarm-delegate.h>
+#include <app/server-cluster/DefaultServerCluster.h>
+#include <clusters/ElectricalAlarm/AttributeIds.h>
+#include <clusters/ElectricalAlarm/ClusterId.h>
+#include <clusters/ElectricalAlarm/Commands.h>
+#include <clusters/ElectricalAlarm/Enums.h>
+#include <clusters/ElectricalAlarm/Events.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalAlarm {
+
+class ElectricalAlarmCluster : public DefaultServerCluster
+{
+public:
+    struct Config
+    {
+        EndpointId endpointId;
+        Delegate & delegate;
+        BitMask<Feature> features;
+    };
+
+    explicit ElectricalAlarmCluster(const Config & config) :
+        DefaultServerCluster({ config.endpointId, ElectricalAlarm::Id }), mDelegate(config.delegate),
+        mFeatureFlags(config.features)
+    {}
+
+    // DefaultServerCluster overrides
+    CHIP_ERROR Startup(ServerClusterContext & context) override;
+    DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                               AttributeValueEncoder & encoder) override;
+    CHIP_ERROR Attributes(const ConcreteClusterPath & path,
+                          ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
+    CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
+                                ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
+    std::optional<DataModel::ActionReturnStatus> InvokeCommand(const DataModel::InvokeRequest & request,
+                                                               TLV::TLVReader & input_arguments,
+                                                               CommandHandler * handler) override;
+
+    // Alarm Base attribute setters — callable by the application
+    // A change in Supported narrows Latch, then Mask, then State.
+    Protocols::InteractionModel::Status SetSupportedValue(BitMask<AlarmBitmap> supported);
+    // A change in Mask narrows State (drops newly-suppressed active alarms).
+    Protocols::InteractionModel::Status SetMaskValue(BitMask<AlarmBitmap> mask);
+    Protocols::InteractionModel::Status SetLatchValue(BitMask<AlarmBitmap> latch);
+    // When ignoreLatchState=false, latched active bits are preserved and cannot be cleared here.
+    Protocols::InteractionModel::Status SetStateValue(BitMask<AlarmBitmap> newState, bool ignoreLatchState = false);
+    Protocols::InteractionModel::Status ResetLatchedAlarms(BitMask<AlarmBitmap> alarms);
+
+    // Threshold attribute setters — return UnsupportedAttribute when the feature is absent.
+    Protocols::InteractionModel::Status SetOverVoltageThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetUnderVoltageThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetOverFrequencyThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetUnderFrequencyThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetOverPowerThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetUnderPowerThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetOverCurrentThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetUnderCurrentThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetPowerImportThreshold(int64_t value);
+    Protocols::InteractionModel::Status SetPowerExportThreshold(int64_t value);
+
+    // Read-only accessors used by command handlers and tests
+    BitMask<AlarmBitmap> GetMask() const { return mMask; }
+    BitMask<AlarmBitmap> GetState() const { return mState; }
+    BitMask<AlarmBitmap> GetSupported() const { return mSupported; }
+    BitMask<AlarmBitmap> GetLatch() const { return mLatch; }
+
+    bool HasFeature(Feature f) const { return mFeatureFlags.Has(f); }
+
+private:
+    Protocols::InteractionModel::Status HandleModifyEnabledAlarms(BitMask<AlarmBitmap> mask);
+    Protocols::InteractionModel::Status HandleReset(BitMask<AlarmBitmap> alarms);
+    Protocols::InteractionModel::Status HandleSetThresholds(const Commands::SetElectricalAlarmThresholds::DecodableType & data);
+
+    void SendNotifyEvent(BitMask<AlarmBitmap> becameActive, BitMask<AlarmBitmap> becameInactive, BitMask<AlarmBitmap> newState,
+                         BitMask<AlarmBitmap> mask);
+
+    Delegate & mDelegate;
+    const BitMask<Feature> mFeatureFlags;
+
+    // Alarm Base attribute state
+    BitMask<AlarmBitmap> mMask;
+    BitMask<AlarmBitmap> mState;
+    BitMask<AlarmBitmap> mSupported;
+    BitMask<AlarmBitmap> mLatch;
+
+    // Threshold attribute state (valid only when the corresponding feature is present)
+    int64_t mOverVoltageThreshold   = 0;
+    int64_t mUnderVoltageThreshold  = 0;
+    int64_t mOverFrequencyThreshold = 0;
+    int64_t mUnderFrequencyThreshold  = 0;
+    int64_t mOverPowerThreshold     = 0;
+    int64_t mUnderPowerThreshold    = 0;
+    int64_t mOverCurrentThreshold   = 0;
+    int64_t mUnderCurrentThreshold  = 0;
+    int64_t mPowerImportThreshold   = 0;
+    int64_t mPowerExportThreshold   = 0;
+};
+
+} // namespace ElectricalAlarm
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h
@@ -36,7 +36,7 @@ public:
     struct Config
     {
         EndpointId endpointId;
-        Delegate & delegate;
+        Delegate * delegate = nullptr;
         BitMask<Feature> features;
     };
 
@@ -44,6 +44,8 @@ public:
         DefaultServerCluster({ config.endpointId, ElectricalAlarm::Id }), mDelegate(config.delegate),
         mFeatureFlags(config.features)
     {}
+
+    void SetDelegate(Delegate * delegate) { mDelegate = delegate; }
 
     // DefaultServerCluster overrides
     CHIP_ERROR Startup(ServerClusterContext & context) override;
@@ -95,7 +97,7 @@ private:
     void SendNotifyEvent(BitMask<AlarmBitmap> becameActive, BitMask<AlarmBitmap> becameInactive, BitMask<AlarmBitmap> newState,
                          BitMask<AlarmBitmap> mask);
 
-    Delegate & mDelegate;
+    Delegate * mDelegate;
     const BitMask<Feature> mFeatureFlags;
 
     // Alarm Base attribute state
@@ -105,16 +107,28 @@ private:
     BitMask<AlarmBitmap> mLatch;
 
     // Threshold attribute state (valid only when the corresponding feature is present)
-    int64_t mOverVoltageThreshold   = 0;
-    int64_t mUnderVoltageThreshold  = 0;
-    int64_t mOverFrequencyThreshold = 0;
-    int64_t mUnderFrequencyThreshold  = 0;
-    int64_t mOverPowerThreshold     = 0;
-    int64_t mUnderPowerThreshold    = 0;
-    int64_t mOverCurrentThreshold   = 0;
-    int64_t mUnderCurrentThreshold  = 0;
-    int64_t mPowerImportThreshold   = 0;
-    int64_t mPowerExportThreshold   = 0;
+    int64_t mOverVoltageThreshold    = 0;
+    int64_t mUnderVoltageThreshold   = 0;
+    int64_t mOverFrequencyThreshold  = 0;
+    int64_t mUnderFrequencyThreshold = 0;
+    int64_t mOverPowerThreshold      = 0;
+    int64_t mUnderPowerThreshold     = 0;
+    int64_t mOverCurrentThreshold    = 0;
+    int64_t mUnderCurrentThreshold   = 0;
+    int64_t mPowerImportThreshold    = 0;
+    int64_t mPowerExportThreshold    = 0;
+
+    // Tracks whether each threshold has been explicitly set (0 is a valid threshold value).
+    bool mOverVoltageThresholdSet    = false;
+    bool mUnderVoltageThresholdSet   = false;
+    bool mOverFrequencyThresholdSet  = false;
+    bool mUnderFrequencyThresholdSet = false;
+    bool mOverPowerThresholdSet      = false;
+    bool mUnderPowerThresholdSet     = false;
+    bool mOverCurrentThresholdSet    = false;
+    bool mUnderCurrentThresholdSet   = false;
+    bool mPowerImportThresholdSet    = false;
+    bool mPowerExportThresholdSet    = false;
 };
 
 } // namespace ElectricalAlarm

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmTestEventTriggerHandler.h
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmTestEventTriggerHandler.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/TestEventTriggerDelegate.h>
+
+#include <cstdint>
+
+/**
+ * Application-provided handler for Electrical Alarm (0x00A1) test-event-triggers.
+ *
+ * The example app implements this to drive alarm State (and thus the Notify event) for
+ * TC-ESALM-3.x, which tests the Notify event lifecycle. Returns true if the trigger was
+ * recognized and handled.
+ */
+bool HandleElectricalAlarmTestEventTrigger(uint64_t eventTrigger);
+
+namespace chip {
+
+/// EventTrigger codes for the Electrical Alarm cluster. The top two bytes carry the cluster id
+/// (0x00A1) to namespace the trigger; the low bytes select the alarm bit to activate, or 0 to
+/// clear all active alarms.
+enum class ElectricalAlarmTrigger : uint64_t
+{
+    kClearAll              = 0x00a1'0000'0000'0000,
+    kSetOverVoltage        = 0x00a1'0000'0000'0001,
+    kSetUnderVoltage       = 0x00a1'0000'0000'0002,
+    kSetOverFrequency      = 0x00a1'0000'0000'0003,
+    kSetUnderFrequency     = 0x00a1'0000'0000'0004,
+    kSetOverPower          = 0x00a1'0000'0000'0005,
+    kSetUnderPower         = 0x00a1'0000'0000'0006,
+    kSetOverCurrent        = 0x00a1'0000'0000'0007,
+    kSetUnderCurrent       = 0x00a1'0000'0000'0008,
+    kSetPowerImport        = 0x00a1'0000'0000'0009,
+    kSetPowerExport        = 0x00a1'0000'0000'000a,
+};
+
+class ElectricalAlarmTestEventTriggerHandler : public TestEventTriggerHandler
+{
+public:
+    ElectricalAlarmTestEventTriggerHandler() = default;
+
+    CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
+    {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
+        return HandleElectricalAlarmTestEventTrigger(eventTrigger) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
+    }
+};
+
+} // namespace chip

--- a/src/app/clusters/electrical-alarm-server/ElectricalAlarmTestEventTriggerHandler.h
+++ b/src/app/clusters/electrical-alarm-server/ElectricalAlarmTestEventTriggerHandler.h
@@ -37,17 +37,17 @@ namespace chip {
 /// clear all active alarms.
 enum class ElectricalAlarmTrigger : uint64_t
 {
-    kClearAll              = 0x00a1'0000'0000'0000,
-    kSetOverVoltage        = 0x00a1'0000'0000'0001,
-    kSetUnderVoltage       = 0x00a1'0000'0000'0002,
-    kSetOverFrequency      = 0x00a1'0000'0000'0003,
-    kSetUnderFrequency     = 0x00a1'0000'0000'0004,
-    kSetOverPower          = 0x00a1'0000'0000'0005,
-    kSetUnderPower         = 0x00a1'0000'0000'0006,
-    kSetOverCurrent        = 0x00a1'0000'0000'0007,
-    kSetUnderCurrent       = 0x00a1'0000'0000'0008,
-    kSetPowerImport        = 0x00a1'0000'0000'0009,
-    kSetPowerExport        = 0x00a1'0000'0000'000a,
+    kClearAll          = 0x00a1'0000'0000'0000,
+    kSetOverVoltage    = 0x00a1'0000'0000'0001,
+    kSetUnderVoltage   = 0x00a1'0000'0000'0002,
+    kSetOverFrequency  = 0x00a1'0000'0000'0003,
+    kSetUnderFrequency = 0x00a1'0000'0000'0004,
+    kSetOverPower      = 0x00a1'0000'0000'0005,
+    kSetUnderPower     = 0x00a1'0000'0000'0006,
+    kSetOverCurrent    = 0x00a1'0000'0000'0007,
+    kSetUnderCurrent   = 0x00a1'0000'0000'0008,
+    kSetPowerImport    = 0x00a1'0000'0000'0009,
+    kSetPowerExport    = 0x00a1'0000'0000'000a,
 };
 
 class ElectricalAlarmTestEventTriggerHandler : public TestEventTriggerHandler

--- a/src/app/clusters/electrical-alarm-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/electrical-alarm-server/app_config_dependent_sources.cmake
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TARGET_SOURCES(
+  ${APP_TARGET}
+  PRIVATE
+    "${CLUSTER_DIR}/CodegenIntegration.h"
+    "${CLUSTER_DIR}/CodegenIntegration.cpp"
+    "${CLUSTER_DIR}/electrical-alarm-delegate.h"
+)

--- a/src/app/clusters/electrical-alarm-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/electrical-alarm-server/app_config_dependent_sources.cmake
@@ -17,5 +17,6 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.h"
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
+    "${CLUSTER_DIR}/ElectricalAlarmTestEventTriggerHandler.h"
     "${CLUSTER_DIR}/electrical-alarm-delegate.h"
 )

--- a/src/app/clusters/electrical-alarm-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/electrical-alarm-server/app_config_dependent_sources.gni
@@ -15,5 +15,6 @@
 app_config_dependent_sources = [
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
+  "ElectricalAlarmTestEventTriggerHandler.h",
   "electrical-alarm-delegate.h",
 ]

--- a/src/app/clusters/electrical-alarm-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/electrical-alarm-server/app_config_dependent_sources.gni
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+app_config_dependent_sources = [
+  "CodegenIntegration.cpp",
+  "CodegenIntegration.h",
+  "electrical-alarm-delegate.h",
+]

--- a/src/app/clusters/electrical-alarm-server/electrical-alarm-delegate.h
+++ b/src/app/clusters/electrical-alarm-server/electrical-alarm-delegate.h
@@ -1,0 +1,75 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/CommandResponseHelper.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalAlarm {
+
+/** @brief
+ *  Defines methods for implementing application-specific logic for the ElectricalAlarm Cluster.
+ */
+class Delegate
+{
+public:
+    /**
+     *   @brief
+     *   A notification that the Mask attribute will be changed.
+     *   @param[in] mask The new value of the Mask attribute.
+     *   @return true if the cluster should apply the change; false to reject.
+     */
+    virtual bool ModifyEnabledAlarmsCallback(const BitMask<AlarmBitmap> mask) = 0;
+
+    /**
+     *   @brief
+     *   A notification that the server should reset the given latched alarms.
+     *   @param[in] alarms Bitmask of alarms to reset.
+     *   @return true if the cluster should apply the reset; false to reject.
+     */
+    virtual bool ResetAlarmsCallback(const BitMask<AlarmBitmap> alarms) = 0;
+
+    /**
+     *   @brief
+     *   A notification that the server should apply new threshold values
+     *   (ADJUST feature, SetElectricalAlarmThresholds command).
+     *   Only fields that are present (HasValue() == true) need to be applied.
+     *   @param[in] commandData Decoded command fields; absent optionals retain
+     *                          their current attribute value.
+     *   @return true if the cluster should persist the new thresholds; false to reject.
+     */
+    virtual bool SetElectricalAlarmThresholdsCallback(
+        const Commands::SetElectricalAlarmThresholds::DecodableType & commandData) = 0;
+
+    Delegate(EndpointId endpoint) : mEndpoint(endpoint) {}
+
+    Delegate() = default;
+
+    virtual ~Delegate() = default;
+
+protected:
+    EndpointId mEndpoint = 0;
+};
+
+} // namespace ElectricalAlarm
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/electrical-alarm-server/electrical-alarm-delegate.h
+++ b/src/app/clusters/electrical-alarm-server/electrical-alarm-delegate.h
@@ -58,8 +58,10 @@ public:
      *   Default implementation approves all threshold changes; override to add
      *   device-specific validation or to write values to hardware.
      */
-    virtual bool SetElectricalAlarmThresholdsCallback(
-        const Commands::SetElectricalAlarmThresholds::DecodableType & commandData) { return true; }
+    virtual bool SetElectricalAlarmThresholdsCallback(const Commands::SetElectricalAlarmThresholds::DecodableType & commandData)
+    {
+        return true;
+    }
 
     Delegate(EndpointId endpoint) : mEndpoint(endpoint) {}
 

--- a/src/app/clusters/electrical-alarm-server/electrical-alarm-delegate.h
+++ b/src/app/clusters/electrical-alarm-server/electrical-alarm-delegate.h
@@ -55,9 +55,11 @@ public:
      *   @param[in] commandData Decoded command fields; absent optionals retain
      *                          their current attribute value.
      *   @return true if the cluster should persist the new thresholds; false to reject.
+     *   Default implementation approves all threshold changes; override to add
+     *   device-specific validation or to write values to hardware.
      */
     virtual bool SetElectricalAlarmThresholdsCallback(
-        const Commands::SetElectricalAlarmThresholds::DecodableType & commandData) = 0;
+        const Commands::SetElectricalAlarmThresholds::DecodableType & commandData) { return true; }
 
     Delegate(EndpointId endpoint) : mEndpoint(endpoint) {}
 

--- a/src/app/clusters/electrical-alarm-server/tests/BUILD.gn
+++ b/src/app/clusters/electrical-alarm-server/tests/BUILD.gn
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "TestElectricalAlarmCluster"
+
+  test_sources = [ "TestElectricalAlarmCluster.cpp" ]
+
+  sources = [ "MockElectricalAlarmDelegate.h" ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/app/clusters/electrical-alarm-server",
+    "${chip_root}/src/app/data-model-provider/tests:encode-decode",
+    "${chip_root}/src/app/server-cluster/testing",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/app/clusters/electrical-alarm-server/tests/MockElectricalAlarmDelegate.h
+++ b/src/app/clusters/electrical-alarm-server/tests/MockElectricalAlarmDelegate.h
@@ -1,0 +1,63 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/electrical-alarm-server/electrical-alarm-delegate.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalAlarm {
+
+class MockElectricalAlarmDelegate : public Delegate
+{
+public:
+    // Configurable reject flags — set to false to simulate a delegate rejection.
+    bool allowModifyEnabledAlarms    = true;
+    bool allowReset                  = true;
+    bool allowSetThresholds          = true;
+
+    // Call counts for assertion in tests.
+    int modifyEnabledAlarmsCallCount    = 0;
+    int resetAlarmsCallCount            = 0;
+    int setThresholdsCallCount          = 0;
+
+    bool ModifyEnabledAlarmsCallback(const BitMask<AlarmBitmap> mask) override
+    {
+        ++modifyEnabledAlarmsCallCount;
+        return allowModifyEnabledAlarms;
+    }
+
+    bool ResetAlarmsCallback(const BitMask<AlarmBitmap> alarms) override
+    {
+        ++resetAlarmsCallCount;
+        return allowReset;
+    }
+
+    bool SetElectricalAlarmThresholdsCallback(
+        const Commands::SetElectricalAlarmThresholds::DecodableType & commandData) override
+    {
+        ++setThresholdsCallCount;
+        return allowSetThresholds;
+    }
+};
+
+} // namespace ElectricalAlarm
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/electrical-alarm-server/tests/MockElectricalAlarmDelegate.h
+++ b/src/app/clusters/electrical-alarm-server/tests/MockElectricalAlarmDelegate.h
@@ -28,14 +28,14 @@ class MockElectricalAlarmDelegate : public Delegate
 {
 public:
     // Configurable reject flags — set to false to simulate a delegate rejection.
-    bool allowModifyEnabledAlarms    = true;
-    bool allowReset                  = true;
-    bool allowSetThresholds          = true;
+    bool allowModifyEnabledAlarms = true;
+    bool allowReset               = true;
+    bool allowSetThresholds       = true;
 
     // Call counts for assertion in tests.
-    int modifyEnabledAlarmsCallCount    = 0;
-    int resetAlarmsCallCount            = 0;
-    int setThresholdsCallCount          = 0;
+    int modifyEnabledAlarmsCallCount = 0;
+    int resetAlarmsCallCount         = 0;
+    int setThresholdsCallCount       = 0;
 
     bool ModifyEnabledAlarmsCallback(const BitMask<AlarmBitmap> mask) override
     {
@@ -49,8 +49,7 @@ public:
         return allowReset;
     }
 
-    bool SetElectricalAlarmThresholdsCallback(
-        const Commands::SetElectricalAlarmThresholds::DecodableType & commandData) override
+    bool SetElectricalAlarmThresholdsCallback(const Commands::SetElectricalAlarmThresholds::DecodableType & commandData) override
     {
         ++setThresholdsCallCount;
         return allowSetThresholds;

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -421,6 +421,7 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateRejects)
     Commands::ModifyEnabledAlarms::Type cmd;
     cmd.mask    = BitMask<AlarmBitmap>();
     auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
     // Mask must be unchanged.
     EXPECT_EQ(cluster.GetMask(), supported);
@@ -440,6 +441,7 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_UnsupportedBits)
     Commands::ModifyEnabledAlarms::Type cmd;
     cmd.mask    = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
     auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::InvalidCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -461,6 +463,7 @@ TEST_F(TestElectricalAlarmCluster, Reset_FeatureAbsent)
     cmd.alarms  = BitMask<AlarmBitmap>();
     auto result = tester.Invoke(Commands::Reset::Id, cmd);
     // Command is not in AcceptedCommands — ClusterTester returns UnsupportedCommand.
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -508,6 +511,7 @@ TEST_F(TestElectricalAlarmCluster, Reset_DelegateRejects)
     Commands::Reset::Type cmd;
     cmd.alarms  = supported;
     auto result = tester.Invoke(Commands::Reset::Id, cmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
     // State must be unchanged.
     EXPECT_TRUE(cluster.GetState().Has(AlarmBitmap::kOverVoltage));
@@ -529,6 +533,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_FeatureAbsent)
     ClusterTester tester(cluster);
     Commands::SetElectricalAlarmThresholds::Type cmd;
     auto result = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -548,6 +553,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_CrossPairVoltageViolation)
     cmd.overVoltageThreshold  = MakeOptional<int64_t>(1000);
     cmd.underVoltageThreshold = MakeOptional<int64_t>(2000);
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -614,6 +620,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_SingleSidedWithStoredBaseline)
     // Supply only over; stored under (500) acts as baseline → over (200) ≤ under (500) → ConstraintError.
     cmd.overVoltageThreshold = MakeOptional<int64_t>(200);
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -632,6 +639,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_DelegateRejects)
     Commands::SetElectricalAlarmThresholds::Type cmd;
     cmd.overVoltageThreshold = MakeOptional<int64_t>(1000);
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
 
     // Threshold must not have been persisted.
@@ -656,6 +664,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_AbsentFeatureFieldRejected)
     // underVoltageThreshold field present but kUnderVoltage feature absent.
     cmd.underVoltageThreshold = MakeOptional<int64_t>(500);
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    ASSERT_TRUE(result.GetStatusCode().has_value());
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::InvalidCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -396,7 +396,7 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateAccepts)
 
     ClusterTester tester(cluster);
     Commands::ModifyEnabledAlarms::Type cmd;
-    cmd.mask = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
+    cmd.mask    = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
     auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
     EXPECT_TRUE(result.status.has_value() && result.status->IsSuccess());
     EXPECT_EQ(cluster.GetMask(), BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage));
@@ -419,8 +419,8 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateRejects)
 
     ClusterTester tester(cluster);
     Commands::ModifyEnabledAlarms::Type cmd;
-    cmd.mask        = BitMask<AlarmBitmap>();
-    auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    cmd.mask    = BitMask<AlarmBitmap>();
+    auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
     // Mask must be unchanged.
     EXPECT_EQ(cluster.GetMask(), supported);
@@ -528,7 +528,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_FeatureAbsent)
 
     ClusterTester tester(cluster);
     Commands::SetElectricalAlarmThresholds::Type cmd;
-    auto result     = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    auto result = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
     EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -423,7 +423,7 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateRejects)
     auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::Failure);
     // Mask must be unchanged.
     EXPECT_EQ(cluster.GetMask(), supported);
 
@@ -444,7 +444,7 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_UnsupportedBits)
     auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::InvalidCommand);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::InvalidCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -467,7 +467,7 @@ TEST_F(TestElectricalAlarmCluster, Reset_FeatureAbsent)
     // Command is not in AcceptedCommands — ClusterTester returns UnsupportedCommand.
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::UnsupportedCommand);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::UnsupportedCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -516,7 +516,7 @@ TEST_F(TestElectricalAlarmCluster, Reset_DelegateRejects)
     auto result     = tester.Invoke(Commands::Reset::Id, cmd);
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::Failure);
     // State must be unchanged.
     EXPECT_TRUE(cluster.GetState().Has(AlarmBitmap::kOverVoltage));
 
@@ -539,7 +539,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_FeatureAbsent)
     auto result     = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::UnsupportedCommand);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::UnsupportedCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -560,7 +560,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_CrossPairVoltageViolation)
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
     auto statusCode           = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::ConstraintError);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::ConstraintError);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -628,7 +628,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_SingleSidedWithStoredBaseline)
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
     auto statusCode          = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::ConstraintError);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::ConstraintError);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -648,7 +648,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_DelegateRejects)
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
     auto statusCode          = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::Failure);
 
     // Threshold must not have been persisted.
     int64_t val = 0;
@@ -674,7 +674,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_AbsentFeatureFieldRejected)
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
     auto statusCode           = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode->GetStatus(), Status::InvalidCommand);
+    EXPECT_EQ(statusCode.value().GetStatus(), Status::InvalidCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -419,8 +419,8 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateRejects)
 
     ClusterTester tester(cluster);
     Commands::ModifyEnabledAlarms::Type cmd;
-    cmd.mask    = BitMask<AlarmBitmap>();
-    auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    cmd.mask        = BitMask<AlarmBitmap>();
+    auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
     EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
@@ -440,8 +440,8 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_UnsupportedBits)
     // Supported is empty; any non-zero mask has unsupported bits.
     ClusterTester tester(cluster);
     Commands::ModifyEnabledAlarms::Type cmd;
-    cmd.mask    = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
-    auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    cmd.mask        = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
+    auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
     EXPECT_EQ(statusCode->GetStatus(), Status::InvalidCommand);
@@ -512,8 +512,8 @@ TEST_F(TestElectricalAlarmCluster, Reset_DelegateRejects)
 
     ClusterTester tester(cluster);
     Commands::Reset::Type cmd;
-    cmd.alarms  = supported;
-    auto result = tester.Invoke(Commands::Reset::Id, cmd);
+    cmd.alarms      = supported;
+    auto result     = tester.Invoke(Commands::Reset::Id, cmd);
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
     EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
@@ -536,7 +536,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_FeatureAbsent)
 
     ClusterTester tester(cluster);
     Commands::SetElectricalAlarmThresholds::Type cmd;
-    auto result = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    auto result     = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
     auto statusCode = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
     EXPECT_EQ(statusCode->GetStatus(), Status::UnsupportedCommand);
@@ -558,7 +558,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_CrossPairVoltageViolation)
     cmd.overVoltageThreshold  = MakeOptional<int64_t>(1000);
     cmd.underVoltageThreshold = MakeOptional<int64_t>(2000);
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    auto statusCode = result.GetStatusCode();
+    auto statusCode           = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
     EXPECT_EQ(statusCode->GetStatus(), Status::ConstraintError);
 
@@ -626,7 +626,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_SingleSidedWithStoredBaseline)
     // Supply only over; stored under (500) acts as baseline → over (200) ≤ under (500) → ConstraintError.
     cmd.overVoltageThreshold = MakeOptional<int64_t>(200);
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    auto statusCode = result.GetStatusCode();
+    auto statusCode          = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
     EXPECT_EQ(statusCode->GetStatus(), Status::ConstraintError);
 
@@ -646,7 +646,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_DelegateRejects)
     Commands::SetElectricalAlarmThresholds::Type cmd;
     cmd.overVoltageThreshold = MakeOptional<int64_t>(1000);
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    auto statusCode = result.GetStatusCode();
+    auto statusCode          = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
     EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
 
@@ -672,7 +672,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_AbsentFeatureFieldRejected)
     // underVoltageThreshold field present but kUnderVoltage feature absent.
     cmd.underVoltageThreshold = MakeOptional<int64_t>(500);
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    auto statusCode = result.GetStatusCode();
+    auto statusCode           = result.GetStatusCode();
     ASSERT_TRUE(statusCode.has_value());
     EXPECT_EQ(statusCode->GetStatus(), Status::InvalidCommand);
 

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -419,8 +419,8 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateRejects)
 
     ClusterTester tester(cluster);
     Commands::ModifyEnabledAlarms::Type cmd;
-    cmd.mask        = BitMask<AlarmBitmap>();
-    auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    cmd.mask    = BitMask<AlarmBitmap>();
+    auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
     ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
     if (statusCode.has_value())
@@ -443,8 +443,8 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_UnsupportedBits)
     // Supported is empty; any non-zero mask has unsupported bits.
     ClusterTester tester(cluster);
     Commands::ModifyEnabledAlarms::Type cmd;
-    cmd.mask        = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
-    auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    cmd.mask    = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
+    auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
     ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
     if (statusCode.has_value())
@@ -521,8 +521,8 @@ TEST_F(TestElectricalAlarmCluster, Reset_DelegateRejects)
 
     ClusterTester tester(cluster);
     Commands::Reset::Type cmd;
-    cmd.alarms      = supported;
-    auto result     = tester.Invoke(Commands::Reset::Id, cmd);
+    cmd.alarms  = supported;
+    auto result = tester.Invoke(Commands::Reset::Id, cmd);
     ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
     if (statusCode.has_value())
@@ -548,7 +548,7 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_FeatureAbsent)
 
     ClusterTester tester(cluster);
     Commands::SetElectricalAlarmThresholds::Type cmd;
-    auto result     = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    auto result = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
     ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
     if (statusCode.has_value())

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -421,8 +421,9 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateRejects)
     Commands::ModifyEnabledAlarms::Type cmd;
     cmd.mask    = BitMask<AlarmBitmap>();
     auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
     // Mask must be unchanged.
     EXPECT_EQ(cluster.GetMask(), supported);
 
@@ -441,8 +442,9 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_UnsupportedBits)
     Commands::ModifyEnabledAlarms::Type cmd;
     cmd.mask    = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
     auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::InvalidCommand);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::InvalidCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -463,8 +465,9 @@ TEST_F(TestElectricalAlarmCluster, Reset_FeatureAbsent)
     cmd.alarms  = BitMask<AlarmBitmap>();
     auto result = tester.Invoke(Commands::Reset::Id, cmd);
     // Command is not in AcceptedCommands — ClusterTester returns UnsupportedCommand.
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedCommand);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::UnsupportedCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -511,8 +514,9 @@ TEST_F(TestElectricalAlarmCluster, Reset_DelegateRejects)
     Commands::Reset::Type cmd;
     cmd.alarms  = supported;
     auto result = tester.Invoke(Commands::Reset::Id, cmd);
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
     // State must be unchanged.
     EXPECT_TRUE(cluster.GetState().Has(AlarmBitmap::kOverVoltage));
 
@@ -533,8 +537,9 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_FeatureAbsent)
     ClusterTester tester(cluster);
     Commands::SetElectricalAlarmThresholds::Type cmd;
     auto result = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedCommand);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::UnsupportedCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -553,8 +558,9 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_CrossPairVoltageViolation)
     cmd.overVoltageThreshold  = MakeOptional<int64_t>(1000);
     cmd.underVoltageThreshold = MakeOptional<int64_t>(2000);
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::ConstraintError);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -620,8 +626,9 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_SingleSidedWithStoredBaseline)
     // Supply only over; stored under (500) acts as baseline → over (200) ≤ under (500) → ConstraintError.
     cmd.overVoltageThreshold = MakeOptional<int64_t>(200);
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::ConstraintError);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -639,8 +646,9 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_DelegateRejects)
     Commands::SetElectricalAlarmThresholds::Type cmd;
     cmd.overVoltageThreshold = MakeOptional<int64_t>(1000);
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
 
     // Threshold must not have been persisted.
     int64_t val = 0;
@@ -664,8 +672,9 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_AbsentFeatureFieldRejected)
     // underVoltageThreshold field present but kUnderVoltage feature absent.
     cmd.underVoltageThreshold = MakeOptional<int64_t>(500);
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    ASSERT_TRUE(result.GetStatusCode().has_value());
-    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::InvalidCommand);
+    auto statusCode = result.GetStatusCode();
+    ASSERT_TRUE(statusCode.has_value());
+    EXPECT_EQ(statusCode->GetStatus(), Status::InvalidCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -421,9 +421,12 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateRejects)
     Commands::ModifyEnabledAlarms::Type cmd;
     cmd.mask        = BitMask<AlarmBitmap>();
     auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::Failure);
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
+    }
     // Mask must be unchanged.
     EXPECT_EQ(cluster.GetMask(), supported);
 
@@ -442,9 +445,12 @@ TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_UnsupportedBits)
     Commands::ModifyEnabledAlarms::Type cmd;
     cmd.mask        = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
     auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::InvalidCommand);
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::InvalidCommand);
+    }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -465,9 +471,12 @@ TEST_F(TestElectricalAlarmCluster, Reset_FeatureAbsent)
     cmd.alarms  = BitMask<AlarmBitmap>();
     auto result = tester.Invoke(Commands::Reset::Id, cmd);
     // Command is not in AcceptedCommands — ClusterTester returns UnsupportedCommand.
+    ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::UnsupportedCommand);
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::UnsupportedCommand);
+    }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -514,9 +523,12 @@ TEST_F(TestElectricalAlarmCluster, Reset_DelegateRejects)
     Commands::Reset::Type cmd;
     cmd.alarms      = supported;
     auto result     = tester.Invoke(Commands::Reset::Id, cmd);
+    ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::Failure);
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
+    }
     // State must be unchanged.
     EXPECT_TRUE(cluster.GetState().Has(AlarmBitmap::kOverVoltage));
 
@@ -537,9 +549,12 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_FeatureAbsent)
     ClusterTester tester(cluster);
     Commands::SetElectricalAlarmThresholds::Type cmd;
     auto result     = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    ASSERT_FALSE(result.IsSuccess());
     auto statusCode = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::UnsupportedCommand);
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::UnsupportedCommand);
+    }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -558,9 +573,12 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_CrossPairVoltageViolation)
     cmd.overVoltageThreshold  = MakeOptional<int64_t>(1000);
     cmd.underVoltageThreshold = MakeOptional<int64_t>(2000);
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    auto statusCode           = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::ConstraintError);
+    ASSERT_FALSE(result.IsSuccess());
+    auto statusCode = result.GetStatusCode();
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::ConstraintError);
+    }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -626,9 +644,12 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_SingleSidedWithStoredBaseline)
     // Supply only over; stored under (500) acts as baseline → over (200) ≤ under (500) → ConstraintError.
     cmd.overVoltageThreshold = MakeOptional<int64_t>(200);
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    auto statusCode          = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::ConstraintError);
+    ASSERT_FALSE(result.IsSuccess());
+    auto statusCode = result.GetStatusCode();
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::ConstraintError);
+    }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -646,9 +667,12 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_DelegateRejects)
     Commands::SetElectricalAlarmThresholds::Type cmd;
     cmd.overVoltageThreshold = MakeOptional<int64_t>(1000);
     auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    auto statusCode          = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::Failure);
+    ASSERT_FALSE(result.IsSuccess());
+    auto statusCode = result.GetStatusCode();
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
+    }
 
     // Threshold must not have been persisted.
     int64_t val = 0;
@@ -672,9 +696,12 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_AbsentFeatureFieldRejected)
     // underVoltageThreshold field present but kUnderVoltage feature absent.
     cmd.underVoltageThreshold = MakeOptional<int64_t>(500);
     auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
-    auto statusCode           = result.GetStatusCode();
-    ASSERT_TRUE(statusCode.has_value());
-    EXPECT_EQ(statusCode.value().GetStatus(), Status::InvalidCommand);
+    ASSERT_FALSE(result.IsSuccess());
+    auto statusCode = result.GetStatusCode();
+    if (statusCode.has_value())
+    {
+        EXPECT_EQ(statusCode->GetStatus(), Status::InvalidCommand);
+    }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -21,6 +21,7 @@
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
 #include <clusters/ElectricalAlarm/Attributes.h>
+#include <clusters/ElectricalAlarm/Commands.h>
 #include <clusters/ElectricalAlarm/Metadata.h>
 
 #include <pw_unit_test/framework.h>
@@ -347,6 +348,331 @@ TEST_F(TestElectricalAlarmCluster, ThresholdSetterRejectsWithoutFeature)
 
     EXPECT_EQ(cluster.SetOverVoltageThreshold(100), Status::UnsupportedAttribute);
     EXPECT_EQ(cluster.SetUnderVoltageThreshold(-100), Status::UnsupportedAttribute);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// SetSupportedValue with Latch narrowing
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, SetSupportedNarrowsLatchAndMask)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kReset));
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetMaskValue(supported), Status::Success);
+
+    // Latch both bits.
+    EXPECT_EQ(cluster.SetLatchValue(supported), Status::Success);
+
+    // Narrow Supported to just kOverVoltage — Latch AND Mask must narrow.
+    BitMask<AlarmBitmap> narrowed(AlarmBitmap::kOverVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(narrowed), Status::Success);
+    EXPECT_EQ(cluster.GetMask(), narrowed);
+    EXPECT_EQ(cluster.GetLatch(), narrowed);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// ModifyEnabledAlarms command
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateAccepts)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetMaskValue(supported), Status::Success);
+
+    ClusterTester tester(cluster);
+    Commands::ModifyEnabledAlarms::Type cmd;
+    cmd.mask = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
+    auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    EXPECT_TRUE(result.status.has_value() && result.status->IsSuccess());
+    EXPECT_EQ(cluster.GetMask(), BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage));
+    EXPECT_EQ(delegate.modifyEnabledAlarmsCallCount, 1);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_DelegateRejects)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    delegate.allowModifyEnabledAlarms = false;
+    auto cluster                      = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetMaskValue(supported), Status::Success);
+
+    ClusterTester tester(cluster);
+    Commands::ModifyEnabledAlarms::Type cmd;
+    cmd.mask        = BitMask<AlarmBitmap>();
+    auto result     = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
+    // Mask must be unchanged.
+    EXPECT_EQ(cluster.GetMask(), supported);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, ModifyEnabledAlarms_UnsupportedBits)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    // Supported is empty; any non-zero mask has unsupported bits.
+    ClusterTester tester(cluster);
+    Commands::ModifyEnabledAlarms::Type cmd;
+    cmd.mask    = BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage);
+    auto result = tester.Invoke(Commands::ModifyEnabledAlarms::Id, cmd);
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::InvalidCommand);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// Reset command
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, Reset_FeatureAbsent)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>()); // no kReset
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::Reset::Type cmd;
+    cmd.alarms  = BitMask<AlarmBitmap>();
+    auto result = tester.Invoke(Commands::Reset::Id, cmd);
+    // Command is not in AcceptedCommands — ClusterTester returns UnsupportedCommand.
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedCommand);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, Reset_DelegateAccepts)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kReset));
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetMaskValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetLatchValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetStateValue(supported), Status::Success);
+
+    ClusterTester tester(cluster);
+    Commands::Reset::Type cmd;
+    cmd.alarms  = supported;
+    auto result = tester.Invoke(Commands::Reset::Id, cmd);
+    EXPECT_TRUE(result.status.has_value() && result.status->IsSuccess());
+    EXPECT_FALSE(cluster.GetState().Has(AlarmBitmap::kOverVoltage));
+    EXPECT_EQ(delegate.resetAlarmsCallCount, 1);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, Reset_DelegateRejects)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    delegate.allowReset = false;
+    auto cluster        = MakeCluster(delegate, BitMask<Feature>(Feature::kReset));
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetMaskValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetLatchValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetStateValue(supported), Status::Success);
+
+    ClusterTester tester(cluster);
+    Commands::Reset::Type cmd;
+    cmd.alarms  = supported;
+    auto result = tester.Invoke(Commands::Reset::Id, cmd);
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
+    // State must be unchanged.
+    EXPECT_TRUE(cluster.GetState().Has(AlarmBitmap::kOverVoltage));
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// SetElectricalAlarmThresholds command
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, SetThresholds_FeatureAbsent)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kOverVoltage)); // no kAdjustableThresholds
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::SetElectricalAlarmThresholds::Type cmd;
+    auto result     = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::UnsupportedCommand);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, SetThresholds_CrossPairVoltageViolation)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    BitMask<Feature> features(Feature::kAdjustableThresholds, Feature::kOverVoltage, Feature::kUnderVoltage);
+    auto cluster = MakeCluster(delegate, features);
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::SetElectricalAlarmThresholds::Type cmd;
+    // Over ≤ Under — should be rejected.
+    cmd.overVoltageThreshold  = MakeOptional<int64_t>(1000);
+    cmd.underVoltageThreshold = MakeOptional<int64_t>(2000);
+    auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, SetThresholds_ImportExportBothZero)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    BitMask<Feature> features(Feature::kAdjustableThresholds, Feature::kPowerImport, Feature::kPowerExport);
+    auto cluster = MakeCluster(delegate, features);
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::SetElectricalAlarmThresholds::Type cmd;
+    // Both at zero is a valid quiescent state (import >= export with non-strict check).
+    cmd.powerImportThreshold = MakeOptional<int64_t>(0);
+    cmd.powerExportThreshold = MakeOptional<int64_t>(0);
+    auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    EXPECT_TRUE(result.status.has_value() && result.status->IsSuccess());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, SetThresholds_ValidPairPersisted)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    BitMask<Feature> features(Feature::kAdjustableThresholds, Feature::kOverVoltage, Feature::kUnderVoltage);
+    auto cluster = MakeCluster(delegate, features);
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::SetElectricalAlarmThresholds::Type cmd;
+    cmd.overVoltageThreshold  = MakeOptional<int64_t>(3000);
+    cmd.underVoltageThreshold = MakeOptional<int64_t>(1000);
+    auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    EXPECT_TRUE(result.status.has_value() && result.status->IsSuccess());
+
+    // Verify thresholds were persisted.
+    int64_t val = 0;
+    EXPECT_TRUE(tester.ReadAttribute(Attributes::OverVoltageThreshold::Id, val).IsSuccess());
+    EXPECT_EQ(val, 3000);
+    EXPECT_TRUE(tester.ReadAttribute(Attributes::UnderVoltageThreshold::Id, val).IsSuccess());
+    EXPECT_EQ(val, 1000);
+    EXPECT_EQ(delegate.setThresholdsCallCount, 1);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, SetThresholds_SingleSidedWithStoredBaseline)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    BitMask<Feature> features(Feature::kAdjustableThresholds, Feature::kOverVoltage, Feature::kUnderVoltage);
+    auto cluster = MakeCluster(delegate, features);
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    // Establish a baseline for under voltage.
+    EXPECT_EQ(cluster.SetUnderVoltageThreshold(500), Status::Success);
+
+    ClusterTester tester(cluster);
+    Commands::SetElectricalAlarmThresholds::Type cmd;
+    // Supply only over; stored under (500) acts as baseline → over (200) ≤ under (500) → ConstraintError.
+    cmd.overVoltageThreshold = MakeOptional<int64_t>(200);
+    auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::ConstraintError);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, SetThresholds_DelegateRejects)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    delegate.allowSetThresholds = false;
+    BitMask<Feature> features(Feature::kAdjustableThresholds, Feature::kOverVoltage);
+    auto cluster = MakeCluster(delegate, features);
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::SetElectricalAlarmThresholds::Type cmd;
+    cmd.overVoltageThreshold = MakeOptional<int64_t>(1000);
+    auto result              = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::Failure);
+
+    // Threshold must not have been persisted.
+    int64_t val = 0;
+    EXPECT_TRUE(tester.ReadAttribute(Attributes::OverVoltageThreshold::Id, val).IsSuccess());
+    EXPECT_EQ(val, 0);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, SetThresholds_AbsentFeatureFieldRejected)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    // Only kOverVoltage + ADJUST — underVoltage feature is absent.
+    BitMask<Feature> features(Feature::kAdjustableThresholds, Feature::kOverVoltage);
+    auto cluster = MakeCluster(delegate, features);
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::SetElectricalAlarmThresholds::Type cmd;
+    // underVoltageThreshold field present but kUnderVoltage feature absent.
+    cmd.underVoltageThreshold = MakeOptional<int64_t>(500);
+    auto result               = tester.Invoke(Commands::SetElectricalAlarmThresholds::Id, cmd);
+    EXPECT_EQ(result.GetStatusCode()->GetStatus(), Status::InvalidCommand);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// ResetLatchedAlarms — feature guard on public C++ API
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, ResetLatchedAlarms_FeatureAbsent)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>()); // no kReset
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    EXPECT_EQ(cluster.ResetLatchedAlarms(BitMask<AlarmBitmap>(AlarmBitmap::kOverVoltage)), Status::UnsupportedCommand);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -76,9 +76,9 @@ TEST_F(TestElectricalAlarmCluster, ResetFeatureAddsLatch)
     auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kReset));
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
-    EXPECT_TRUE(IsAttributesListEqualTo(
-        cluster, { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry, Attributes::Supported::kMetadataEntry,
-                   Attributes::Latch::kMetadataEntry }));
+    EXPECT_TRUE(IsAttributesListEqualTo(cluster,
+                                        { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry,
+                                          Attributes::Supported::kMetadataEntry, Attributes::Latch::kMetadataEntry }));
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
@@ -89,9 +89,10 @@ TEST_F(TestElectricalAlarmCluster, OverVoltageFeatureAddsThreshold)
     auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kOverVoltage));
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
-    EXPECT_TRUE(IsAttributesListEqualTo(
-        cluster, { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry, Attributes::Supported::kMetadataEntry,
-                   Attributes::OverVoltageThreshold::kMetadataEntry }));
+    EXPECT_TRUE(
+        IsAttributesListEqualTo(cluster,
+                                { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry,
+                                  Attributes::Supported::kMetadataEntry, Attributes::OverVoltageThreshold::kMetadataEntry }));
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
@@ -106,13 +107,14 @@ TEST_F(TestElectricalAlarmCluster, AllFeaturesAttributeList)
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
     EXPECT_TRUE(IsAttributesListEqualTo(
-        cluster, { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry, Attributes::Supported::kMetadataEntry,
-                   Attributes::Latch::kMetadataEntry, Attributes::OverVoltageThreshold::kMetadataEntry,
-                   Attributes::UnderVoltageThreshold::kMetadataEntry, Attributes::OverFrequencyThreshold::kMetadataEntry,
-                   Attributes::UnderFrequencyThreshold::kMetadataEntry, Attributes::OverPowerThreshold::kMetadataEntry,
-                   Attributes::UnderPowerThreshold::kMetadataEntry, Attributes::OverCurrentThreshold::kMetadataEntry,
-                   Attributes::UnderCurrentThreshold::kMetadataEntry, Attributes::PowerImportThreshold::kMetadataEntry,
-                   Attributes::PowerExportThreshold::kMetadataEntry }));
+        cluster,
+        { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry, Attributes::Supported::kMetadataEntry,
+          Attributes::Latch::kMetadataEntry, Attributes::OverVoltageThreshold::kMetadataEntry,
+          Attributes::UnderVoltageThreshold::kMetadataEntry, Attributes::OverFrequencyThreshold::kMetadataEntry,
+          Attributes::UnderFrequencyThreshold::kMetadataEntry, Attributes::OverPowerThreshold::kMetadataEntry,
+          Attributes::UnderPowerThreshold::kMetadataEntry, Attributes::OverCurrentThreshold::kMetadataEntry,
+          Attributes::UnderCurrentThreshold::kMetadataEntry, Attributes::PowerImportThreshold::kMetadataEntry,
+          Attributes::PowerExportThreshold::kMetadataEntry }));
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -1,0 +1,352 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/electrical-alarm-server/ElectricalAlarmCluster.h>
+#include <app/clusters/electrical-alarm-server/tests/MockElectricalAlarmDelegate.h>
+#include <app/server-cluster/testing/ClusterTester.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <app/server-cluster/testing/ValidateGlobalAttributes.h>
+#include <clusters/ElectricalAlarm/Attributes.h>
+#include <clusters/ElectricalAlarm/Metadata.h>
+
+#include <pw_unit_test/framework.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::ElectricalAlarm;
+using namespace chip::app::Clusters::ElectricalAlarm::Attributes;
+using namespace chip::Testing;
+using chip::Protocols::InteractionModel::Status;
+
+namespace {
+
+constexpr EndpointId kTestEndpointId = 1;
+
+// Helper: build a cluster for a given feature set.
+ElectricalAlarmCluster MakeCluster(MockElectricalAlarmDelegate & delegate, BitMask<Feature> features)
+{
+    return ElectricalAlarmCluster(ElectricalAlarmCluster::Config{
+        .endpointId = kTestEndpointId,
+        .delegate   = delegate,
+        .features   = features,
+    });
+}
+
+struct TestElectricalAlarmCluster : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+// ---------------------------------------------------------------------------
+// AttributeList / feature gating
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, NoFeaturesAttributeList)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+    EXPECT_TRUE(IsAttributesListEqualTo(
+        cluster, { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry, Attributes::Supported::kMetadataEntry }));
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, ResetFeatureAddsLatch)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kReset));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+    EXPECT_TRUE(IsAttributesListEqualTo(
+        cluster, { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry, Attributes::Supported::kMetadataEntry,
+                   Attributes::Latch::kMetadataEntry }));
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, OverVoltageFeatureAddsThreshold)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kOverVoltage));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+    EXPECT_TRUE(IsAttributesListEqualTo(
+        cluster, { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry, Attributes::Supported::kMetadataEntry,
+                   Attributes::OverVoltageThreshold::kMetadataEntry }));
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, AllFeaturesAttributeList)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    BitMask<Feature> all(Feature::kReset, Feature::kAdjustableThresholds, Feature::kOverVoltage, Feature::kUnderVoltage,
+                         Feature::kOverFrequency, Feature::kUnderFrequency, Feature::kOverPower, Feature::kUnderPower,
+                         Feature::kOverCurrent, Feature::kUnderCurrent, Feature::kPowerImport, Feature::kPowerExport);
+    auto cluster = MakeCluster(delegate, all);
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+    EXPECT_TRUE(IsAttributesListEqualTo(
+        cluster, { Attributes::Mask::kMetadataEntry, Attributes::State::kMetadataEntry, Attributes::Supported::kMetadataEntry,
+                   Attributes::Latch::kMetadataEntry, Attributes::OverVoltageThreshold::kMetadataEntry,
+                   Attributes::UnderVoltageThreshold::kMetadataEntry, Attributes::OverFrequencyThreshold::kMetadataEntry,
+                   Attributes::UnderFrequencyThreshold::kMetadataEntry, Attributes::OverPowerThreshold::kMetadataEntry,
+                   Attributes::UnderPowerThreshold::kMetadataEntry, Attributes::OverCurrentThreshold::kMetadataEntry,
+                   Attributes::UnderCurrentThreshold::kMetadataEntry, Attributes::PowerImportThreshold::kMetadataEntry,
+                   Attributes::PowerExportThreshold::kMetadataEntry }));
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// Startup validation
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, AdjustableThresholdsWithoutAlarmClassFails)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    // ADJUST alone (no alarm-class feature) must fail.
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kAdjustableThresholds));
+
+    EXPECT_NE(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, AdjustableThresholdsWithAlarmClassSucceeds)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kAdjustableThresholds, Feature::kOverVoltage));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// Attribute reads
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, ReadMandatoryAttributes)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+
+    BitMask<AlarmBitmap> mask, state, supported;
+    EXPECT_TRUE(tester.ReadAttribute(Mask::Id, mask).IsSuccess());
+    EXPECT_TRUE(tester.ReadAttribute(State::Id, state).IsSuccess());
+    EXPECT_TRUE(tester.ReadAttribute(Supported::Id, supported).IsSuccess());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, LatchUnsupportedWithoutReset)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    BitMask<AlarmBitmap> latch;
+    auto status = tester.ReadAttribute(Latch::Id, latch);
+    EXPECT_FALSE(status.IsSuccess());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, ThresholdUnsupportedWithoutFeature)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    int64_t val;
+    EXPECT_FALSE(tester.ReadAttribute(OverVoltageThreshold::Id, val).IsSuccess());
+    EXPECT_FALSE(tester.ReadAttribute(UnderVoltageThreshold::Id, val).IsSuccess());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, ThresholdReadWithFeature)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kOverVoltage));
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    EXPECT_EQ(cluster.SetOverVoltageThreshold(2500), Status::Success);
+
+    ClusterTester tester(cluster);
+    int64_t val = 0;
+    EXPECT_TRUE(tester.ReadAttribute(OverVoltageThreshold::Id, val).IsSuccess());
+    EXPECT_EQ(val, 2500);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// SetSupportedValue cascade
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, SetSupportedNarrowsMask)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+
+    // Set a mask that includes only supported bits.
+    BitMask<AlarmBitmap> mask(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetMaskValue(mask), Status::Success);
+
+    // Remove kUnderVoltage from Supported — Mask must narrow too.
+    BitMask<AlarmBitmap> narrowedSupported(AlarmBitmap::kOverVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(narrowedSupported), Status::Success);
+    EXPECT_EQ(cluster.GetMask(), narrowedSupported);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, SetMaskNarrowsState)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+
+    BitMask<AlarmBitmap> mask(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetMaskValue(mask), Status::Success);
+
+    // Activate both alarms in State.
+    BitMask<AlarmBitmap> state(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetStateValue(state), Status::Success);
+
+    // Narrow Mask to just kOverVoltage — State must drop kUnderVoltage.
+    BitMask<AlarmBitmap> narrowMask(AlarmBitmap::kOverVoltage);
+    EXPECT_EQ(cluster.SetMaskValue(narrowMask), Status::Success);
+    EXPECT_EQ(cluster.GetState(), narrowMask);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// SetStateValue latch preservation
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, LatchedBitsPreserved)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kReset));
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetMaskValue(supported), Status::Success);
+
+    // Latch kOverVoltage so it sticks once active.
+    BitMask<AlarmBitmap> latch(AlarmBitmap::kOverVoltage);
+    EXPECT_EQ(cluster.SetLatchValue(latch), Status::Success);
+
+    // Activate kOverVoltage.
+    BitMask<AlarmBitmap> both(AlarmBitmap::kOverVoltage, AlarmBitmap::kUnderVoltage);
+    EXPECT_EQ(cluster.SetStateValue(both), Status::Success);
+
+    // Now try to clear everything — kOverVoltage must stay because it's latched+active.
+    BitMask<AlarmBitmap> empty;
+    EXPECT_EQ(cluster.SetStateValue(empty), Status::Success);
+    EXPECT_TRUE(cluster.GetState().Has(AlarmBitmap::kOverVoltage));
+    EXPECT_FALSE(cluster.GetState().Has(AlarmBitmap::kUnderVoltage));
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalAlarmCluster, ResetClearsLatchedAlarms)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>(Feature::kReset));
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    BitMask<AlarmBitmap> supported(AlarmBitmap::kOverVoltage);
+    EXPECT_EQ(cluster.SetSupportedValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetMaskValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetLatchValue(supported), Status::Success);
+    EXPECT_EQ(cluster.SetStateValue(supported), Status::Success);
+
+    // Explicitly reset the latched alarm.
+    EXPECT_EQ(cluster.ResetLatchedAlarms(supported), Status::Success);
+    EXPECT_FALSE(cluster.GetState().Has(AlarmBitmap::kOverVoltage));
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// FeatureMap read
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, FeatureMapRead)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    BitMask<Feature> features(Feature::kReset, Feature::kOverVoltage);
+    auto cluster = MakeCluster(delegate, features);
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    uint32_t featureMapValue = 0;
+    EXPECT_TRUE(tester.ReadAttribute(FeatureMap::Id, featureMapValue).IsSuccess());
+    EXPECT_EQ(featureMapValue, features.Raw());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// ---------------------------------------------------------------------------
+// Threshold setter guard
+// ---------------------------------------------------------------------------
+
+TEST_F(TestElectricalAlarmCluster, ThresholdSetterRejectsWithoutFeature)
+{
+    TestServerClusterContext context;
+    MockElectricalAlarmDelegate delegate;
+    auto cluster = MakeCluster(delegate, BitMask<Feature>());
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    EXPECT_EQ(cluster.SetOverVoltageThreshold(100), Status::UnsupportedAttribute);
+    EXPECT_EQ(cluster.SetUnderVoltageThreshold(-100), Status::UnsupportedAttribute);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+} // namespace

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -674,10 +674,10 @@ TEST_F(TestElectricalAlarmCluster, SetThresholds_DelegateRejects)
         EXPECT_EQ(statusCode->GetStatus(), Status::Failure);
     }
 
-    // Threshold must not have been persisted.
+    // Threshold must not have been persisted (should still be the Fallback default, not 1000).
     int64_t val = 0;
     EXPECT_TRUE(tester.ReadAttribute(Attributes::OverVoltageThreshold::Id, val).IsSuccess());
-    EXPECT_EQ(val, 0);
+    EXPECT_NE(val, 1000);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
+++ b/src/app/clusters/electrical-alarm-server/tests/TestElectricalAlarmCluster.cpp
@@ -42,7 +42,7 @@ ElectricalAlarmCluster MakeCluster(MockElectricalAlarmDelegate & delegate, BitMa
 {
     return ElectricalAlarmCluster(ElectricalAlarmCluster::Config{
         .endpointId = kTestEndpointId,
-        .delegate   = delegate,
+        .delegate   = &delegate,
         .features   = features,
     });
 }

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -114,6 +114,7 @@ CodeDrivenClusters:
     - Dishwasher Alarm
     - Dishwasher Mode
     - Dynamic Lighting
+    - Electrical Alarm
     - Electrical Power Measurement
     - Electrical Protection Alarm
     - Energy EVSE

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -26,6 +26,7 @@ CommandHandlerInterfaceOnlyClusters:
     - Camera AV Settings User Level Management
     - Commodity Price
     - Commodity Tariff
+    - Electrical Alarm
     - Electrical Distribution
     - Electrical Energy Measurement
     - Joint Fabric Administrator

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -130,7 +130,6 @@ void MatterRvcOperationalStatePluginServerInitCallback() {}
 void MatterOvenModePluginServerInitCallback() {}
 void MatterOvenCavityOperationalStatePluginServerInitCallback() {}
 void MatterDishwasherAlarmPluginServerInitCallback() {}
-void MatterElectricalAlarmPluginServerInitCallback() {}
 void MatterMicrowaveOvenModePluginServerInitCallback() {}
 void MatterDeviceEnergyManagementModePluginServerInitCallback() {}
 void MatterEnergyEvseModePluginServerInitCallback() {}

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -130,6 +130,7 @@ void MatterRvcOperationalStatePluginServerInitCallback() {}
 void MatterOvenModePluginServerInitCallback() {}
 void MatterOvenCavityOperationalStatePluginServerInitCallback() {}
 void MatterDishwasherAlarmPluginServerInitCallback() {}
+void MatterElectricalAlarmPluginServerInitCallback() {}
 void MatterMicrowaveOvenModePluginServerInitCallback() {}
 void MatterDeviceEnergyManagementModePluginServerInitCallback() {}
 void MatterEnergyEvseModePluginServerInitCallback() {}

--- a/src/app/zap_cluster_list.json
+++ b/src/app/zap_cluster_list.json
@@ -231,7 +231,7 @@
         "DISHWASHER_ALARM_CLUSTER": ["dishwasher-alarm-server"],
         "DISHWASHER_MODE_CLUSTER": ["mode-base-server"],
         "DYNAMIC_LIGHTING_CLUSTER": ["dynamic-lighting-server"],
-        "ELECTRICAL_ALARM_CLUSTER": [],
+        "ELECTRICAL_ALARM_CLUSTER": ["electrical-alarm-server"],
         "ELECTRICAL_DISTRIBUTION_CLUSTER": ["electrical-distribution-server"],
         "ELECTRICAL_GRID_CONDITIONS_CLUSTER": [
             "electrical-grid-conditions-server"

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -7780,8 +7780,8 @@ namespace Attributes {
 
 namespace Mask {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint,
+                                               chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value)
 {
     using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
     Traits::StorageType temp;
@@ -7795,42 +7795,14 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint,
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value,
-                                        MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value)
-{
-    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
 } // namespace Mask
 
 namespace Latch {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint,
+                                               chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value)
 {
     using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
     Traits::StorageType temp;
@@ -7844,42 +7816,14 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint,
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value,
-                                        MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value)
-{
-    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
 } // namespace Latch
 
 namespace State {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint,
+                                               chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value)
 {
     using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
     Traits::StorageType temp;
@@ -7893,42 +7837,14 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint,
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value,
-                                        MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value)
-{
-    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
 } // namespace State
 
 namespace Supported {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint,
+                                               chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value)
 {
     using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
     Traits::StorageType temp;
@@ -7942,41 +7858,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint,
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value,
-                                        MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value)
-{
-    using Traits = NumericAttributeTraits<chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap>>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
 } // namespace Supported
 
 namespace OverVoltageThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -7990,40 +7878,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_VOLTAGE_MV_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_VOLTAGE_MV_ATTRIBUTE_TYPE);
 }
 
 } // namespace OverVoltageThreshold
 
 namespace UnderVoltageThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8037,40 +7898,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_VOLTAGE_MV_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_VOLTAGE_MV_ATTRIBUTE_TYPE);
 }
 
 } // namespace UnderVoltageThreshold
 
 namespace OverFrequencyThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8084,40 +7918,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_INT64S_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_INT64S_ATTRIBUTE_TYPE);
 }
 
 } // namespace OverFrequencyThreshold
 
 namespace UnderFrequencyThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8131,40 +7938,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_INT64S_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_INT64S_ATTRIBUTE_TYPE);
 }
 
 } // namespace UnderFrequencyThreshold
 
 namespace OverPowerThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8178,40 +7958,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_POWER_MW_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_POWER_MW_ATTRIBUTE_TYPE);
 }
 
 } // namespace OverPowerThreshold
 
 namespace UnderPowerThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8225,40 +7978,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_POWER_MW_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_POWER_MW_ATTRIBUTE_TYPE);
 }
 
 } // namespace UnderPowerThreshold
 
 namespace OverCurrentThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8272,40 +7998,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_AMPERAGE_MA_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_AMPERAGE_MA_ATTRIBUTE_TYPE);
 }
 
 } // namespace OverCurrentThreshold
 
 namespace UnderCurrentThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8319,40 +8018,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_AMPERAGE_MA_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_AMPERAGE_MA_ATTRIBUTE_TYPE);
 }
 
 } // namespace UnderCurrentThreshold
 
 namespace PowerImportThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8366,40 +8038,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_POWER_MW_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_POWER_MW_ATTRIBUTE_TYPE);
 }
 
 } // namespace PowerImportThreshold
 
 namespace PowerExportThreshold {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value)
 {
     using Traits = NumericAttributeTraits<int64_t>;
     Traits::StorageType temp;
@@ -8413,40 +8058,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_POWER_MW_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value)
-{
-    using Traits = NumericAttributeTraits<int64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_POWER_MW_ATTRIBUTE_TYPE);
 }
 
 } // namespace PowerExportThreshold
 
 namespace FeatureMap {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, uint32_t * value)
 {
     using Traits = NumericAttributeTraits<uint32_t>;
     Traits::StorageType temp;
@@ -8460,40 +8078,13 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<uint32_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_BITMAP32_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
-{
-    using Traits = NumericAttributeTraits<uint32_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
 } // namespace FeatureMap
 
 namespace ClusterRevision {
 
-Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, uint16_t * value)
 {
     using Traits = NumericAttributeTraits<uint16_t>;
     Traits::StorageType temp;
@@ -8507,33 +8098,6 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
     }
     *value = Traits::StorageToWorking(temp);
     return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::ElectricalAlarm::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::ElectricalAlarm::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ClusterRevision

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -1623,111 +1623,71 @@ namespace ElectricalAlarm {
 namespace Attributes {
 
 namespace Mask {
-Protocols::InteractionModel::Status Get(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value); // AlarmBitmap
-Protocols::InteractionModel::Status Set(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value,
-                                        MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status
+GetDefault(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value); // AlarmBitmap
 } // namespace Mask
 
 namespace Latch {
-Protocols::InteractionModel::Status Get(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value); // AlarmBitmap
-Protocols::InteractionModel::Status Set(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value,
-                                        MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status
+GetDefault(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value); // AlarmBitmap
 } // namespace Latch
 
 namespace State {
-Protocols::InteractionModel::Status Get(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value); // AlarmBitmap
-Protocols::InteractionModel::Status Set(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value,
-                                        MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status
+GetDefault(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value); // AlarmBitmap
 } // namespace State
 
 namespace Supported {
-Protocols::InteractionModel::Status Get(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value); // AlarmBitmap
-Protocols::InteractionModel::Status Set(EndpointId endpoint,
-                                        chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> value,
-                                        MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status
+GetDefault(EndpointId endpoint, chip::BitMask<chip::app::Clusters::ElectricalAlarm::AlarmBitmap> * value); // AlarmBitmap
 } // namespace Supported
 
 namespace OverVoltageThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // voltage_mv
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // voltage_mv
 } // namespace OverVoltageThreshold
 
 namespace UnderVoltageThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // voltage_mv
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // voltage_mv
 } // namespace UnderVoltageThreshold
 
 namespace OverFrequencyThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // int64s
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // int64s
 } // namespace OverFrequencyThreshold
 
 namespace UnderFrequencyThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // int64s
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // int64s
 } // namespace UnderFrequencyThreshold
 
 namespace OverPowerThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // power_mw
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // power_mw
 } // namespace OverPowerThreshold
 
 namespace UnderPowerThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // power_mw
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // power_mw
 } // namespace UnderPowerThreshold
 
 namespace OverCurrentThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // amperage_ma
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // amperage_ma
 } // namespace OverCurrentThreshold
 
 namespace UnderCurrentThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // amperage_ma
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // amperage_ma
 } // namespace UnderCurrentThreshold
 
 namespace PowerImportThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // power_mw
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // power_mw
 } // namespace PowerImportThreshold
 
 namespace PowerExportThreshold {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, int64_t * value); // power_mw
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, int64_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, int64_t * value); // power_mw
 } // namespace PowerExportThreshold
 
 namespace FeatureMap {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, uint32_t * value); // bitmap32
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, uint32_t * value); // bitmap32
 } // namespace FeatureMap
 
 namespace ClusterRevision {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value); // int16u
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty);
+Protocols::InteractionModel::Status GetDefault(EndpointId endpoint, uint16_t * value); // int16u
 } // namespace ClusterRevision
 
 } // namespace Attributes

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -7783,12 +7783,6 @@ bool emberAfMessagesClusterCancelMessagesRequestCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::Messages::Commands::CancelMessagesRequest::DecodableType & commandData);
 /**
- * @brief Electrical Protection Alarm Cluster ModifyEnabledAlarms Command callback (from client)
- */
-bool emberAfElectricalProtectionAlarmClusterModifyEnabledAlarmsCallback(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::ElectricalProtectionAlarm::Commands::ModifyEnabledAlarms::DecodableType & commandData);
-/**
  * @brief Door Lock Cluster LockDoor Command callback (from client)
  */
 bool emberAfDoorLockClusterLockDoorCallback(chip::app::CommandHandler * commandObj,

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -7783,23 +7783,11 @@ bool emberAfMessagesClusterCancelMessagesRequestCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::Messages::Commands::CancelMessagesRequest::DecodableType & commandData);
 /**
- * @brief Electrical Alarm Cluster Reset Command callback (from client)
+ * @brief Electrical Protection Alarm Cluster ModifyEnabledAlarms Command callback (from client)
  */
-bool emberAfElectricalAlarmClusterResetCallback(
+bool emberAfElectricalProtectionAlarmClusterModifyEnabledAlarmsCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::ElectricalAlarm::Commands::Reset::DecodableType & commandData);
-/**
- * @brief Electrical Alarm Cluster ModifyEnabledAlarms Command callback (from client)
- */
-bool emberAfElectricalAlarmClusterModifyEnabledAlarmsCallback(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::ElectricalAlarm::Commands::ModifyEnabledAlarms::DecodableType & commandData);
-/**
- * @brief Electrical Alarm Cluster SetElectricalAlarmThresholds Command callback (from client)
- */
-bool emberAfElectricalAlarmClusterSetElectricalAlarmThresholdsCallback(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::ElectricalAlarm::Commands::SetElectricalAlarmThresholds::DecodableType & commandData);
+    const chip::app::Clusters::ElectricalProtectionAlarm::Commands::ModifyEnabledAlarms::DecodableType & commandData);
 /**
  * @brief Door Lock Cluster LockDoor Command callback (from client)
  */


### PR DESCRIPTION
## Summary

Adds a code-driven `DefaultServerCluster` subclass for the **Electrical Alarm** cluster (0x00A1, ESALM) introduced in Matter 1.7.

**What this PR adds:**

- `ElectricalAlarmCluster` — `DefaultServerCluster` subclass with `ReadAttribute`, `Attributes`, `AcceptedCommands`, `InvokeCommand`
- Alarm Base attributes: `Mask`, `State`, `Supported`, `Latch` (RST feature-gated); cascade invariants (State ⊆ Mask ⊆ Supported, Latch ⊆ Supported) maintained across all setters
- Commands: `ModifyEnabledAlarms` (always), `Reset` (RST feature), `SetElectricalAlarmThresholds` (ADJT feature)
- 10 threshold attributes (`OverVoltageThreshold` … `PowerExportThreshold`), each feature-gated on the corresponding alarm-class feature bit
- `Notify` event fired on State transitions with correct `active`/`inactive` delta fields
- `CodegenIntegration.h/.cpp` — `Instance` wrapper for `RegisteredServerCluster` + `__attribute__((weak))` init/shutdown stubs
- `electrical-alarm-delegate.h` — application delegate interface (`ModifyEnabledAlarmsCallback`, `ResetAlarmsCallback`, `SetElectricalAlarmThresholdsCallback`)
- Unit tests in `tests/TestElectricalAlarmCluster.cpp`

**SDK wiring:**
- `src/app/clusters/BUILD.gn` — `electrical-alarm-server` added (keep-sorted)
- `src/app/common/templates/config-data.yaml` — `Electrical Alarm` added to `CodeDrivenClusters` and provisional list
- `src/app/zap_cluster_list.json` — `ELECTRICAL_ALARM_CLUSTER` mapped to `electrical-alarm-server`
- `src/BUILD.gn` — test target added (keep-sorted)
- `src/app/util/util.cpp` — bare stub removed; weak stubs in `CodegenIntegration.cpp` instead
- `app_config_dependent_sources.gni/.cmake` added

**Draft status:** App integration (enabling ESALM on the ECB endpoint of `electrical-protection-app`) is gated on PRs #73403 and #72320. The cluster server itself is app-independent and ready for review now.

Related:
- Cluster XML (merged): #72223
- ECB device-type ESALM include: #72320 (open)
- `electrical-protection-app`: #73403 (open)
- Python test scripts: #72763 (draft, gated on this PR + app integration)

### Testing

Unit tests (no app required):

```bash
scripts/run_in_build_env.sh "ninja -C out/linux-x64-tests-clang src/app/clusters/electrical-alarm-server/tests:TestElectricalAlarmCluster.run"
```

Integration testing against `electrical-protection-app` is deferred pending #73403 and #72320. The Python test scripts in #72763 will update their `app:` directive once app integration lands.