### PR TITLE
Setup checks for SMOKECO Test cases.

### DIFF
--- a/src/python_testing/TC_SMOKECO_2_1.py
+++ b/src/python_testing/TC_SMOKECO_2_1.py
@@ -42,7 +42,7 @@ from mobly import asserts
 from support_modules.smokeco_support import SmokeCoBaseTest
 
 import matter.clusters as Clusters
-from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.decorators import async_test_body, has_cluster, run_if_endpoint_matches
 from matter.testing.runner import TestStep, default_matter_test_main
 
 log = logging.getLogger(__name__)
@@ -89,6 +89,11 @@ class TC_SMOKECO_2_1(SmokeCoBaseTest):
         return [
             "SMOKECO.S",
         ]
+
+    @async_test_body
+    async def setup_test(self):
+        await self.smokeco_cluster_checks()
+        super().setup_test()
 
     @run_if_endpoint_matches(has_cluster(Clusters.SmokeCoAlarm))
     async def test_TC_SMOKECO_2_1(self):

--- a/src/python_testing/TC_SMOKECO_2_2.py
+++ b/src/python_testing/TC_SMOKECO_2_2.py
@@ -52,6 +52,7 @@ class TC_SMOKECO_2_2(SmokeCoBaseTest):
 
     @async_test_body
     async def setup_test(self):
+        await self.smokeco_cluster_checks()
         super().setup_test()
         self.gd_cluster = Clusters.GeneralDiagnostics
 

--- a/src/python_testing/TC_SMOKECO_2_3.py
+++ b/src/python_testing/TC_SMOKECO_2_3.py
@@ -49,6 +49,7 @@ class TC_SMOKECO_2_3(SmokeCoBaseTest):
 
     @async_test_body
     async def setup_test(self):
+        await self.smokeco_cluster_checks()
         super().setup_test()
         self.gd_cluster = Clusters.GeneralDiagnostics
 

--- a/src/python_testing/TC_SMOKECO_2_4.py
+++ b/src/python_testing/TC_SMOKECO_2_4.py
@@ -55,6 +55,7 @@ class TC_SMOKECO_2_4(SmokeCoBaseTest):
 
     @async_test_body
     async def setup_test(self):
+        await self.smokeco_cluster_checks()
         super().setup_test()
         self.gd_cluster = Clusters.GeneralDiagnostics
 

--- a/src/python_testing/TC_SMOKECO_2_5.py
+++ b/src/python_testing/TC_SMOKECO_2_5.py
@@ -55,6 +55,7 @@ class TC_SMOKECO_2_5(SmokeCoBaseTest):
 
     @async_test_body
     async def setup_test(self):
+        await self.smokeco_cluster_checks()
         super().setup_test()
         self.gd_cluster = Clusters.GeneralDiagnostics
 

--- a/src/python_testing/TC_SMOKECO_2_6.py
+++ b/src/python_testing/TC_SMOKECO_2_6.py
@@ -61,6 +61,7 @@ class TC_SMOKECO_2_6(SmokeCoBaseTest):
 
     @async_test_body
     async def setup_test(self):
+        await self.smokeco_cluster_checks()
         super().setup_test()
         # ALARM PRIORITY
         # These PIXIT values might change depending of the manufacturer or also if one or both of the

--- a/src/python_testing/TC_SMOKECO_2_7.py
+++ b/src/python_testing/TC_SMOKECO_2_7.py
@@ -40,25 +40,23 @@
 import logging
 
 from mobly import asserts
+from support_modules.smokeco_support import SmokeCoBaseTest
 
 import matter.clusters as Clusters
 from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
-from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
 log = logging.getLogger(__name__)
 
 
-class TC_SMOKECO_2_7(MatterBaseTest):
-    def setup_test(self):
+class TC_SMOKECO_2_7(SmokeCoBaseTest):
+
+    @async_test_body
+    async def setup_test(self):
+        await self.smokeco_cluster_checks()
         super().setup_test()
         self.is_ci = self.matter_test_config.global_test_params.get('simulate_mounting', False)
-
-    async def read_smokeco_attribute_expect_success(self, attribute):
-        cluster = Clusters.Objects.SmokeCoAlarm
-        endpoint = self.get_endpoint()
-        return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
     def desc_TC_SMOKECO_2_7(self) -> str:
         return "[TC-SMOKECO-2.7] Unmount Attribute with DUT as Server"

--- a/src/python_testing/support_modules/smokeco_support.py
+++ b/src/python_testing/support_modules/smokeco_support.py
@@ -332,3 +332,24 @@ class SmokeCoBaseTest(MatterBaseTest):
         self.step(21)
         # This will fail if AllClearEvent is not retrieved
         await self.read_smokeco_event(self.smokeco_cluster.Events.AllClear)
+
+    async def smokeco_cluster_checks(self):
+        """This method checks that the DUT can perform the test: ExpiryDate is not expired, TestInProgress is False,
+        HardwareFaultAlert is False, and EndOfServiceAlert has not reached kExpired."""
+
+        # Check DUT ExpiryDate is valid
+        expiry_date = await self.read_smokeco_attribute_expect_success(attribute=self.smokeco_cluster.Attributes.ExpiryDate)
+        self.is_valid_expired_date(expiry_date)
+
+        # Check if the DUT has a test in progress
+        test_in_progress = await self.read_smokeco_attribute_expect_success(attribute=self.smokeco_cluster.Attributes.TestInProgress)
+        asserts.assert_equal(test_in_progress, False, "DUT has a test in progress")
+
+        # Check if DUT has a HardwareFault
+        hardware_fault = await self.read_smokeco_attribute_expect_success(attribute=self.smokeco_cluster.Attributes.HardwareFaultAlert)
+        asserts.assert_equal(hardware_fault, False, "DUT has a Hardware Fault")
+
+        # Verify if the DUT EndOfServiceAlert is not equal to kExpired to continue
+        end_of_service_alert = await self.read_smokeco_attribute_expect_success(attribute=self.smokeco_cluster.Attributes.EndOfServiceAlert)
+        asserts.assert_not_equal(end_of_service_alert, self.smokeco_enums.EndOfServiceEnum.kExpired,
+                                 "DUT has reached the end of service.")


### PR DESCRIPTION
### Summary

This PR contain some constraints for the SMOKECO Test cases on the test_setup.
The implemented checks are related to ExpiryDate, HardwareFault, EndOfService and Test In Progress, if any of these 
attributes is enabled or is expired the test should not run as there is not need to test a device which is Expired, at the end of service , with hardware fault or the test is in progress.

### Related issues

This PR was done as some feedback:

Fixes: https://github.com/project-chip/matter-test-scripts/issues/774 

### Testing

Test smoke tests:

```
python3 scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_SMOKECO_2_1.py

python3 scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_SMOKECO_2_2.py

python3 scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_SMOKECO_2_3.py

python3 scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_SMOKECO_2_4.py

python3 scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_SMOKECO_2_5.py

python3 scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_SMOKECO_2_6.py

python3 scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_SMOKECO_2_7.py
```
