### PR TITLE
TC_MOD_1_2: accept null StartUpMode per spec

### DIFF
--- a/src/python_testing/TC_MOD_1_2.py
+++ b/src/python_testing/TC_MOD_1_2.py
@@ -41,6 +41,7 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
+from matter.testing import matter_asserts
 from matter.testing.decorators import async_test_body
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
@@ -158,8 +159,8 @@ class TC_MOD_1_2(MatterBaseTest):
         if await self.attribute_guard(endpoint=self.endpoint, attribute=self.cluster.Attributes.StartUpMode):
             startup_mode = await self.read_single_attribute_check_success(endpoint=self.endpoint, cluster=self.cluster, attribute=self.cluster.Attributes.StartUpMode)
             self._log_attribute("StartupMode", startup_mode)
-            asserts.assert_true((matter_asserts.is_valid_uint_value(startup_mode, 8) or startup_mode is NullValue, "Value for StartupMode is not uint8 or Null"),
-                                "StartupMode is not int or NullValue")
+            asserts.assert_true(matter_asserts.is_valid_uint_value(startup_mode, 8) or startup_mode is NullValue,
+                                "StartupMode is not uint8 or NullValue")
             if startup_mode is not NullValue:
                 asserts.assert_in(startup_mode, supported_modes_values,
                                   f"StartupMode {startup_mode} is not in {supported_modes_values}")

--- a/src/python_testing/TC_MOD_1_2.py
+++ b/src/python_testing/TC_MOD_1_2.py
@@ -158,7 +158,7 @@ class TC_MOD_1_2(MatterBaseTest):
         if await self.attribute_guard(endpoint=self.endpoint, attribute=self.cluster.Attributes.StartUpMode):
             startup_mode = await self.read_single_attribute_check_success(endpoint=self.endpoint, cluster=self.cluster, attribute=self.cluster.Attributes.StartUpMode)
             self._log_attribute("StartupMode", startup_mode)
-            asserts.assert_true((isinstance(startup_mode, int) or startup_mode is NullValue),
+            asserts.assert_true((matter_asserts.is_valid_uint_value(startup_mode, 8) or startup_mode is NullValue,"Value for StartupMode is not uint8 or Null"),
                                 "StartupMode is not int or NullValue")
             if startup_mode is not NullValue:
                 asserts.assert_in(startup_mode, supported_modes_values,

--- a/src/python_testing/TC_MOD_1_2.py
+++ b/src/python_testing/TC_MOD_1_2.py
@@ -158,7 +158,7 @@ class TC_MOD_1_2(MatterBaseTest):
         if await self.attribute_guard(endpoint=self.endpoint, attribute=self.cluster.Attributes.StartUpMode):
             startup_mode = await self.read_single_attribute_check_success(endpoint=self.endpoint, cluster=self.cluster, attribute=self.cluster.Attributes.StartUpMode)
             self._log_attribute("StartupMode", startup_mode)
-            asserts.assert_true((matter_asserts.is_valid_uint_value(startup_mode, 8) or startup_mode is NullValue,"Value for StartupMode is not uint8 or Null"),
+            asserts.assert_true((matter_asserts.is_valid_uint_value(startup_mode, 8) or startup_mode is NullValue, "Value for StartupMode is not uint8 or Null"),
                                 "StartupMode is not int or NullValue")
             if startup_mode is not NullValue:
                 asserts.assert_in(startup_mode, supported_modes_values,

--- a/src/python_testing/TC_MOD_1_2.py
+++ b/src/python_testing/TC_MOD_1_2.py
@@ -158,9 +158,11 @@ class TC_MOD_1_2(MatterBaseTest):
         if await self.attribute_guard(endpoint=self.endpoint, attribute=self.cluster.Attributes.StartUpMode):
             startup_mode = await self.read_single_attribute_check_success(endpoint=self.endpoint, cluster=self.cluster, attribute=self.cluster.Attributes.StartUpMode)
             self._log_attribute("StartupMode", startup_mode)
-            asserts.assert_true(isinstance(startup_mode, int), "Startupmode is not int")
-            asserts.assert_in(startup_mode, supported_modes_values,
-                              f"Startupmode {startup_mode} is not in {supported_modes_values}")
+            asserts.assert_true((isinstance(startup_mode, int) or startup_mode is NullValue),
+                                "StartupMode is not int or NullValue")
+            if startup_mode is not NullValue:
+                asserts.assert_in(startup_mode, supported_modes_values,
+                                  f"StartupMode {startup_mode} is not in {supported_modes_values}")
 
         # Verify the string  is str and larger that 1 char.
         self.step(6)


### PR DESCRIPTION
#### Summary

##### Problem

Step 5 of TC-MOD-1.2 asserts `isinstance(startup_mode, int)`, which rejects a null `StartUpMode`. The spec (`modebase_common.adoc` step 5) states the DUT reply should be "an integer from `supported_modes_dut` or null", making null a valid value.

##### Solution

Accept null in addition to int, mirroring the existing `OnMode` check in step 4. Skip the `supported_modes_dut` membership check when the value is null.

#### Testing

Manual review against the spec. The pattern matches the already-correct `OnMode` handling in step 4 of the same test.