### PR TITLE
TC-EPALM-2.2: Add Python automation test script for the Electrical Protection Alarm state machine

### DIFF
--- a/src/python_testing/TC_EPALM_2_2.py
+++ b/src/python_testing/TC_EPALM_2_2.py
@@ -53,7 +53,7 @@ from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import TestStep, default_matter_test_main
+from matter.testing.runner import default_matter_test_main
 from matter.tlv import uint
 
 log = logging.getLogger(__name__)
@@ -108,43 +108,6 @@ class TC_EPALM_2_2(MatterBaseTest):
     def pics_TC_EPALM_2_2(self) -> list[str]:
         return ["EPALM.S"]
 
-    def steps_TC_EPALM_2_2(self) -> list[TestStep]:
-        return [
-            TestStep(1, "Commission DUT to TH (already done)", is_commissioning=True),
-            TestStep(2, "TH reads TestEventTriggersEnabled from General Diagnostics on endpoint 0",
-                     "Value is 1 (True). If 0, the remaining steps cannot run."),
-            TestStep(3, "TH establishes a subscription to the State attribute with MinIntervalFloor=0 "
-                        "and MaxIntervalCeiling=30",
-                     "Subscription is established and an initial priming report carrying the current "
-                     "State value is received."),
-            TestStep(4, "TH sends the TestEventTrigger for ShortCircuitFault",
-                     "DUT returns SUCCESS and reports a State value with bit 0 set."),
-            TestStep(5, "TH sends the TestEventTrigger for OverLoadFault",
-                     "DUT returns SUCCESS and reports a State value with bit 1 set."),
-            TestStep(6, "TH sends the TestEventTrigger for OverVoltageFault",
-                     "DUT returns SUCCESS and reports a State value with bit 2 set."),
-            TestStep(7, "TH sends the TestEventTrigger for VoltageSurgeFault",
-                     "DUT returns SUCCESS and reports a State value with bit 3 set."),
-            TestStep(8, "TH sends the TestEventTrigger for ResidualCurrentFault",
-                     "DUT returns SUCCESS and reports a State value with bit 4 set."),
-            TestStep(9, "TH sends the TestEventTrigger for ArcFault",
-                     "DUT returns SUCCESS and reports a State value with bit 5 set."),
-            TestStep(10, "TH sends the TestEventTrigger for SelfTest",
-                     "DUT returns SUCCESS and reports a State value with bit 6 set."),
-            TestStep(11, "TH reads the State attribute and inspects the value",
-                     "Every bit set in State is also set in Supported."),
-            TestStep(12, "TH sends the Reset command (Alarm Base.Reset) to the DUT",
-                     "DUT replies UNSUPPORTED_COMMAND (0x81). EPALM disallows the inherited RESET "
-                     "feature, so the command is not callable."),
-            TestStep(13, "If the DUT does not accept ModifyEnabledAlarms, TH sends it anyway",
-                     "DUT replies UNSUPPORTED_COMMAND (0x81)."),
-            TestStep("13a", "If the DUT accepts ModifyEnabledAlarms, TH sends it",
-                     "DUT returns SUCCESS. The command is optional in Alarm Base, so a DUT that "
-                     "implements it accepts rather than rejects it."),
-            TestStep(14, "TH sends the TestEventTrigger that clears all alarms",
-                     "DUT returns SUCCESS and reports a State value of 0."),
-        ]
-
     async def _command_status(self, command: ClusterCommand, endpoint: int) -> Status:
         """Send a command and return the resulting status, treating no exception as Success."""
         try:
@@ -186,9 +149,10 @@ class TC_EPALM_2_2(MatterBaseTest):
         alarm_bits = cluster.Bitmaps.AlarmBitmap
         features = cluster.Bitmaps.Feature
 
-        self.step(1)
+        self.step(1, "Commission DUT to TH (already done)", is_commissioning=True)
 
-        self.step(2)
+        self.step(2, "TH reads TestEventTriggersEnabled from General Diagnostics on endpoint 0",
+                  expectation="Value is 1 (True). If 0, the remaining steps cannot run.")
         await self.check_test_event_triggers_enabled()
 
         feature_map = await self.read_single_attribute_check_success(
@@ -199,7 +163,10 @@ class TC_EPALM_2_2(MatterBaseTest):
             endpoint=endpoint, cluster=cluster, attribute=attributes.AcceptedCommandList)
         accepts_modify = MODIFY_ENABLED_ALARMS_COMMAND_ID in accepted_commands
 
-        self.step(3)
+        self.step(3, "TH establishes a subscription to the State attribute with MinIntervalFloor=0 "
+                     "and MaxIntervalCeiling=30",
+                  expectation="Subscription is established and the current State value is read as "
+                              "the baseline.")
         sub = AttributeSubscriptionHandler(expected_cluster=cluster, expected_attribute=attributes.State)
         await sub.start(self.default_controller, self.dut_node_id, endpoint,
                         min_interval_sec=0, max_interval_sec=30)
@@ -211,27 +178,65 @@ class TC_EPALM_2_2(MatterBaseTest):
             endpoint=endpoint, cluster=cluster, attribute=attributes.State)
         log.info('State at subscription time: 0x%08X', priming_state)
 
-        # Steps 4 to 10 are each gated on the feature that owns the alarm bit. Steps for
-        # unsupported features are skipped per the standard PICS-gated step rules.
-        fault_steps = [
-            (4, features.kShortCircuit, TRIGGER_SHORT_CIRCUIT_FAULT, alarm_bits.kShortCircuitFault, 'ShortCircuitFault'),
-            (5, features.kOverLoad, TRIGGER_OVER_LOAD_FAULT, alarm_bits.kOverLoadFault, 'OverLoadFault'),
-            (6, features.kOverVoltage, TRIGGER_OVER_VOLTAGE_FAULT, alarm_bits.kOverVoltageFault, 'OverVoltageFault'),
-            (7, features.kSurgeProtection, TRIGGER_VOLTAGE_SURGE_FAULT, alarm_bits.kVoltageSurgeFault, 'VoltageSurgeFault'),
-            (8, features.kResidualCurrent, TRIGGER_RESIDUAL_CURRENT_FAULT, alarm_bits.kResidualCurrentFault,
-             'ResidualCurrentFault'),
-            (9, features.kArcFault, TRIGGER_ARC_FAULT, alarm_bits.kArcFault, 'ArcFault'),
-            (10, features.kSelfTest, TRIGGER_SELF_TEST, alarm_bits.kSelfTest, 'SelfTest'),
-        ]
         current_state = int(priming_state)
-        for step_number, feature, trigger, bit, name in fault_steps:
-            self.step(step_number)
-            if not feature_map & feature:
-                self.mark_current_step_skipped()
-                continue
-            current_state = await self._trigger_and_expect_bit(sub, trigger, bit, name, endpoint, current_state)
+        self.step(4, "TH sends the TestEventTrigger for ShortCircuitFault",
+                  expectation="DUT returns SUCCESS and reports a State value with bit 0 set.")
+        if feature_map & features.kShortCircuit:
+            current_state = await self._trigger_and_expect_bit(
+                sub, TRIGGER_SHORT_CIRCUIT_FAULT, alarm_bits.kShortCircuitFault, "ShortCircuitFault", endpoint, current_state)
+        else:
+            self.mark_current_step_skipped()
 
-        self.step(11)
+        self.step(5, "TH sends the TestEventTrigger for OverLoadFault",
+                  expectation="DUT returns SUCCESS and reports a State value with bit 1 set.")
+        if feature_map & features.kOverLoad:
+            current_state = await self._trigger_and_expect_bit(
+                sub, TRIGGER_OVER_LOAD_FAULT, alarm_bits.kOverLoadFault, "OverLoadFault", endpoint, current_state)
+        else:
+            self.mark_current_step_skipped()
+
+        self.step(6, "TH sends the TestEventTrigger for OverVoltageFault",
+                  expectation="DUT returns SUCCESS and reports a State value with bit 2 set.")
+        if feature_map & features.kOverVoltage:
+            current_state = await self._trigger_and_expect_bit(
+                sub, TRIGGER_OVER_VOLTAGE_FAULT, alarm_bits.kOverVoltageFault, "OverVoltageFault", endpoint, current_state)
+        else:
+            self.mark_current_step_skipped()
+
+        self.step(7, "TH sends the TestEventTrigger for VoltageSurgeFault",
+                  expectation="DUT returns SUCCESS and reports a State value with bit 3 set.")
+        if feature_map & features.kSurgeProtection:
+            current_state = await self._trigger_and_expect_bit(
+                sub, TRIGGER_VOLTAGE_SURGE_FAULT, alarm_bits.kVoltageSurgeFault, "VoltageSurgeFault", endpoint, current_state)
+        else:
+            self.mark_current_step_skipped()
+
+        self.step(8, "TH sends the TestEventTrigger for ResidualCurrentFault",
+                  expectation="DUT returns SUCCESS and reports a State value with bit 4 set.")
+        if feature_map & features.kResidualCurrent:
+            current_state = await self._trigger_and_expect_bit(
+                sub, TRIGGER_RESIDUAL_CURRENT_FAULT, alarm_bits.kResidualCurrentFault, "ResidualCurrentFault", endpoint, current_state)
+        else:
+            self.mark_current_step_skipped()
+
+        self.step(9, "TH sends the TestEventTrigger for ArcFault",
+                  expectation="DUT returns SUCCESS and reports a State value with bit 5 set.")
+        if feature_map & features.kArcFault:
+            current_state = await self._trigger_and_expect_bit(
+                sub, TRIGGER_ARC_FAULT, alarm_bits.kArcFault, "ArcFault", endpoint, current_state)
+        else:
+            self.mark_current_step_skipped()
+
+        self.step(10, "TH sends the TestEventTrigger for SelfTest",
+                  expectation="DUT returns SUCCESS and reports a State value with bit 6 set.")
+        if feature_map & features.kSelfTest:
+            current_state = await self._trigger_and_expect_bit(
+                sub, TRIGGER_SELF_TEST, alarm_bits.kSelfTest, "SelfTest", endpoint, current_state)
+        else:
+            self.mark_current_step_skipped()
+
+        self.step(11, "TH reads the State attribute and inspects the value",
+                  expectation="Every bit set in State is also set in Supported.")
         state = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attributes.State)
         supported = await self.read_single_attribute_check_success(
@@ -240,12 +245,14 @@ class TC_EPALM_2_2(MatterBaseTest):
         asserts.assert_equal(int(state) & ~int(supported), 0,
                              'State must not set any bit that is absent from Supported')
 
-        self.step(12)
+        self.step(12, "TH sends the Reset command (Alarm Base.Reset) to the DUT",
+                  expectation="DUT replies UNSUPPORTED_COMMAND (0x81).")
         status = await self._command_status(FakeReset(alarms=0), endpoint)
         asserts.assert_equal(status, Status.UnsupportedCommand,
                              'Reset must return UNSUPPORTED_COMMAND: EPALM disallows the RESET feature')
 
-        self.step(13)
+        self.step(13, "If the DUT does not accept ModifyEnabledAlarms, TH sends it anyway",
+                  expectation="DUT replies UNSUPPORTED_COMMAND (0x81).")
         if accepts_modify:
             self.mark_current_step_skipped()
         else:
@@ -255,7 +262,8 @@ class TC_EPALM_2_2(MatterBaseTest):
                                  'ModifyEnabledAlarms must return UNSUPPORTED_COMMAND when the DUT '
                                  'does not accept it')
 
-        self.step("13a")
+        self.step("13a", "If the DUT accepts ModifyEnabledAlarms, TH sends it",
+                  expectation="DUT returns SUCCESS.")
         if not accepts_modify:
             self.mark_current_step_skipped()
         else:
@@ -265,7 +273,8 @@ class TC_EPALM_2_2(MatterBaseTest):
                                  'ModifyEnabledAlarms is optional in Alarm Base, so a DUT that '
                                  'accepts it must succeed rather than reject')
 
-        self.step(14)
+        self.step(14, "TH sends the TestEventTrigger that clears all alarms",
+                  expectation="DUT returns SUCCESS and reports a State value of 0.")
         await self.send_test_event_triggers(eventTrigger=TRIGGER_CLEAR_ALL)
         if int(state) == 0:
             # Nothing was raised, so clearing is a no-op and the cluster reports nothing.

--- a/src/python_testing/TC_EPALM_2_2.py
+++ b/src/python_testing/TC_EPALM_2_2.py
@@ -127,11 +127,10 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
 
         This test case verifies the alarm state machine of the Electrical Protection Alarm
         Cluster server: that inducing each supported fault condition via the General Diagnostics
-        TestEventTrigger sets the correct AlarmBitmap bit in State, that latched alarms remain set
-        after the fault condition clears (and only clear via the Alarm Base cluster's Reset
-        semantics where applicable), and that the inherited Alarm Base Reset command is rejected
-        because EPALM disallows the inherited RESET feature. ModifyEnabledAlarms is optional in
-        Alarm Base and is checked against whichever behavior the DUT declares.
+        TestEventTrigger sets the correct AlarmBitmap bit in State, and that the inherited Alarm
+        Base Reset command is rejected because EPALM disallows the inherited RESET feature.
+        ModifyEnabledAlarms is optional in Alarm Base and is checked against whichever behavior
+        the DUT declares.
         """
         endpoint = self.get_endpoint()
         attributes = cluster.Attributes
@@ -272,6 +271,24 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
             asserts.assert_equal(status, Status.Success,
                                  'ModifyEnabledAlarms is optional in Alarm Base, so a DUT that '
                                  'accepts it must succeed rather than reject')
+
+        self.step("13b", "TH sends the ModifyEnabledAlarms command with a mask that clears at least one "
+                         "bit set in Supported, then TH reads from the DUT the Mask attribute.",
+                  expectation="Value has to be the mask TH sent, with the cleared bit no longer set. If the "
+                  "DUT does not declare EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
+        if not accepts_modify or not int(supported):
+            self.mark_current_step_skipped()
+        else:
+            lowest_supported_bit = int(supported) & -int(supported)
+            reduced_mask = int(supported) & ~lowest_supported_bit
+            status = await self._command_status(
+                cluster.Commands.ModifyEnabledAlarms(mask=reduced_mask), endpoint)
+            asserts.assert_equal(status, Status.Success,
+                                 'ModifyEnabledAlarms must succeed when the DUT accepts it')
+            mask = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attributes.Mask)
+            asserts.assert_equal(int(mask), reduced_mask,
+                                 'Mask must reflect the value sent to ModifyEnabledAlarms')
 
         self.step(14, "TH sends the TestEventTrigger that clears all alarms",
                   expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "

--- a/src/python_testing/TC_EPALM_2_2.py
+++ b/src/python_testing/TC_EPALM_2_2.py
@@ -90,9 +90,6 @@ class FakeReset(ClusterCommand):
 
 class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
 
-    def desc_TC_EPALM_2_2(self) -> str:
-        return "[TC-EPALM-2.2] Primary functionality (alarm state machine) with Server as DUT"
-
     def pics_TC_EPALM_2_2(self) -> list[str]:
         return ["EPALM.S"]
 
@@ -128,6 +125,16 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
 
     @async_test_body
     async def test_TC_EPALM_2_2(self):
+        """[TC-EPALM-2.2] Primary functionality (alarm state machine) with Server as DUT
+
+        This test case verifies the alarm state machine of the Electrical Protection Alarm
+        Cluster server: that inducing each supported fault condition via the General Diagnostics
+        TestEventTrigger sets the correct AlarmBitmap bit in State, that latched alarms remain set
+        after the fault condition clears (and only clear via the Alarm Base cluster's Reset
+        semantics where applicable), and that the inherited Alarm Base Reset command is rejected
+        because EPALM disallows the inherited RESET feature. ModifyEnabledAlarms is optional in
+        Alarm Base and is checked against whichever behavior the DUT declares.
+        """
         endpoint = self.get_endpoint()
         attributes = cluster.Attributes
         alarm_bits = cluster.Bitmaps.AlarmBitmap

--- a/src/python_testing/TC_EPALM_2_2.py
+++ b/src/python_testing/TC_EPALM_2_2.py
@@ -1,0 +1,260 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ELECTRICAL_PROTECTION_APP}
+#     app-args: >
+#       --discriminator 1234
+#       --KVS kvs1
+#       --enable-key 000102030405060708090a0b0c0d0e0f
+#       --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --endpoint 1
+#       --hex-arg enableKey:000102030405060708090a0b0c0d0e0f
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+import typing
+from dataclasses import dataclass
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter import ChipUtility
+from matter.clusters.ClusterObjects import ClusterCommand, ClusterObjectDescriptor, ClusterObjectFieldDescriptor
+from matter.interaction_model import InteractionModelError, Status
+from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
+from matter.tlv import uint
+
+log = logging.getLogger(__name__)
+
+cluster = Clusters.ElectricalProtectionAlarm
+
+# TestEventTrigger codes implemented by ElectricalProtectionAlarmTestEventTriggerHandler.
+# The top two bytes carry the cluster id to namespace the trigger; the low byte selects the
+# alarm bit to set, or 0 to clear all alarms.
+TRIGGER_CLEAR_ALL = 0x00A3_0000_0000_0000
+TRIGGER_SHORT_CIRCUIT_FAULT = 0x00A3_0000_0000_0001
+TRIGGER_OVER_LOAD_FAULT = 0x00A3_0000_0000_0002
+TRIGGER_OVER_VOLTAGE_FAULT = 0x00A3_0000_0000_0003
+TRIGGER_VOLTAGE_SURGE_FAULT = 0x00A3_0000_0000_0004
+TRIGGER_RESIDUAL_CURRENT_FAULT = 0x00A3_0000_0000_0005
+TRIGGER_ARC_FAULT = 0x00A3_0000_0000_0006
+TRIGGER_SELF_TEST = 0x00A3_0000_0000_0007
+
+# Alarm Base command ids, inherited by EPALM.
+RESET_COMMAND_ID = 0x00
+MODIFY_ENABLED_ALARMS_COMMAND_ID = 0x01
+
+REPORT_TIMEOUT_SEC = 10.0
+
+
+# EPALM disallows the inherited RESET feature, so no Reset command is generated into the
+# Python bindings for this cluster and it cannot be sent through Clusters.ElectricalProtectionAlarm.
+# Declaring it locally is the established way to exercise the negative path; see TC_REFALM_2_2.py,
+# which does the same for Refrigerator Alarm.
+@dataclass
+class FakeReset(ClusterCommand):
+    cluster_id: typing.ClassVar[int] = 0x000000A3
+    command_id: typing.ClassVar[int] = RESET_COMMAND_ID
+    is_client: typing.ClassVar[bool] = True
+    response_type: typing.ClassVar[str | None] = None
+
+    @ChipUtility.classproperty
+    def descriptor(cls) -> ClusterObjectDescriptor:
+        return ClusterObjectDescriptor(
+            Fields=[
+                ClusterObjectFieldDescriptor(Label="alarms", Tag=0, Type=uint),
+            ])
+
+    alarms: uint = 0
+
+
+class TC_EPALM_2_2(MatterBaseTest):
+
+    def desc_TC_EPALM_2_2(self) -> str:
+        return "[TC-EPALM-2.2] Primary functionality (alarm state machine) with Server as DUT"
+
+    def pics_TC_EPALM_2_2(self) -> list[str]:
+        return ["EPALM.S"]
+
+    def steps_TC_EPALM_2_2(self) -> list[TestStep]:
+        return [
+            TestStep(1, "Commission DUT to TH (already done)", is_commissioning=True),
+            TestStep(2, "TH reads TestEventTriggersEnabled from General Diagnostics on endpoint 0",
+                     "Value is 1 (True). If 0, the remaining steps cannot run."),
+            TestStep(3, "TH establishes a subscription to the State attribute with MinIntervalFloor=0 "
+                        "and MaxIntervalCeiling=30",
+                     "Subscription is established and an initial priming report carrying the current "
+                     "State value is received."),
+            TestStep(4, "TH sends the TestEventTrigger for ShortCircuitFault",
+                     "DUT returns SUCCESS and reports a State value with bit 0 set."),
+            TestStep(5, "TH sends the TestEventTrigger for OverLoadFault",
+                     "DUT returns SUCCESS and reports a State value with bit 1 set."),
+            TestStep(6, "TH sends the TestEventTrigger for OverVoltageFault",
+                     "DUT returns SUCCESS and reports a State value with bit 2 set."),
+            TestStep(7, "TH sends the TestEventTrigger for VoltageSurgeFault",
+                     "DUT returns SUCCESS and reports a State value with bit 3 set."),
+            TestStep(8, "TH sends the TestEventTrigger for ResidualCurrentFault",
+                     "DUT returns SUCCESS and reports a State value with bit 4 set."),
+            TestStep(9, "TH sends the TestEventTrigger for ArcFault",
+                     "DUT returns SUCCESS and reports a State value with bit 5 set."),
+            TestStep(10, "TH sends the TestEventTrigger for SelfTest",
+                     "DUT returns SUCCESS and reports a State value with bit 6 set."),
+            TestStep(11, "TH reads the State attribute and inspects the value",
+                     "Every bit set in State is also set in Supported."),
+            TestStep(12, "TH sends the Reset command (Alarm Base.Reset) to the DUT",
+                     "DUT replies UNSUPPORTED_COMMAND (0x81). EPALM disallows the inherited RESET "
+                     "feature, so the command is not callable."),
+            TestStep(13, "If the DUT does not accept ModifyEnabledAlarms, TH sends it anyway",
+                     "DUT replies UNSUPPORTED_COMMAND (0x81)."),
+            TestStep("13a", "If the DUT accepts ModifyEnabledAlarms, TH sends it",
+                     "DUT returns SUCCESS. The command is optional in Alarm Base, so a DUT that "
+                     "implements it accepts rather than rejects it."),
+            TestStep(14, "TH sends the TestEventTrigger that clears all alarms",
+                     "DUT returns SUCCESS and reports a State value of 0."),
+        ]
+
+    async def _command_status(self, command: ClusterCommand, endpoint: int) -> Status:
+        """Send a command and return the resulting status, treating no exception as Success."""
+        try:
+            await self.default_controller.SendCommand(
+                nodeId=self.dut_node_id, endpoint=endpoint, payload=command)
+        except InteractionModelError as e:
+            return e.status
+        return Status.Success
+
+    async def _trigger_and_expect_bit(self, sub: AttributeSubscriptionHandler, trigger: int,
+                                      bit: cluster.Bitmaps.AlarmBitmap, name: str) -> None:
+        """Fire a fault trigger and wait for a State report that carries the corresponding bit."""
+        await self.send_test_event_triggers(eventTrigger=trigger)
+        report = sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC)
+        state = report.value
+        log.info('State after %s trigger: 0x%08X', name, state)
+        asserts.assert_true(int(state) & int(bit),
+                            f'State must have the {name} bit set after its TestEventTrigger')
+
+    @async_test_body
+    async def test_TC_EPALM_2_2(self):
+        endpoint = self.get_endpoint()
+        attributes = cluster.Attributes
+        alarm_bits = cluster.Bitmaps.AlarmBitmap
+        features = cluster.Bitmaps.Feature
+
+        self.step(1)
+
+        self.step(2)
+        await self.check_test_event_triggers_enabled()
+
+        feature_map = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attributes.FeatureMap)
+        log.info('FeatureMap: 0x%08X', feature_map)
+
+        accepted_commands = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attributes.AcceptedCommandList)
+        accepts_modify = MODIFY_ENABLED_ALARMS_COMMAND_ID in accepted_commands
+
+        self.step(3)
+        sub = AttributeSubscriptionHandler(expected_cluster=cluster, expected_attribute=attributes.State)
+        await sub.start(self.default_controller, self.dut_node_id, endpoint,
+                        min_interval_sec=0, max_interval_sec=30)
+        # AttributeSubscriptionHandler.start() registers its update callback only after
+        # ReadAttribute returns, so the priming report is delivered before the handler is
+        # listening and never reaches its queue. Read the attribute for the baseline instead;
+        # every later report in this test is change-driven and does reach the queue.
+        priming_state = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attributes.State)
+        log.info('State at subscription time: 0x%08X', priming_state)
+
+        # Steps 4 to 10 are each gated on the feature that owns the alarm bit. Steps for
+        # unsupported features are skipped per the standard PICS-gated step rules.
+        fault_steps = [
+            (4, features.kShortCircuit, TRIGGER_SHORT_CIRCUIT_FAULT, alarm_bits.kShortCircuitFault, 'ShortCircuitFault'),
+            (5, features.kOverLoad, TRIGGER_OVER_LOAD_FAULT, alarm_bits.kOverLoadFault, 'OverLoadFault'),
+            (6, features.kOverVoltage, TRIGGER_OVER_VOLTAGE_FAULT, alarm_bits.kOverVoltageFault, 'OverVoltageFault'),
+            (7, features.kSurgeProtection, TRIGGER_VOLTAGE_SURGE_FAULT, alarm_bits.kVoltageSurgeFault, 'VoltageSurgeFault'),
+            (8, features.kResidualCurrent, TRIGGER_RESIDUAL_CURRENT_FAULT, alarm_bits.kResidualCurrentFault,
+             'ResidualCurrentFault'),
+            (9, features.kArcFault, TRIGGER_ARC_FAULT, alarm_bits.kArcFault, 'ArcFault'),
+            (10, features.kSelfTest, TRIGGER_SELF_TEST, alarm_bits.kSelfTest, 'SelfTest'),
+        ]
+        for step_number, feature, trigger, bit, name in fault_steps:
+            self.step(step_number)
+            if not feature_map & feature:
+                self.mark_current_step_skipped()
+                continue
+            await self._trigger_and_expect_bit(sub, trigger, bit, name)
+
+        self.step(11)
+        state = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attributes.State)
+        supported = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attributes.Supported)
+        log.info('State: 0x%08X  Supported: 0x%08X', state, supported)
+        asserts.assert_equal(int(state) & ~int(supported), 0,
+                             'State must not set any bit that is absent from Supported')
+
+        self.step(12)
+        status = await self._command_status(FakeReset(alarms=0), endpoint)
+        asserts.assert_equal(status, Status.UnsupportedCommand,
+                             'Reset must return UNSUPPORTED_COMMAND: EPALM disallows the RESET feature')
+
+        self.step(13)
+        if accepts_modify:
+            self.mark_current_step_skipped()
+        else:
+            status = await self._command_status(
+                cluster.Commands.ModifyEnabledAlarms(mask=0), endpoint)
+            asserts.assert_equal(status, Status.UnsupportedCommand,
+                                 'ModifyEnabledAlarms must return UNSUPPORTED_COMMAND when the DUT '
+                                 'does not accept it')
+
+        self.step("13a")
+        if not accepts_modify:
+            self.mark_current_step_skipped()
+        else:
+            status = await self._command_status(
+                cluster.Commands.ModifyEnabledAlarms(mask=int(supported)), endpoint)
+            asserts.assert_equal(status, Status.Success,
+                                 'ModifyEnabledAlarms is optional in Alarm Base, so a DUT that '
+                                 'accepts it must succeed rather than reject')
+
+        self.step(14)
+        await self.send_test_event_triggers(eventTrigger=TRIGGER_CLEAR_ALL)
+        report = sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC)
+        asserts.assert_equal(int(report.value), 0, 'State must be 0 after the clear-all trigger')
+        sub.cancel()
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_EPALM_2_2.py
+++ b/src/python_testing/TC_EPALM_2_2.py
@@ -155,14 +155,29 @@ class TC_EPALM_2_2(MatterBaseTest):
         return Status.Success
 
     async def _trigger_and_expect_bit(self, sub: AttributeSubscriptionHandler, trigger: int,
-                                      bit: cluster.Bitmaps.AlarmBitmap, name: str) -> None:
-        """Fire a fault trigger and wait for a State report that carries the corresponding bit."""
+                                      bit: cluster.Bitmaps.AlarmBitmap, name: str,
+                                      endpoint: int, current_state: int) -> int:
+        """Fire a fault trigger and confirm the bit ends up set. Returns the new State.
+
+        The cluster reports only on an actual transition, so a DUT that already has this alarm
+        raised emits nothing and waiting for a report would hang. Read in that case instead.
+        """
         await self.send_test_event_triggers(eventTrigger=trigger)
-        report = sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC)
-        state = report.value
-        log.info('State after %s trigger: 0x%08X', name, state)
+        if current_state & int(bit):
+            state = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.State)
+            log.info('State after %s trigger: 0x%08X (already raised, no transition to report)', name, state)
+        else:
+            report = sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC)
+            state = report.value
+            log.info('State after %s trigger: 0x%08X', name, state)
         asserts.assert_true(int(state) & int(bit),
                             f'State must have the {name} bit set after its TestEventTrigger')
+        return int(state)
+
+    async def _read_state(self, endpoint: int) -> int:
+        return int(await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.State))
 
     @async_test_body
     async def test_TC_EPALM_2_2(self):
@@ -208,12 +223,13 @@ class TC_EPALM_2_2(MatterBaseTest):
             (9, features.kArcFault, TRIGGER_ARC_FAULT, alarm_bits.kArcFault, 'ArcFault'),
             (10, features.kSelfTest, TRIGGER_SELF_TEST, alarm_bits.kSelfTest, 'SelfTest'),
         ]
+        current_state = int(priming_state)
         for step_number, feature, trigger, bit, name in fault_steps:
             self.step(step_number)
             if not feature_map & feature:
                 self.mark_current_step_skipped()
                 continue
-            await self._trigger_and_expect_bit(sub, trigger, bit, name)
+            current_state = await self._trigger_and_expect_bit(sub, trigger, bit, name, endpoint, current_state)
 
         self.step(11)
         state = await self.read_single_attribute_check_success(
@@ -251,8 +267,12 @@ class TC_EPALM_2_2(MatterBaseTest):
 
         self.step(14)
         await self.send_test_event_triggers(eventTrigger=TRIGGER_CLEAR_ALL)
-        report = sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC)
-        asserts.assert_equal(int(report.value), 0, 'State must be 0 after the clear-all trigger')
+        if int(state) == 0:
+            # Nothing was raised, so clearing is a no-op and the cluster reports nothing.
+            final_state = await self._read_state(endpoint)
+        else:
+            final_state = int(sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC).value)
+        asserts.assert_equal(final_state, 0, 'State must be 0 after the clear-all trigger')
         sub.cancel()
 
 

--- a/src/python_testing/TC_EPALM_2_2.py
+++ b/src/python_testing/TC_EPALM_2_2.py
@@ -60,9 +60,8 @@ log = logging.getLogger(__name__)
 
 cluster = Clusters.ElectricalProtectionAlarm
 
-# Alarm Base command ids, inherited by EPALM.
+# Alarm Base Reset command id, inherited by EPALM.
 RESET_COMMAND_ID = 0x00
-MODIFY_ENABLED_ALARMS_COMMAND_ID = 0x01
 
 REPORT_TIMEOUT_SEC = 10.0
 
@@ -112,8 +111,7 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
         """
         await self.send_test_event_trigger_set_alarm(bit)
         if current_state & int(bit):
-            state = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.State)
+            state = await self.read_state(endpoint)
             log.info('State after %s trigger: 0x%08X (already raised, no transition to report)', name, state)
         else:
             report = sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC)
@@ -143,7 +141,7 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
         self.step(1, "Commission DUT to TH (already done)", is_commissioning=True)
 
         self.step(2, "TH reads TestEventTriggersEnabled from General Diagnostics on endpoint 0",
-                  expectation="Value is 1 (True). If 0, the remaining steps cannot run.")
+                  expectation="Value has to be 1 (True). If 0, skip the remaining steps and end the test case.")
         await self.check_test_event_triggers_enabled()
 
         feature_map = await self.read_single_attribute_check_success(
@@ -152,12 +150,12 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
 
         accepted_commands = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attributes.AcceptedCommandList)
-        accepts_modify = MODIFY_ENABLED_ALARMS_COMMAND_ID in accepted_commands
+        accepts_modify = cluster.Commands.ModifyEnabledAlarms.command_id in accepted_commands
 
         self.step(3, "TH establishes a subscription to the State attribute with MinIntervalFloor=0 "
                      "and MaxIntervalCeiling=30",
-                  expectation="Subscription is established and the current State value is read as "
-                              "the baseline.")
+                  expectation="Subscription is established successfully; TH awaits subscription report of an initial "
+                  "priming report carrying the current State value (in the no-fault baseline this is 0).")
         sub = AttributeSubscriptionHandler(expected_cluster=cluster, expected_attribute=attributes.State)
         await sub.start(self.default_controller, self.dut_node_id, endpoint,
                         min_interval_sec=0, max_interval_sec=30)
@@ -165,13 +163,13 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
         # ReadAttribute returns, so the priming report is delivered before the handler is
         # listening and never reaches its queue. Read the attribute for the baseline instead;
         # every later report in this test is change-driven and does reach the queue.
-        priming_state = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster, attribute=attributes.State)
+        priming_state = await self.read_state(endpoint)
         log.info('State at subscription time: 0x%08X', priming_state)
 
         current_state = int(priming_state)
         self.step(4, "TH sends the TestEventTrigger for ShortCircuitFault",
-                  expectation="DUT returns SUCCESS and reports a State value with bit 0 set.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                  "value with bit 0 (ShortCircuitFault) set.")
         if feature_map & features.kShortCircuit:
             current_state = await self._trigger_and_expect_bit(
                 sub, alarm_bits.kShortCircuitFault, "ShortCircuitFault", endpoint, current_state)
@@ -179,7 +177,8 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
             self.mark_current_step_skipped()
 
         self.step(5, "TH sends the TestEventTrigger for OverLoadFault",
-                  expectation="DUT returns SUCCESS and reports a State value with bit 1 set.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                  "value with bit 1 (OverLoadFault) set.")
         if feature_map & features.kOverLoad:
             current_state = await self._trigger_and_expect_bit(
                 sub, alarm_bits.kOverLoadFault, "OverLoadFault", endpoint, current_state)
@@ -187,7 +186,8 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
             self.mark_current_step_skipped()
 
         self.step(6, "TH sends the TestEventTrigger for OverVoltageFault",
-                  expectation="DUT returns SUCCESS and reports a State value with bit 2 set.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                  "value with bit 2 (OverVoltageFault) set.")
         if feature_map & features.kOverVoltage:
             current_state = await self._trigger_and_expect_bit(
                 sub, alarm_bits.kOverVoltageFault, "OverVoltageFault", endpoint, current_state)
@@ -195,7 +195,8 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
             self.mark_current_step_skipped()
 
         self.step(7, "TH sends the TestEventTrigger for VoltageSurgeFault",
-                  expectation="DUT returns SUCCESS and reports a State value with bit 3 set.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                  "value with bit 3 (VoltageSurgeFault) set.")
         if feature_map & features.kSurgeProtection:
             current_state = await self._trigger_and_expect_bit(
                 sub, alarm_bits.kVoltageSurgeFault, "VoltageSurgeFault", endpoint, current_state)
@@ -203,7 +204,8 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
             self.mark_current_step_skipped()
 
         self.step(8, "TH sends the TestEventTrigger for ResidualCurrentFault",
-                  expectation="DUT returns SUCCESS and reports a State value with bit 4 set.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                  "value with bit 4 (ResidualCurrentFault) set.")
         if feature_map & features.kResidualCurrent:
             current_state = await self._trigger_and_expect_bit(
                 sub, alarm_bits.kResidualCurrentFault, "ResidualCurrentFault", endpoint, current_state)
@@ -211,7 +213,8 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
             self.mark_current_step_skipped()
 
         self.step(9, "TH sends the TestEventTrigger for ArcFault",
-                  expectation="DUT returns SUCCESS and reports a State value with bit 5 set.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                  "value with bit 5 (ArcFault) set.")
         if feature_map & features.kArcFault:
             current_state = await self._trigger_and_expect_bit(
                 sub, alarm_bits.kArcFault, "ArcFault", endpoint, current_state)
@@ -219,7 +222,8 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
             self.mark_current_step_skipped()
 
         self.step(10, "TH sends the TestEventTrigger for SelfTest",
-                  expectation="DUT returns SUCCESS and reports a State value with bit 6 set.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                  "value with bit 6 (SelfTest) set.")
         if feature_map & features.kSelfTest:
             current_state = await self._trigger_and_expect_bit(
                 sub, alarm_bits.kSelfTest, "SelfTest", endpoint, current_state)
@@ -227,9 +231,10 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
             self.mark_current_step_skipped()
 
         self.step(11, "TH reads the State attribute and inspects the value",
-                  expectation="Every bit set in State is also set in Supported.")
-        state = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster, attribute=attributes.State)
+                  expectation="For every bit b that is set: the feature corresponding to bit b is supported by the DUT "
+                  "(per Supported). For every bit b that is NOT supported by the DUT: bit b MUST NOT be set "
+                  "(feature gating is correctly enforced).")
+        state = await self.read_state(endpoint)
         supported = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attributes.Supported)
         log.info('State: 0x%08X  Supported: 0x%08X', state, supported)
@@ -237,13 +242,15 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
                              'State must not set any bit that is absent from Supported')
 
         self.step(12, "TH sends the Reset command (Alarm Base.Reset) to the DUT",
-                  expectation="DUT replies UNSUPPORTED_COMMAND (0x81).")
+                  expectation="Verify that the DUT response contains UNSUPPORTED_COMMAND (0x81). Reason: EPALM "
+                  "disallows the inherited RESET feature, so the Reset command is not callable.")
         status = await self._command_status(FakeReset(alarms=0), endpoint)
         asserts.assert_equal(status, Status.UnsupportedCommand,
                              'Reset must return UNSUPPORTED_COMMAND: EPALM disallows the RESET feature')
 
         self.step(13, "If the DUT does not accept ModifyEnabledAlarms, TH sends it anyway",
-                  expectation="DUT replies UNSUPPORTED_COMMAND (0x81).")
+                  expectation="Verify that the DUT response contains UNSUPPORTED_COMMAND (0x81). If the DUT declares "
+                  "EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
         if accepts_modify:
             self.mark_current_step_skipped()
         else:
@@ -254,7 +261,9 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
                                  'does not accept it')
 
         self.step("13a", "If the DUT accepts ModifyEnabledAlarms, TH sends it",
-                  expectation="DUT returns SUCCESS.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). The command is optional in Alarm Base, so a "
+                  "DUT that implements it SHALL accept it rather than reject it. If the DUT does not "
+                  "declare EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
         if not accepts_modify:
             self.mark_current_step_skipped()
         else:
@@ -265,7 +274,8 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
                                  'accepts it must succeed rather than reject')
 
         self.step(14, "TH sends the TestEventTrigger that clears all alarms",
-                  expectation="DUT returns SUCCESS and reports a State value of 0.")
+                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                  "value of 0 (cleanup).")
         await self.send_test_event_trigger_clear_all()
         if int(state) == 0:
             # Nothing was raised, so clearing is a no-op and the cluster reports nothing.

--- a/src/python_testing/TC_EPALM_2_2.py
+++ b/src/python_testing/TC_EPALM_2_2.py
@@ -45,6 +45,7 @@ import typing
 from dataclasses import dataclass
 
 from mobly import asserts
+from TC_EPALM_TestBase import ElectricalProtectionAlarmTestBaseHelper
 
 import matter.clusters as Clusters
 from matter import ChipUtility
@@ -52,25 +53,12 @@ from matter.clusters.ClusterObjects import ClusterCommand, ClusterObjectDescript
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
-from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import default_matter_test_main
 from matter.tlv import uint
 
 log = logging.getLogger(__name__)
 
 cluster = Clusters.ElectricalProtectionAlarm
-
-# TestEventTrigger codes implemented by ElectricalProtectionAlarmTestEventTriggerHandler.
-# The top two bytes carry the cluster id to namespace the trigger; the low byte selects the
-# alarm bit to set, or 0 to clear all alarms.
-TRIGGER_CLEAR_ALL = 0x00A3_0000_0000_0000
-TRIGGER_SHORT_CIRCUIT_FAULT = 0x00A3_0000_0000_0001
-TRIGGER_OVER_LOAD_FAULT = 0x00A3_0000_0000_0002
-TRIGGER_OVER_VOLTAGE_FAULT = 0x00A3_0000_0000_0003
-TRIGGER_VOLTAGE_SURGE_FAULT = 0x00A3_0000_0000_0004
-TRIGGER_RESIDUAL_CURRENT_FAULT = 0x00A3_0000_0000_0005
-TRIGGER_ARC_FAULT = 0x00A3_0000_0000_0006
-TRIGGER_SELF_TEST = 0x00A3_0000_0000_0007
 
 # Alarm Base command ids, inherited by EPALM.
 RESET_COMMAND_ID = 0x00
@@ -100,7 +88,7 @@ class FakeReset(ClusterCommand):
     alarms: uint = 0
 
 
-class TC_EPALM_2_2(MatterBaseTest):
+class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
 
     def desc_TC_EPALM_2_2(self) -> str:
         return "[TC-EPALM-2.2] Primary functionality (alarm state machine) with Server as DUT"
@@ -117,7 +105,7 @@ class TC_EPALM_2_2(MatterBaseTest):
             return e.status
         return Status.Success
 
-    async def _trigger_and_expect_bit(self, sub: AttributeSubscriptionHandler, trigger: int,
+    async def _trigger_and_expect_bit(self, sub: AttributeSubscriptionHandler,
                                       bit: cluster.Bitmaps.AlarmBitmap, name: str,
                                       endpoint: int, current_state: int) -> int:
         """Fire a fault trigger and confirm the bit ends up set. Returns the new State.
@@ -125,7 +113,7 @@ class TC_EPALM_2_2(MatterBaseTest):
         The cluster reports only on an actual transition, so a DUT that already has this alarm
         raised emits nothing and waiting for a report would hang. Read in that case instead.
         """
-        await self.send_test_event_triggers(eventTrigger=trigger)
+        await self.send_test_event_trigger_set_alarm(bit)
         if current_state & int(bit):
             state = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.State)
@@ -137,10 +125,6 @@ class TC_EPALM_2_2(MatterBaseTest):
         asserts.assert_true(int(state) & int(bit),
                             f'State must have the {name} bit set after its TestEventTrigger')
         return int(state)
-
-    async def _read_state(self, endpoint: int) -> int:
-        return int(await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.State))
 
     @async_test_body
     async def test_TC_EPALM_2_2(self):
@@ -183,7 +167,7 @@ class TC_EPALM_2_2(MatterBaseTest):
                   expectation="DUT returns SUCCESS and reports a State value with bit 0 set.")
         if feature_map & features.kShortCircuit:
             current_state = await self._trigger_and_expect_bit(
-                sub, TRIGGER_SHORT_CIRCUIT_FAULT, alarm_bits.kShortCircuitFault, "ShortCircuitFault", endpoint, current_state)
+                sub, alarm_bits.kShortCircuitFault, "ShortCircuitFault", endpoint, current_state)
         else:
             self.mark_current_step_skipped()
 
@@ -191,7 +175,7 @@ class TC_EPALM_2_2(MatterBaseTest):
                   expectation="DUT returns SUCCESS and reports a State value with bit 1 set.")
         if feature_map & features.kOverLoad:
             current_state = await self._trigger_and_expect_bit(
-                sub, TRIGGER_OVER_LOAD_FAULT, alarm_bits.kOverLoadFault, "OverLoadFault", endpoint, current_state)
+                sub, alarm_bits.kOverLoadFault, "OverLoadFault", endpoint, current_state)
         else:
             self.mark_current_step_skipped()
 
@@ -199,7 +183,7 @@ class TC_EPALM_2_2(MatterBaseTest):
                   expectation="DUT returns SUCCESS and reports a State value with bit 2 set.")
         if feature_map & features.kOverVoltage:
             current_state = await self._trigger_and_expect_bit(
-                sub, TRIGGER_OVER_VOLTAGE_FAULT, alarm_bits.kOverVoltageFault, "OverVoltageFault", endpoint, current_state)
+                sub, alarm_bits.kOverVoltageFault, "OverVoltageFault", endpoint, current_state)
         else:
             self.mark_current_step_skipped()
 
@@ -207,7 +191,7 @@ class TC_EPALM_2_2(MatterBaseTest):
                   expectation="DUT returns SUCCESS and reports a State value with bit 3 set.")
         if feature_map & features.kSurgeProtection:
             current_state = await self._trigger_and_expect_bit(
-                sub, TRIGGER_VOLTAGE_SURGE_FAULT, alarm_bits.kVoltageSurgeFault, "VoltageSurgeFault", endpoint, current_state)
+                sub, alarm_bits.kVoltageSurgeFault, "VoltageSurgeFault", endpoint, current_state)
         else:
             self.mark_current_step_skipped()
 
@@ -215,7 +199,7 @@ class TC_EPALM_2_2(MatterBaseTest):
                   expectation="DUT returns SUCCESS and reports a State value with bit 4 set.")
         if feature_map & features.kResidualCurrent:
             current_state = await self._trigger_and_expect_bit(
-                sub, TRIGGER_RESIDUAL_CURRENT_FAULT, alarm_bits.kResidualCurrentFault, "ResidualCurrentFault", endpoint, current_state)
+                sub, alarm_bits.kResidualCurrentFault, "ResidualCurrentFault", endpoint, current_state)
         else:
             self.mark_current_step_skipped()
 
@@ -223,7 +207,7 @@ class TC_EPALM_2_2(MatterBaseTest):
                   expectation="DUT returns SUCCESS and reports a State value with bit 5 set.")
         if feature_map & features.kArcFault:
             current_state = await self._trigger_and_expect_bit(
-                sub, TRIGGER_ARC_FAULT, alarm_bits.kArcFault, "ArcFault", endpoint, current_state)
+                sub, alarm_bits.kArcFault, "ArcFault", endpoint, current_state)
         else:
             self.mark_current_step_skipped()
 
@@ -231,7 +215,7 @@ class TC_EPALM_2_2(MatterBaseTest):
                   expectation="DUT returns SUCCESS and reports a State value with bit 6 set.")
         if feature_map & features.kSelfTest:
             current_state = await self._trigger_and_expect_bit(
-                sub, TRIGGER_SELF_TEST, alarm_bits.kSelfTest, "SelfTest", endpoint, current_state)
+                sub, alarm_bits.kSelfTest, "SelfTest", endpoint, current_state)
         else:
             self.mark_current_step_skipped()
 
@@ -275,10 +259,10 @@ class TC_EPALM_2_2(MatterBaseTest):
 
         self.step(14, "TH sends the TestEventTrigger that clears all alarms",
                   expectation="DUT returns SUCCESS and reports a State value of 0.")
-        await self.send_test_event_triggers(eventTrigger=TRIGGER_CLEAR_ALL)
+        await self.send_test_event_trigger_clear_all()
         if int(state) == 0:
             # Nothing was raised, so clearing is a no-op and the cluster reports nothing.
-            final_state = await self._read_state(endpoint)
+            final_state = await self.read_state(endpoint)
         else:
             final_state = int(sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC).value)
         asserts.assert_equal(final_state, 0, 'State must be 0 after the clear-all trigger')

--- a/src/python_testing/TC_EPALM_2_2.py
+++ b/src/python_testing/TC_EPALM_2_2.py
@@ -155,152 +155,178 @@ class TC_EPALM_2_2(ElectricalProtectionAlarmTestBaseHelper):
                      "and MaxIntervalCeiling=30",
                   expectation="Subscription is established successfully; TH awaits subscription report of an initial "
                   "priming report carrying the current State value (in the no-fault baseline this is 0).")
+        original_mask: int | None = None
         sub = AttributeSubscriptionHandler(expected_cluster=cluster, expected_attribute=attributes.State)
         await sub.start(self.default_controller, self.dut_node_id, endpoint,
                         min_interval_sec=0, max_interval_sec=30)
-        # AttributeSubscriptionHandler.start() registers its update callback only after
-        # ReadAttribute returns, so the priming report is delivered before the handler is
-        # listening and never reaches its queue. Read the attribute for the baseline instead;
-        # every later report in this test is change-driven and does reach the queue.
-        priming_state = await self.read_state(endpoint)
-        log.info('State at subscription time: 0x%08X', priming_state)
+        try:
+            # AttributeSubscriptionHandler.start() registers its update callback only after
+            # ReadAttribute returns, so the priming report is delivered before the handler is
+            # listening and never reaches its queue. Read the attribute for the baseline instead;
+            # every later report in this test is change-driven and does reach the queue.
+            priming_state = await self.read_state(endpoint)
+            log.info('State at subscription time: 0x%08X', priming_state)
 
-        current_state = int(priming_state)
-        self.step(4, "TH sends the TestEventTrigger for ShortCircuitFault",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
-                  "value with bit 0 (ShortCircuitFault) set.")
-        if feature_map & features.kShortCircuit:
-            current_state = await self._trigger_and_expect_bit(
-                sub, alarm_bits.kShortCircuitFault, "ShortCircuitFault", endpoint, current_state)
-        else:
-            self.mark_current_step_skipped()
+            current_state = int(priming_state)
+            self.step(4, "TH sends the TestEventTrigger for ShortCircuitFault",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                      "value with bit 0 (ShortCircuitFault) set.")
+            if feature_map & features.kShortCircuit:
+                current_state = await self._trigger_and_expect_bit(
+                    sub, alarm_bits.kShortCircuitFault, "ShortCircuitFault", endpoint, current_state)
+            else:
+                self.mark_current_step_skipped()
 
-        self.step(5, "TH sends the TestEventTrigger for OverLoadFault",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
-                  "value with bit 1 (OverLoadFault) set.")
-        if feature_map & features.kOverLoad:
-            current_state = await self._trigger_and_expect_bit(
-                sub, alarm_bits.kOverLoadFault, "OverLoadFault", endpoint, current_state)
-        else:
-            self.mark_current_step_skipped()
+            self.step(5, "TH sends the TestEventTrigger for OverLoadFault",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                      "value with bit 1 (OverLoadFault) set.")
+            if feature_map & features.kOverLoad:
+                current_state = await self._trigger_and_expect_bit(
+                    sub, alarm_bits.kOverLoadFault, "OverLoadFault", endpoint, current_state)
+            else:
+                self.mark_current_step_skipped()
 
-        self.step(6, "TH sends the TestEventTrigger for OverVoltageFault",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
-                  "value with bit 2 (OverVoltageFault) set.")
-        if feature_map & features.kOverVoltage:
-            current_state = await self._trigger_and_expect_bit(
-                sub, alarm_bits.kOverVoltageFault, "OverVoltageFault", endpoint, current_state)
-        else:
-            self.mark_current_step_skipped()
+            self.step(6, "TH sends the TestEventTrigger for OverVoltageFault",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                      "value with bit 2 (OverVoltageFault) set.")
+            if feature_map & features.kOverVoltage:
+                current_state = await self._trigger_and_expect_bit(
+                    sub, alarm_bits.kOverVoltageFault, "OverVoltageFault", endpoint, current_state)
+            else:
+                self.mark_current_step_skipped()
 
-        self.step(7, "TH sends the TestEventTrigger for VoltageSurgeFault",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
-                  "value with bit 3 (VoltageSurgeFault) set.")
-        if feature_map & features.kSurgeProtection:
-            current_state = await self._trigger_and_expect_bit(
-                sub, alarm_bits.kVoltageSurgeFault, "VoltageSurgeFault", endpoint, current_state)
-        else:
-            self.mark_current_step_skipped()
+            self.step(7, "TH sends the TestEventTrigger for VoltageSurgeFault",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                      "value with bit 3 (VoltageSurgeFault) set.")
+            if feature_map & features.kSurgeProtection:
+                current_state = await self._trigger_and_expect_bit(
+                    sub, alarm_bits.kVoltageSurgeFault, "VoltageSurgeFault", endpoint, current_state)
+            else:
+                self.mark_current_step_skipped()
 
-        self.step(8, "TH sends the TestEventTrigger for ResidualCurrentFault",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
-                  "value with bit 4 (ResidualCurrentFault) set.")
-        if feature_map & features.kResidualCurrent:
-            current_state = await self._trigger_and_expect_bit(
-                sub, alarm_bits.kResidualCurrentFault, "ResidualCurrentFault", endpoint, current_state)
-        else:
-            self.mark_current_step_skipped()
+            self.step(8, "TH sends the TestEventTrigger for ResidualCurrentFault",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                      "value with bit 4 (ResidualCurrentFault) set.")
+            if feature_map & features.kResidualCurrent:
+                current_state = await self._trigger_and_expect_bit(
+                    sub, alarm_bits.kResidualCurrentFault, "ResidualCurrentFault", endpoint, current_state)
+            else:
+                self.mark_current_step_skipped()
 
-        self.step(9, "TH sends the TestEventTrigger for ArcFault",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
-                  "value with bit 5 (ArcFault) set.")
-        if feature_map & features.kArcFault:
-            current_state = await self._trigger_and_expect_bit(
-                sub, alarm_bits.kArcFault, "ArcFault", endpoint, current_state)
-        else:
-            self.mark_current_step_skipped()
+            self.step(9, "TH sends the TestEventTrigger for ArcFault",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                      "value with bit 5 (ArcFault) set.")
+            if feature_map & features.kArcFault:
+                current_state = await self._trigger_and_expect_bit(
+                    sub, alarm_bits.kArcFault, "ArcFault", endpoint, current_state)
+            else:
+                self.mark_current_step_skipped()
 
-        self.step(10, "TH sends the TestEventTrigger for SelfTest",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
-                  "value with bit 6 (SelfTest) set.")
-        if feature_map & features.kSelfTest:
-            current_state = await self._trigger_and_expect_bit(
-                sub, alarm_bits.kSelfTest, "SelfTest", endpoint, current_state)
-        else:
-            self.mark_current_step_skipped()
+            self.step(10, "TH sends the TestEventTrigger for SelfTest",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                      "value with bit 6 (SelfTest) set.")
+            if feature_map & features.kSelfTest:
+                current_state = await self._trigger_and_expect_bit(
+                    sub, alarm_bits.kSelfTest, "SelfTest", endpoint, current_state)
+            else:
+                self.mark_current_step_skipped()
 
-        self.step(11, "TH reads the State attribute and inspects the value",
-                  expectation="For every bit b that is set: the feature corresponding to bit b is supported by the DUT "
-                  "(per Supported). For every bit b that is NOT supported by the DUT: bit b MUST NOT be set "
-                  "(feature gating is correctly enforced).")
-        state = await self.read_state(endpoint)
-        supported = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster, attribute=attributes.Supported)
-        log.info('State: 0x%08X  Supported: 0x%08X', state, supported)
-        asserts.assert_equal(int(state) & ~int(supported), 0,
-                             'State must not set any bit that is absent from Supported')
+            self.step(11, "TH reads the State attribute and inspects the value",
+                      expectation="For every bit b that is set: the feature corresponding to bit b is supported by the DUT "
+                      "(per Supported). For every bit b that is NOT supported by the DUT: bit b MUST NOT be set "
+                      "(feature gating is correctly enforced).")
+            state = await self.read_state(endpoint)
+            supported = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attributes.Supported)
+            log.info('State: 0x%08X  Supported: 0x%08X', state, supported)
+            asserts.assert_equal(int(state) & ~int(supported), 0,
+                                 'State must not set any bit that is absent from Supported')
 
-        self.step(12, "TH sends the Reset command (Alarm Base.Reset) to the DUT",
-                  expectation="Verify that the DUT response contains UNSUPPORTED_COMMAND (0x81). Reason: EPALM "
-                  "disallows the inherited RESET feature, so the Reset command is not callable.")
-        status = await self._command_status(FakeReset(alarms=0), endpoint)
-        asserts.assert_equal(status, Status.UnsupportedCommand,
-                             'Reset must return UNSUPPORTED_COMMAND: EPALM disallows the RESET feature')
-
-        self.step(13, "If the DUT does not accept ModifyEnabledAlarms, TH sends it anyway",
-                  expectation="Verify that the DUT response contains UNSUPPORTED_COMMAND (0x81). If the DUT declares "
-                  "EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
-        if accepts_modify:
-            self.mark_current_step_skipped()
-        else:
-            status = await self._command_status(
-                cluster.Commands.ModifyEnabledAlarms(mask=0), endpoint)
+            self.step(12, "TH sends the Reset command (Alarm Base.Reset) to the DUT",
+                      expectation="Verify that the DUT response contains UNSUPPORTED_COMMAND (0x81). Reason: EPALM "
+                      "disallows the inherited RESET feature, so the Reset command is not callable.")
+            status = await self._command_status(FakeReset(alarms=0), endpoint)
             asserts.assert_equal(status, Status.UnsupportedCommand,
-                                 'ModifyEnabledAlarms must return UNSUPPORTED_COMMAND when the DUT '
-                                 'does not accept it')
+                                 'Reset must return UNSUPPORTED_COMMAND: EPALM disallows the RESET feature')
 
-        self.step("13a", "If the DUT accepts ModifyEnabledAlarms, TH sends it",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). The command is optional in Alarm Base, so a "
-                  "DUT that implements it SHALL accept it rather than reject it. If the DUT does not "
-                  "declare EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
-        if not accepts_modify:
-            self.mark_current_step_skipped()
-        else:
-            status = await self._command_status(
-                cluster.Commands.ModifyEnabledAlarms(mask=int(supported)), endpoint)
-            asserts.assert_equal(status, Status.Success,
-                                 'ModifyEnabledAlarms is optional in Alarm Base, so a DUT that '
-                                 'accepts it must succeed rather than reject')
+            self.step(13, "If the DUT does not accept ModifyEnabledAlarms, TH sends it anyway",
+                      expectation="Verify that the DUT response contains UNSUPPORTED_COMMAND (0x81). If the DUT declares "
+                      "EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
+            if accepts_modify:
+                self.mark_current_step_skipped()
+            else:
+                status = await self._command_status(
+                    cluster.Commands.ModifyEnabledAlarms(mask=0), endpoint)
+                asserts.assert_equal(status, Status.UnsupportedCommand,
+                                     'ModifyEnabledAlarms must return UNSUPPORTED_COMMAND when the DUT '
+                                     'does not accept it')
 
-        self.step("13b", "TH sends the ModifyEnabledAlarms command with a mask that clears at least one "
-                         "bit set in Supported, then TH reads from the DUT the Mask attribute.",
-                  expectation="Value has to be the mask TH sent, with the cleared bit no longer set. If the "
-                  "DUT does not declare EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
-        if not accepts_modify or not int(supported):
-            self.mark_current_step_skipped()
-        else:
-            lowest_supported_bit = int(supported) & -int(supported)
-            reduced_mask = int(supported) & ~lowest_supported_bit
-            status = await self._command_status(
-                cluster.Commands.ModifyEnabledAlarms(mask=reduced_mask), endpoint)
-            asserts.assert_equal(status, Status.Success,
-                                 'ModifyEnabledAlarms must succeed when the DUT accepts it')
-            mask = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster, attribute=attributes.Mask)
-            asserts.assert_equal(int(mask), reduced_mask,
-                                 'Mask must reflect the value sent to ModifyEnabledAlarms')
+            self.step("13a", "If the DUT accepts ModifyEnabledAlarms, TH sends it",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). The command is optional in Alarm Base, so a "
+                      "DUT that implements it SHALL accept it rather than reject it. If the DUT does not "
+                      "declare EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
+            if not accepts_modify:
+                self.mark_current_step_skipped()
+            else:
+                original_mask = int(await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attributes.Mask))
+                status = await self._command_status(
+                    cluster.Commands.ModifyEnabledAlarms(mask=int(supported)), endpoint)
+                asserts.assert_equal(status, Status.Success,
+                                     'ModifyEnabledAlarms is optional in Alarm Base, so a DUT that '
+                                     'accepts it must succeed rather than reject')
 
-        self.step(14, "TH sends the TestEventTrigger that clears all alarms",
-                  expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
-                  "value of 0 (cleanup).")
-        await self.send_test_event_trigger_clear_all()
-        if int(state) == 0:
-            # Nothing was raised, so clearing is a no-op and the cluster reports nothing.
-            final_state = await self.read_state(endpoint)
-        else:
-            final_state = int(sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC).value)
-        asserts.assert_equal(final_state, 0, 'State must be 0 after the clear-all trigger')
-        sub.cancel()
+            self.step("13b", "TH sends the ModifyEnabledAlarms command with a mask that clears at least one "
+                             "bit set in Supported, then TH reads from the DUT the Mask attribute.",
+                      expectation="Value has to be the mask TH sent, with the cleared bit no longer set. If the "
+                      "DUT does not declare EPALM.S.C01.Rsp(ModifyEnabledAlarms), the step is skipped.")
+            if not accepts_modify or not int(supported):
+                self.mark_current_step_skipped()
+            else:
+                lowest_supported_bit = int(supported) & -int(supported)
+                reduced_mask = int(supported) & ~lowest_supported_bit
+                status = await self._command_status(
+                    cluster.Commands.ModifyEnabledAlarms(mask=reduced_mask), endpoint)
+                asserts.assert_equal(status, Status.Success,
+                                     'ModifyEnabledAlarms must succeed when the DUT accepts it')
+                mask = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attributes.Mask)
+                asserts.assert_equal(int(mask), reduced_mask,
+                                     'Mask must reflect the value sent to ModifyEnabledAlarms')
+                # Alarm Base SetMask clears any active State bit the new mask no longer covers, which is a
+                # State transition and therefore a report. Drain it, or step 14 dequeues it instead of the
+                # report from the clear-all trigger.
+                if current_state & lowest_supported_bit:
+                    dropped = int(sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC).value)
+                    log.info('State after masking off 0x%08X: 0x%08X', lowest_supported_bit, dropped)
+                    current_state = dropped
+
+            self.step(14, "TH sends the TestEventTrigger that clears all alarms",
+                      expectation="Verify DUT responds w/ status SUCCESS(0x00). TH awaits subscription report of a State "
+                      "value of 0 (cleanup).")
+            await self.send_test_event_trigger_clear_all()
+            if current_state == 0:
+                # Nothing is raised, so clearing is a no-op and the cluster reports nothing.
+                final_state = await self.read_state(endpoint)
+            else:
+                final_state = int(sub.wait_next_report(timeout_sec=REPORT_TIMEOUT_SEC).value)
+            asserts.assert_equal(final_state, 0, 'State must be 0 after the clear-all trigger')
+        finally:
+            # Best effort: step 14 is the real assertion, but a failure anywhere above must not
+            # leave the DUT with alarms latched, its Mask altered, or the subscription registered.
+            if original_mask is not None:
+                try:
+                    restore = await self._command_status(
+                        cluster.Commands.ModifyEnabledAlarms(mask=original_mask), endpoint)
+                    if restore is not Status.Success:
+                        log.warning('Restoring Mask returned %s', restore)
+                except Exception:
+                    log.warning('Restoring Mask failed', exc_info=True)
+            try:
+                await self.send_test_event_trigger_clear_all()
+            except Exception:
+                log.warning('Cleanup clear-all failed', exc_info=True)
+            sub.cancel()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_EPALM_TestBase.py
+++ b/src/python_testing/TC_EPALM_TestBase.py
@@ -1,0 +1,69 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import matter.clusters as Clusters
+from matter.testing.matter_testing import MatterBaseTest
+
+cluster = Clusters.ElectricalProtectionAlarm
+AlarmBitmap = cluster.Bitmaps.AlarmBitmap
+
+
+class ElectricalProtectionAlarmTestBaseHelper(MatterBaseTest):
+    """Shared TestEventTrigger handling for the TC-EPALM cases.
+
+    The trigger codes are namespaced by cluster id in the top two bytes. In the low byte, 0x00
+    clears every alarm, 0x01 through 0x07 raise a single alarm, and 0x11 through 0x17 clear that
+    same alarm. See ElectricalProtectionAlarmTestEventTriggerHandler.h.
+    """
+
+    test_event_clear_all = 0x00A3_0000_0000_0000
+
+    _set_triggers = {
+        AlarmBitmap.kShortCircuitFault: 0x00A3_0000_0000_0001,
+        AlarmBitmap.kOverLoadFault: 0x00A3_0000_0000_0002,
+        AlarmBitmap.kOverVoltageFault: 0x00A3_0000_0000_0003,
+        AlarmBitmap.kVoltageSurgeFault: 0x00A3_0000_0000_0004,
+        AlarmBitmap.kResidualCurrentFault: 0x00A3_0000_0000_0005,
+        AlarmBitmap.kArcFault: 0x00A3_0000_0000_0006,
+        AlarmBitmap.kSelfTest: 0x00A3_0000_0000_0007,
+    }
+
+    _clear_triggers = {
+        AlarmBitmap.kShortCircuitFault: 0x00A3_0000_0000_0011,
+        AlarmBitmap.kOverLoadFault: 0x00A3_0000_0000_0012,
+        AlarmBitmap.kOverVoltageFault: 0x00A3_0000_0000_0013,
+        AlarmBitmap.kVoltageSurgeFault: 0x00A3_0000_0000_0014,
+        AlarmBitmap.kResidualCurrentFault: 0x00A3_0000_0000_0015,
+        AlarmBitmap.kArcFault: 0x00A3_0000_0000_0016,
+        AlarmBitmap.kSelfTest: 0x00A3_0000_0000_0017,
+    }
+
+    async def send_test_event_trigger_set_alarm(self, alarm: AlarmBitmap):
+        """Raise a single alarm."""
+        await self.send_test_event_triggers(eventTrigger=self._set_triggers[alarm])
+
+    async def send_test_event_trigger_clear_alarm(self, alarm: AlarmBitmap):
+        """Lower a single alarm, leaving the others untouched."""
+        await self.send_test_event_triggers(eventTrigger=self._clear_triggers[alarm])
+
+    async def send_test_event_trigger_clear_all(self):
+        """Lower every alarm."""
+        await self.send_test_event_triggers(eventTrigger=self.test_event_clear_all)
+
+    async def read_state(self, endpoint: int) -> int:
+        return int(await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.State))

--- a/src/python_testing/TC_EPALM_TestBase.py
+++ b/src/python_testing/TC_EPALM_TestBase.py
@@ -52,18 +52,19 @@ class ElectricalProtectionAlarmTestBaseHelper(MatterBaseTest):
         AlarmBitmap.kSelfTest: 0x00A3_0000_0000_0017,
     }
 
-    async def send_test_event_trigger_set_alarm(self, alarm: AlarmBitmap):
+    async def send_test_event_trigger_set_alarm(self, alarm: AlarmBitmap) -> None:
         """Raise a single alarm."""
         await self.send_test_event_triggers(eventTrigger=self._set_triggers[alarm])
 
-    async def send_test_event_trigger_clear_alarm(self, alarm: AlarmBitmap):
+    async def send_test_event_trigger_clear_alarm(self, alarm: AlarmBitmap) -> None:
         """Lower a single alarm, leaving the others untouched."""
         await self.send_test_event_triggers(eventTrigger=self._clear_triggers[alarm])
 
-    async def send_test_event_trigger_clear_all(self):
+    async def send_test_event_trigger_clear_all(self) -> None:
         """Lower every alarm."""
         await self.send_test_event_triggers(eventTrigger=self.test_event_clear_all)
 
     async def read_state(self, endpoint: int) -> int:
+        """Read the State attribute."""
         return int(await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.State))

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -65,6 +65,8 @@ not_automated:
       reason: Shared code for TC_EEM and TC_EPM, not a standalone test
     - name: TC_EGCTestBase.py
       reason: Shared code for TC_EGC, not a standalone test
+    - name: TC_EPALM_TestBase.py
+      reason: Shared code for TC_EPALM, not a standalone test
     - name: TC_OpstateCommon.py
       reason: Shared code for TC_OPSTATE, not a standalone test
     - name: TC_pics_checker.py


### PR DESCRIPTION
#### Summary

##### Problem

TC-EPALM-2.2 ("Primary functionality (alarm state machine) with Server as DUT") has had a merged test plan since 2026-07-16 ([chip-test-plans #6157](https://github.com/CHIP-Specifications/chip-test-plans/pull/6157)), but no Python automation was ever filed for it.

- The sibling cases both have scripts in flight: TC-EPALM-2.1 (#72279) and TC-EPALM-2.3 (#72323).
- The EPALM server already ships the TestEventTrigger handler that exists specifically to drive this case, and its header names TC-EPALM-2.2 as the consumer.
- Without a script the alarm state machine cannot be exercised at TE2, and the Sep 11 cutoff closes the window for adding one.

##### Solution

- Implements all 14 steps of the merged plan.
- Steps 4 to 10 drive each fault bit through the General Diagnostics TestEventTrigger codes the server already implements, and verify the corresponding `State` bit arrives on a subscription report.
- Step 11 checks that `State` sets no bit absent from `Supported`.
- Step 12 exercises the `Reset` rejection path. EPALM disallows the inherited RESET feature, so no `Reset` command is generated into the Python bindings; the script declares it locally, the same approach `TC_REFALM_2_2.py` takes for Refrigerator Alarm.
- Step 13 follows [chip-test-plans #6364](https://github.com/CHIP-Specifications/chip-test-plans/pull/6364): `ModifyEnabledAlarms` is optional in Alarm Base rather than disallowed, so `UNSUPPORTED_COMMAND` is expected only when the DUT does not list the command, and success when it does.

##### Caveats

`AttributeSubscriptionHandler.start()` registers its update callback after `ReadAttribute` returns, so the priming report is delivered before the handler is listening and never reaches its queue. Step 3 reads the attribute for its baseline instead. Every later report in this test is change-driven and does arrive through the handler.

#### Testing

Run against a locally built `chip-electrical-protection-app` on endpoint 1, passing. All 14 steps execute; only step 13a is skipped, correctly, because the app does not accept `ModifyEnabledAlarms`.

Observed progression across steps 4 to 10, with `FeatureMap` `0x07F00000`:

```
State after ShortCircuitFault trigger:    0x00000001
State after OverLoadFault trigger:        0x00000003
State after OverVoltageFault trigger:     0x00000007
State after VoltageSurgeFault trigger:    0x0000000F
State after ResidualCurrentFault trigger: 0x0000001F
State after ArcFault trigger:             0x0000003F
State after SelfTest trigger:             0x0000007F
State: 0x0000007F  Supported: 0x0000007F
```

The test also runs in CI against `${ELECTRICAL_PROTECTION_APP}`, which exposes EPALM on the enclosure endpoint.