### PR TITLE
humidistat cluster: track MistType by SystemState, not Mode

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -8453,7 +8453,7 @@ endpoint 1 {
     ram      attribute maxSetpoint default = 60;
     ram      attribute step default = 5;
     ram      attribute targetSetpoint default = 40;
-    ram      attribute mistType default = 1;
+    ram      attribute mistType;
     ram      attribute continuous default = 0;
     ram      attribute sleep default = 0;
     ram      attribute optimal default = 0;

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -14714,7 +14714,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/src/app/clusters/humidistat-server/CodegenIntegration.cpp
+++ b/src/app/clusters/humidistat-server/CodegenIntegration.cpp
@@ -87,7 +87,8 @@ public:
         if (features.Has(Feature::kHumidifier))
         {
             VerifyOrDie(MistType::GetDefault(endpointId, config.mistType) == Status::Success);
-            VerifyOrDie((config.systemState == SystemStateEnum::kHumidifying)
+            const bool hasMistFeatures = features.HasAny(Feature::kColdMist, Feature::kWarmMist);
+            VerifyOrDie((config.systemState == SystemStateEnum::kHumidifying && hasMistFeatures)
                             ? (!config.mistType.IsNull() && config.mistType.Value().HasAny())
                             : config.mistType.IsNull());
         }

--- a/src/app/clusters/humidistat-server/CodegenIntegration.cpp
+++ b/src/app/clusters/humidistat-server/CodegenIntegration.cpp
@@ -87,8 +87,9 @@ public:
         if (features.Has(Feature::kHumidifier))
         {
             VerifyOrDie(MistType::GetDefault(endpointId, config.mistType) == Status::Success);
-            VerifyOrDie((config.mode == ModeEnum::kHumidifier) ? (!config.mistType.IsNull() && config.mistType.Value().HasAny())
-                                                               : (config.mistType.IsNull() || !config.mistType.Value().HasAny()));
+            VerifyOrDie((config.systemState == SystemStateEnum::kHumidifying)
+                            ? (!config.mistType.IsNull() && config.mistType.Value().HasAny())
+                            : config.mistType.IsNull());
         }
 
         if (features.Has(Feature::kContinuous))

--- a/src/app/clusters/humidistat-server/HumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.cpp
@@ -103,6 +103,25 @@ Humidistat::SystemStateEnum DefaultSystemStateForMode(Humidistat::ModeEnum mode)
     }
 }
 
+void ApplyDefaultMistTypeFromFeatures(BitFlags<Humidistat::Feature> features,
+                                      DataModel::Nullable<chip::BitMask<MistTypeBitmap>> & mistType)
+{
+    if (!mistType.IsNull() && mistType.Value().HasAny())
+    {
+        return;
+    }
+
+    mistType = DataModel::NullNullable;
+    if (features.Has(Feature::kColdMist))
+    {
+        mistType.SetNonNull(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold));
+    }
+    else if (features.Has(Feature::kWarmMist))
+    {
+        mistType.SetNonNull(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistWarm));
+    }
+}
+
 CHIP_ERROR EncodeSupportedModes(BitFlags<Humidistat::Feature> features, const AttributeValueEncoder::ListEncodeHelper & encoder)
 {
     if (features.Has(Feature::kHumidifier))
@@ -144,18 +163,13 @@ HumidistatCluster::HumidistatCluster(EndpointId endpointId, BitFlags<Humidistat:
 {
     VerifyOrDie(IsFeatureConfigurationValid(mFeatures));
 
-    if ((mMode == ModeEnum::kHumidifier) && (mMistType.IsNull() || !mMistType.Value().HasAny()))
+    if (mSystemState == SystemStateEnum::kHumidifying)
     {
-        ChipLogDetail(Zcl, "Humidistat: Startup MistType null/empty in Humidifier mode, applying feature default");
-        mMistType.SetNonNull();
-        if (mFeatures.Has(Feature::kColdMist))
-        {
-            mMistType.Value().Set(MistTypeBitmap::kMistCold);
-        }
-        else if (mFeatures.Has(Feature::kWarmMist))
-        {
-            mMistType.Value().Set(MistTypeBitmap::kMistWarm);
-        }
+        ApplyDefaultMistTypeFromFeatures(mFeatures, mMistType);
+    }
+    else
+    {
+        mMistType = DataModel::NullNullable;
     }
 
     // Spec constraints on Quality F (fixed) setpoint attributes.
@@ -164,7 +178,7 @@ HumidistatCluster::HumidistatCluster(EndpointId endpointId, BitFlags<Humidistat:
     VerifyOrDie(config.step >= 1 && config.step <= static_cast<chip::Percent>(config.maxSetpoint - config.minSetpoint));
     VerifyOrDie((config.maxSetpoint - config.minSetpoint) % config.step == 0);
     VerifyOrDie(IsMistTypeSupportable(mMistType));
-    VerifyOrDie(IsMistTypeConsistentWithMode(mMode, mMistType));
+    VerifyOrDie(IsMistTypeConsistentWithSystemState(mSystemState, mMistType));
 
     // Snap initial setpoints to the valid step grid.
     mUserSetpoint   = SnapToNearestStep(mUserSetpoint);
@@ -252,18 +266,15 @@ void HumidistatCluster::LoadPersistentAttributes()
         {
             loadedMistType.Value().Clear(MistTypeBitmap::kMistWarm);
         }
-        // Spec: MistType SHALL be zero when Mode is not Humidifier.
-        if (mMode != ModeEnum::kHumidifier)
+        // Spec: MistType SHALL be null when SystemState is not Humidifying.
+        if (mSystemState != SystemStateEnum::kHumidifying)
         {
-            if (!loadedMistType.IsNull())
-            {
-                loadedMistType.Value().ClearAll();
-            }
+            loadedMistType = DataModel::NullNullable;
         }
         else if (loadedMistType.IsNull() || !loadedMistType.Value().HasAny())
         {
-            ChipLogDetail(Zcl, "Humidistat: Loaded null/empty MistType in Humidifier mode, using startup default");
-            loadedMistType = mMistType;
+            ChipLogDetail(Zcl, "Humidistat: Loaded null/empty MistType in Humidifying state, using feature default");
+            ApplyDefaultMistTypeFromFeatures(mFeatures, loadedMistType);
         }
         mMistType = loadedMistType;
     }
@@ -356,20 +367,15 @@ bool HumidistatCluster::IsSystemStateSupported(Humidistat::SystemStateEnum syste
     }
 }
 
-bool HumidistatCluster::IsMistTypeConsistentWithMode(Humidistat::ModeEnum mode,
-                                                     DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const
+bool HumidistatCluster::IsMistTypeConsistentWithSystemState(
+    Humidistat::SystemStateEnum systemState, DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const
 {
-    if (mistType.IsNull())
+    if (systemState == SystemStateEnum::kHumidifying)
     {
-        return true;
+        return !mistType.IsNull() && mistType.Value().HasAny();
     }
 
-    if (mode == ModeEnum::kHumidifier)
-    {
-        return mistType.Value().HasAny();
-    }
-
-    return !mistType.Value().HasAny();
+    return mistType.IsNull();
 }
 
 bool HumidistatCluster::ShouldTargetSetpointMatchUserSetpoint() const
@@ -462,9 +468,6 @@ CHIP_ERROR HumidistatCluster::SetMode(Humidistat::ModeEnum mode)
 {
     VerifyOrReturnError(IsModeSupported(mode), CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
-    const bool shouldClearMistType =
-        mFeatures.Has(Feature::kHumidifier) && (mode != ModeEnum::kHumidifier) && !mMistType.IsNull() && mMistType.Value().HasAny();
-
     if (SetAttributeValue(mMode, mode, Mode::Id))
     {
         if (mContext != nullptr)
@@ -480,10 +483,7 @@ CHIP_ERROR HumidistatCluster::SetMode(Humidistat::ModeEnum mode)
         }
     }
 
-    VerifyOrReturnValue(shouldClearMistType, CHIP_NO_ERROR);
-
-    // Spec: "If the value of Mode is not set to Humidifier, all bits of MistType SHALL be set to zero."
-    return SetMistType(chip::BitMask<MistTypeBitmap>{});
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR HumidistatCluster::SetSystemState(Humidistat::SystemStateEnum systemState)
@@ -501,6 +501,21 @@ CHIP_ERROR HumidistatCluster::SetSystemState(Humidistat::SystemStateEnum systemS
     if (mDelegate != nullptr)
     {
         mDelegate->OnSystemStateChanged(mSystemState);
+    }
+
+    if (mFeatures.Has(Feature::kHumidifier) && (mSystemState != SystemStateEnum::kHumidifying))
+    {
+        LogErrorOnFailure(SetMistType(DataModel::NullNullable));
+        return CHIP_NO_ERROR;
+    }
+
+    if (mFeatures.Has(Feature::kHumidifier) && (mSystemState == SystemStateEnum::kHumidifying) &&
+        (mMistType.IsNull() || !mMistType.Value().HasAny()))
+    {
+        DataModel::Nullable<chip::BitMask<MistTypeBitmap>> defaultMistType = DataModel::NullNullable;
+        ApplyDefaultMistTypeFromFeatures(mFeatures, defaultMistType);
+        LogErrorOnFailure(SetMistType(defaultMistType));
+        return CHIP_NO_ERROR;
     }
 
     return CHIP_NO_ERROR;
@@ -558,8 +573,10 @@ CHIP_ERROR HumidistatCluster::SetUserSetpoint(chip::Percent userSetpoint)
 CHIP_ERROR HumidistatCluster::SetMistType(DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType)
 {
     VerifyOrReturnError(mFeatures.Has(Feature::kHumidifier), CHIP_IM_GLOBAL_STATUS(ConstraintError));
-    VerifyOrReturnError(IsMistTypeConsistentWithMode(mMode, mistType), CHIP_IM_GLOBAL_STATUS(ConstraintError));
-    VerifyOrReturnError(IsMistTypeSupportable(mistType), CHIP_IM_GLOBAL_STATUS(InvalidInState));
+    // Reject non-null MistType when not humidifying (e.g. dehumidifying mode).
+    VerifyOrReturnError(IsMistTypeConsistentWithSystemState(mSystemState, mistType), CHIP_IM_GLOBAL_STATUS(InvalidInState));
+    // Reject bits for mist types whose feature flag is absent (e.g. kMistWarm without kWarmMist).
+    VerifyOrReturnError(IsMistTypeSupportable(mistType), CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
     if (mistType.IsNull())
     {
@@ -888,20 +905,19 @@ DataModel::ActionReturnStatus HumidistatCluster::HandleSetSettings(chip::TLV::TL
     Commands::SetSettings::DecodableType commandData;
     ReturnErrorOnFailure(commandData.Decode(input_arguments));
 
-    ModeEnum effectiveMode = mMode;
     if (commandData.mode.HasValue())
     {
         VerifyOrReturnError(IsModeSupported(commandData.mode.Value()), CHIP_IM_GLOBAL_STATUS(ConstraintError));
-        effectiveMode = commandData.mode.Value();
     }
 
-    // Spec: "If the value of Mode is not set to Humidifier, all bits of MistType SHALL be set to zero."
+    // Spec: MistType SHALL be null when SystemState is not Humidifying.
     if (commandData.mistType.HasValue() && mFeatures.Has(Feature::kHumidifier))
     {
-        VerifyOrReturnError(IsMistTypeConsistentWithMode(effectiveMode, commandData.mistType.Value()),
-                            CHIP_IM_GLOBAL_STATUS(ConstraintError));
-        // Spec: unsupported bits SHALL result in INVALID_IN_STATE.
-        VerifyOrReturnError(IsMistTypeSupportable(commandData.mistType.Value()), CHIP_IM_GLOBAL_STATUS(InvalidInState));
+        // Reject non-null MistType when not humidifying (e.g. dehumidifying mode).
+        VerifyOrReturnError(IsMistTypeConsistentWithSystemState(mSystemState, commandData.mistType.Value()),
+                            CHIP_IM_GLOBAL_STATUS(InvalidInState));
+        // Reject bits for mist types whose feature flag is absent (e.g. kMistWarm without kWarmMist).
+        VerifyOrReturnError(IsMistTypeSupportable(commandData.mistType.Value()), CHIP_IM_GLOBAL_STATUS(ConstraintError));
     }
 
     if (commandData.userSetpoint.HasValue() && mFeatures.Has(Feature::kSensor))

--- a/src/app/clusters/humidistat-server/HumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.cpp
@@ -372,6 +372,11 @@ bool HumidistatCluster::IsMistTypeConsistentWithSystemState(
 {
     if (systemState == SystemStateEnum::kHumidifying)
     {
+        // When no mist feature is supported, null is the only reachable value.
+        if (!mFeatures.Has(Feature::kColdMist) && !mFeatures.Has(Feature::kWarmMist))
+        {
+            return mistType.IsNull();
+        }
         return !mistType.IsNull() && mistType.Value().HasAny();
     }
 
@@ -490,6 +495,20 @@ CHIP_ERROR HumidistatCluster::SetSystemState(Humidistat::SystemStateEnum systemS
 {
     VerifyOrReturnError(IsSystemStateSupported(systemState), CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
+    // Pre-compute the MistType that will result from this transition before committing any state.
+    DataModel::Nullable<chip::BitMask<MistTypeBitmap>> newMistType = mMistType;
+    if (mFeatures.Has(Feature::kHumidifier))
+    {
+        if (systemState != SystemStateEnum::kHumidifying)
+        {
+            newMistType = DataModel::NullNullable;
+        }
+        else if (newMistType.IsNull() || !newMistType.Value().HasAny())
+        {
+            ApplyDefaultMistTypeFromFeatures(mFeatures, newMistType);
+        }
+    }
+
     VerifyOrReturnValue(SetAttributeValue(mSystemState, systemState, SystemState::Id), CHIP_NO_ERROR);
     if (mContext != nullptr)
     {
@@ -498,24 +517,15 @@ CHIP_ERROR HumidistatCluster::SetSystemState(Humidistat::SystemStateEnum systemS
             ConcreteAttributePath(mPath.mEndpointId, Humidistat::Id, SystemState::Id), mSystemState));
     }
 
+    // Establish the MistType invariant before notifying the delegate.
+    if (mFeatures.Has(Feature::kHumidifier))
+    {
+        ReturnErrorOnFailure(SetMistType(newMistType));
+    }
+
     if (mDelegate != nullptr)
     {
         mDelegate->OnSystemStateChanged(mSystemState);
-    }
-
-    if (mFeatures.Has(Feature::kHumidifier) && (mSystemState != SystemStateEnum::kHumidifying))
-    {
-        LogErrorOnFailure(SetMistType(DataModel::NullNullable));
-        return CHIP_NO_ERROR;
-    }
-
-    if (mFeatures.Has(Feature::kHumidifier) && (mSystemState == SystemStateEnum::kHumidifying) &&
-        (mMistType.IsNull() || !mMistType.Value().HasAny()))
-    {
-        DataModel::Nullable<chip::BitMask<MistTypeBitmap>> defaultMistType = DataModel::NullNullable;
-        ApplyDefaultMistTypeFromFeatures(mFeatures, defaultMistType);
-        LogErrorOnFailure(SetMistType(defaultMistType));
-        return CHIP_NO_ERROR;
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/clusters/humidistat-server/HumidistatCluster.h
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.h
@@ -123,7 +123,7 @@ public:
         chip::Percent maxSetpoint               = 100;
         chip::Percent step                      = 1;
         chip::Percent targetSetpoint            = 50;
-        DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType{ chip::BitMask<Humidistat::MistTypeBitmap>{ 0 } };
+        DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType = DataModel::NullNullable;
         bool continuous = false;
         bool sleep      = false;
         bool optimal    = false;
@@ -225,8 +225,8 @@ private:
 
     bool IsModeSupported(Humidistat::ModeEnum mode) const;
     bool IsSystemStateSupported(Humidistat::SystemStateEnum systemState) const;
-    bool IsMistTypeConsistentWithMode(Humidistat::ModeEnum mode,
-                                      DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const;
+    bool IsMistTypeConsistentWithSystemState(Humidistat::SystemStateEnum systemState,
+                                             DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const;
     bool ShouldTargetSetpointMatchUserSetpoint() const;
     void SyncTargetSetpointToUserSetpoint();
     bool IsMistTypeSupportable(DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType) const;

--- a/src/app/clusters/humidistat-server/HumidistatCluster.h
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.h
@@ -116,17 +116,17 @@ public:
 
     struct StartupConfiguration
     {
-        Humidistat::ModeEnum mode               = Humidistat::ModeEnum::kAuto;
-        Humidistat::SystemStateEnum systemState = Humidistat::SystemStateEnum::kIdle;
-        chip::Percent userSetpoint              = 50;
-        chip::Percent minSetpoint               = 0;
-        chip::Percent maxSetpoint               = 100;
-        chip::Percent step                      = 1;
-        chip::Percent targetSetpoint            = 50;
+        Humidistat::ModeEnum mode                                               = Humidistat::ModeEnum::kAuto;
+        Humidistat::SystemStateEnum systemState                                 = Humidistat::SystemStateEnum::kIdle;
+        chip::Percent userSetpoint                                              = 50;
+        chip::Percent minSetpoint                                               = 0;
+        chip::Percent maxSetpoint                                               = 100;
+        chip::Percent step                                                      = 1;
+        chip::Percent targetSetpoint                                            = 50;
         DataModel::Nullable<chip::BitMask<Humidistat::MistTypeBitmap>> mistType = DataModel::NullNullable;
-        bool continuous = false;
-        bool sleep      = false;
-        bool optimal    = false;
+        bool continuous                                                         = false;
+        bool sleep                                                              = false;
+        bool optimal                                                            = false;
     };
 
     /**

--- a/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
@@ -600,7 +600,7 @@ TEST_F(TestHumidistatCluster, SetSettingsMistTypeValidation)
 
     tester.GetDirtyList().clear();
 
-    // Setting WarmMist should fail with ConstraintError (feature not supported)
+    // Setting WarmMist should fail with ConstraintError (feature not supported).
     {
         Commands::SetSettings::Type request;
         request.mistType.SetValue(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistWarm));
@@ -611,7 +611,7 @@ TEST_F(TestHumidistatCluster, SetSettingsMistTypeValidation)
         EXPECT_EQ(cluster.GetMistType().Raw(), chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold).Raw());
     }
 
-    // Setting an empty MistType while mode is Humidifier should fail.
+    // Empty MistType while humidifying is inconsistent with SystemState.
     {
         Commands::SetSettings::Type request;
         request.mistType.SetValue(chip::BitMask<MistTypeBitmap>());
@@ -637,6 +637,22 @@ TEST_F(TestHumidistatCluster, SetMistTypeRequiresAtLeastOneBitWhenHumidifying)
     EXPECT_EQ(cluster.SetMistType(chip::BitMask<MistTypeBitmap>()), CHIP_IM_GLOBAL_STATUS(InvalidInState));
     EXPECT_EQ(cluster.GetMistType().Raw(), chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold).Raw());
     EXPECT_FALSE(tester.IsAttributeDirty(MistType::Id));
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestHumidistatCluster, SetSystemStateHumidifyingAllowedWithNoMistFeatures)
+{
+    // kHumidifier without any mist feature: MistType stays null in Humidifying state.
+    const BitFlags<Feature> features{ Feature::kHumidifier };
+    HumidistatCluster cluster(kTestEndpointId, features, {});
+    ClusterTester tester(cluster);
+    ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
+
+    EXPECT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.GetSystemState(), SystemStateEnum::kHumidifying);
+    // MistType must remain null — no mist type bits are available to set.
+    EXPECT_TRUE(cluster.GetMistType().Raw() == 0);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
@@ -396,6 +396,7 @@ TEST_F(TestHumidistatCluster, WriteAttributes)
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
     EXPECT_EQ(tester.WriteAttribute(Mode::Id, ModeEnum::kHumidifier), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
     EXPECT_EQ(tester.WriteAttribute(UserSetpoint::Id, static_cast<chip::Percent>(60)), CHIP_NO_ERROR);
     EXPECT_EQ(tester.WriteAttribute(UserSetpoint::Id, static_cast<chip::Percent>(81)),
               CHIP_IM_GLOBAL_STATUS(ConstraintError)); // out of range
@@ -542,6 +543,9 @@ TEST_F(TestHumidistatCluster, SetSettingsMultipleFields)
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
+    tester.GetDirtyList().clear();
+
     // Set multiple fields in a single command
     {
         Commands::SetSettings::Type request;
@@ -581,7 +585,10 @@ TEST_F(TestHumidistatCluster, SetSettingsMistTypeValidation)
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
-    // Setting ColdMist should succeed when mode is Humidifier
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
+    tester.GetDirtyList().clear();
+
+    // Setting ColdMist should succeed when SystemState is Humidifying
     {
         Commands::SetSettings::Type request;
         request.mode.SetValue(ModeEnum::kHumidifier);
@@ -593,13 +600,13 @@ TEST_F(TestHumidistatCluster, SetSettingsMistTypeValidation)
 
     tester.GetDirtyList().clear();
 
-    // Setting WarmMist should fail with InvalidInState (feature not supported)
+    // Setting WarmMist should fail with ConstraintError (feature not supported)
     {
         Commands::SetSettings::Type request;
         request.mistType.SetValue(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistWarm));
         auto result = tester.Invoke(request);
         EXPECT_FALSE(result.IsSuccess());
-        EXPECT_EQ(result.GetStatusCode(), std::make_optional(CSC(Status::InvalidInState)));
+        EXPECT_EQ(result.GetStatusCode(), std::make_optional(CSC(Status::ConstraintError)));
         // MistType unchanged
         EXPECT_EQ(cluster.GetMistType().Raw(), chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold).Raw());
     }
@@ -610,22 +617,24 @@ TEST_F(TestHumidistatCluster, SetSettingsMistTypeValidation)
         request.mistType.SetValue(chip::BitMask<MistTypeBitmap>());
         auto result = tester.Invoke(request);
         EXPECT_FALSE(result.IsSuccess());
-        EXPECT_EQ(result.GetStatusCode(), std::make_optional(CSC(Status::ConstraintError)));
+        EXPECT_EQ(result.GetStatusCode(), std::make_optional(CSC(Status::InvalidInState)));
         EXPECT_EQ(cluster.GetMistType().Raw(), chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold).Raw());
     }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
-TEST_F(TestHumidistatCluster, SetMistTypeRequiresAtLeastOneBitInHumidifierMode)
+TEST_F(TestHumidistatCluster, SetMistTypeRequiresAtLeastOneBitWhenHumidifying)
 {
     const BitFlags<Feature> features{ Feature::kHumidifier, Feature::kColdMist };
     HumidistatCluster cluster(kTestEndpointId, features, {});
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
-    ASSERT_EQ(cluster.SetMode(ModeEnum::kHumidifier), CHIP_NO_ERROR);
-    EXPECT_EQ(cluster.SetMistType(chip::BitMask<MistTypeBitmap>()), CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
+    tester.GetDirtyList().clear();
+
+    EXPECT_EQ(cluster.SetMistType(chip::BitMask<MistTypeBitmap>()), CHIP_IM_GLOBAL_STATUS(InvalidInState));
     EXPECT_EQ(cluster.GetMistType().Raw(), chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold).Raw());
     EXPECT_FALSE(tester.IsAttributeDirty(MistType::Id));
 
@@ -655,9 +664,14 @@ TEST_F(TestHumidistatCluster, WriteNullableMistType)
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
-    ASSERT_EQ(cluster.SetMode(ModeEnum::kHumidifier), CHIP_NO_ERROR);
+    // Humidifying: MistType must be non-null.
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
     ASSERT_EQ(cluster.SetMistType(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold)), CHIP_NO_ERROR);
 
+    // Transition away from Humidifying: MistType must be null.
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kIdle), CHIP_NO_ERROR);
+
+    // Writing null via attribute path is valid when not Humidifying.
     DataModel::Nullable<chip::BitMask<MistTypeBitmap>> nullMistType = DataModel::NullNullable;
     EXPECT_EQ(tester.WriteAttribute(MistType::Id, nullMistType), CHIP_NO_ERROR);
 
@@ -818,24 +832,27 @@ TEST_F(TestHumidistatCluster, TestPersistence)
     }
 }
 
-TEST_F(TestHumidistatCluster, SetModeClearsMistType)
+TEST_F(TestHumidistatCluster, SetSystemStateClearsMistTypeToNull)
 {
-    // Spec: "If the value of Mode is not set to Humidifier, all bits of MistType SHALL be set to zero."
+    // Spec: MistType SHALL be null when SystemState is not Humidifying.
     const BitFlags<Feature> features{ Feature::kHumidifier, Feature::kDehumidifier, Feature::kColdMist, Feature::kSensor };
     HumidistatCluster cluster(kTestEndpointId, features, {});
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
-    // Set mode to Humidifier and set MistType
-    ASSERT_EQ(cluster.SetMode(ModeEnum::kHumidifier), CHIP_NO_ERROR);
+    // Set state to Humidifying and set MistType.
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
     ASSERT_EQ(cluster.SetMistType(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold)), CHIP_NO_ERROR);
     EXPECT_EQ(cluster.GetMistType().Raw(), chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold).Raw());
 
     tester.GetDirtyList().clear();
 
-    // Change mode away from Humidifier — MistType must be cleared.
-    ASSERT_EQ(cluster.SetMode(ModeEnum::kDehumidifier), CHIP_NO_ERROR);
-    EXPECT_EQ(cluster.GetMistType().Raw(), 0u);
+    // Change state away from Humidifying — MistType must be null.
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kIdle), CHIP_NO_ERROR);
+
+    DataModel::Nullable<chip::BitMask<MistTypeBitmap>> readMistType;
+    ASSERT_EQ(tester.ReadAttribute(MistType::Id, readMistType), CHIP_NO_ERROR);
+    EXPECT_TRUE(readMistType.IsNull());
     EXPECT_TRUE(tester.IsAttributeDirty(MistType::Id));
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -1136,11 +1153,11 @@ TEST_F(TestHumidistatCluster, DelegateCallback_OnMistTypeChanged)
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);
 
+    // Attach delegate after setup so auto-applied default MistType is not counted.
+    ASSERT_EQ(cluster.SetSystemState(SystemStateEnum::kHumidifying), CHIP_NO_ERROR);
+
     FakeHumidistatDelegate delegate;
     cluster.SetDelegate(&delegate);
-
-    // SetMode to Humidifier first so MistType can be set
-    ASSERT_EQ(cluster.SetMode(ModeEnum::kHumidifier), CHIP_NO_ERROR);
 
     const auto expectedMistType = chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistWarm);
 


### PR DESCRIPTION
### Summary

The MistType attribute was handled according to an outdated version of the spec. The current spec requires:

_MistType SHALL represent the mist type currently in use when SystemState is Humidifying. If SystemState is not Humidifying, MistType SHALL be null._

The cluster was instead tracking MistType based on the Mode attribute, which no longer matches the spec.

Updated the cluster to manage MistType based on SystemState rather than Mode, in line with the current spec.

### Related issues

N/A

### Testing

Unit testing and manual execution of draft test scripts.
