### PR TITLE
Fix .pullapprove.yml conflict markers on v1.6-branch

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -74,7 +74,6 @@ notifications:
       and merged.
 
 groups:
-<<<<<<< HEAD
   ############################################################
   #  Shared Reviewer Groups
   ############################################################
@@ -116,14 +115,6 @@ groups:
       - files.include('*')
     reviewers:
       teams: [reviewers-cablelabs]
-    reviews:
-      request: 0 # Do not auto-add
-  shared-reviewers-dyson:
-    type: optional
-    conditions:
-      - files.include('*')
-    reviewers:
-      teams: [reviewers-dyson]
     reviews:
       request: 0 # Do not auto-add
   shared-reviewers-espressif:
@@ -174,14 +165,6 @@ groups:
       teams: [reviewers-lg]
     reviews:
       request: 0 # Do not auto-add
-  shared-reviewers-logitech:
-    type: optional
-    conditions:
-      - files.include('*')
-    reviewers:
-      teams: [reviewers-logitech]
-    reviews:
-      request: 0 # Requested to be only on demand
   shared-reviewers-nordic:
     type: optional
     conditions:
@@ -268,193 +251,6 @@ groups:
       teams: [reviewers-velux]
     reviews:
       request: 0 # Do not auto-add
-=======
-    ############################################################
-    #  Shared Reviewer Groups
-    ############################################################
-    shared-reviewers-amazon:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-amazon]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-apple:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-apple]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-bosch:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-bosch]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-comcast:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-comcast]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-cablelabs:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-cablelabs]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-espressif:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-espressif]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-google:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-google]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-geo:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-geo]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-grundfos:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-grundfos]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-irobot:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-irobot]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-ikea:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-ikea]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-lg:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-lg]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-nordic:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-nordic]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-nxp:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-nxp]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-samsung:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-samsung]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-eve:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-eve]
-        reviews:
-            request: 0 # Do not auto-add
-    # shared-reviewers-signify disabled for now, because the reviewers-signify
-    # team is empty and pullapprove seems to mis-handle that badly and treats
-    # _all_ reviewers as being in this group.
-    #
-    # See https://github.com/dropseed/pullapprove/issues/71
-    #
-    # shared-reviewers-signify:
-    #     type: optional
-    #     conditions:
-    #         - files.include('*')
-    #     reviewers:
-    #         teams: [reviewers-signify]
-    #     reviews:
-    #         request: 0 # Do not auto-add
-    shared-reviewers-silabs:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-silabs]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-somfy:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-somfy]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-tcl:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-tcl]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-qorvo:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-qorvo]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-velux:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-velux]
-        reviews:
-            request: 0 # Do not auto-add
->>>>>>> ac3956e (Remove empty reviewer groups from pullapprove (#73784))
 
   sdk-maintainers:
     type: optional


### PR DESCRIPTION
### Summary

`.pullapprove.yml` on `v1.6-branch` contains unresolved merge conflict markers, so PullApprove cannot parse it. Every pull request targeting this branch reports `pullapprove - Error loading YAML. Check the formatting.` and is blocked from merging.

Root cause: the markers came from #73787, the Mergify backport of #73784. That cherry-pick conflicted because `master` uses four-space indentation for this file while the release branches still use two, so the entire `groups:` block collided. The backport PR was correctly labelled `conflicts` and Mergify's auto-merge rule declined it, but it was merged manually with the markers still in place.

This change keeps the branch's own content and applies the intent of #73784 on top of it: `shared-reviewers-dyson` and `shared-reviewers-logitech` are removed, and nothing else changes.

The diff is large (-204 lines) because a conflicted file holds both halves, so most groups are present twice - 27 to 25 groups after, with the master-indented duplicate copy dropped. No reviewer group other than the two above is removed.

Note that the `pullapprove` check on this PR will stay red until it merges. PullApprove reads its config from the base branch, so a fix on the head branch cannot clear it. Merging needs either the `fast track` label, which `.mergify.yml` accepts in place of `check-success=pullapprove`, or an admin merge.

### Related issues

Introduced by #73787 (backport of #73784). Blocks all open PRs against `v1.6-branch`.

### Testing

- `yaml.safe_load` on the resulting file parses successfully; on the current branch file it raises `ScannerError: while scanning a simple key`, matching the reported check description.
- Group-level comparison against the last good commit on this branch (`ac3cb0c84d0`), parsed as YAML rather than diffed as text: removed `shared-reviewers-dyson` and `shared-reviewers-logitech`, added none, and every surviving group compares equal. Non-`groups` top-level keys are unchanged.
- `grep` confirms zero conflict markers remain.
- Verified in a local git simulation that a single patch cannot cover all three branches: the fix cherry-picks cleanly from `v1.6-branch` to `v1.6.1-branch` but conflicts on `v1.4.2-branch`, which is why these are separate PRs.

`v1.7-branch` and `master` are unaffected.

Companion fixes:
- #73808 - same fix for `v1.6.1-branch`
- #73809 - same fix for `v1.4.2-branch`
