### PR TITLE
[EPALM] Add per-alarm clear TestEventTriggers

### DIFF
--- a/examples/electrical-protection-app/electrical-protection-common/src/electrical-protection-alarm-stub.cpp
+++ b/examples/electrical-protection-app/electrical-protection-common/src/electrical-protection-alarm-stub.cpp
@@ -95,64 +95,44 @@ bool HandleElectricalProtectionAlarmTestEventTrigger(uint64_t eventTrigger)
     VerifyOrReturnValue(gInstance != nullptr, false);
     auto & cluster = gInstance->Cluster();
 
-    BitMask<AlarmBitmap> bit;
-    bool activate = true;
+    auto activate = [&cluster](AlarmBitmap alarm) { return cluster.ActivateAlarms(BitMask<AlarmBitmap>(alarm)) == CHIP_NO_ERROR; };
+    auto deactivate = [&cluster](AlarmBitmap alarm) {
+        return cluster.DeactivateAlarms(BitMask<AlarmBitmap>(alarm)) == CHIP_NO_ERROR;
+    };
+
     switch (static_cast<ElectricalProtectionAlarmTrigger>(eventTrigger))
     {
     case ElectricalProtectionAlarmTrigger::kClearAll:
         return cluster.ClearAllAlarms() == CHIP_NO_ERROR;
     case ElectricalProtectionAlarmTrigger::kSetShortCircuitFault:
-        bit.Set(AlarmBitmap::kShortCircuitFault);
-        break;
+        return activate(AlarmBitmap::kShortCircuitFault);
     case ElectricalProtectionAlarmTrigger::kSetOverLoadFault:
-        bit.Set(AlarmBitmap::kOverLoadFault);
-        break;
+        return activate(AlarmBitmap::kOverLoadFault);
     case ElectricalProtectionAlarmTrigger::kSetOverVoltageFault:
-        bit.Set(AlarmBitmap::kOverVoltageFault);
-        break;
+        return activate(AlarmBitmap::kOverVoltageFault);
     case ElectricalProtectionAlarmTrigger::kSetVoltageSurgeFault:
-        bit.Set(AlarmBitmap::kVoltageSurgeFault);
-        break;
+        return activate(AlarmBitmap::kVoltageSurgeFault);
     case ElectricalProtectionAlarmTrigger::kSetResidualCurrentFault:
-        bit.Set(AlarmBitmap::kResidualCurrentFault);
-        break;
+        return activate(AlarmBitmap::kResidualCurrentFault);
     case ElectricalProtectionAlarmTrigger::kSetArcFault:
-        bit.Set(AlarmBitmap::kArcFault);
-        break;
+        return activate(AlarmBitmap::kArcFault);
     case ElectricalProtectionAlarmTrigger::kSetSelfTest:
-        bit.Set(AlarmBitmap::kSelfTest);
-        break;
+        return activate(AlarmBitmap::kSelfTest);
     case ElectricalProtectionAlarmTrigger::kClearShortCircuitFault:
-        bit.Set(AlarmBitmap::kShortCircuitFault);
-        activate = false;
-        break;
+        return deactivate(AlarmBitmap::kShortCircuitFault);
     case ElectricalProtectionAlarmTrigger::kClearOverLoadFault:
-        bit.Set(AlarmBitmap::kOverLoadFault);
-        activate = false;
-        break;
+        return deactivate(AlarmBitmap::kOverLoadFault);
     case ElectricalProtectionAlarmTrigger::kClearOverVoltageFault:
-        bit.Set(AlarmBitmap::kOverVoltageFault);
-        activate = false;
-        break;
+        return deactivate(AlarmBitmap::kOverVoltageFault);
     case ElectricalProtectionAlarmTrigger::kClearVoltageSurgeFault:
-        bit.Set(AlarmBitmap::kVoltageSurgeFault);
-        activate = false;
-        break;
+        return deactivate(AlarmBitmap::kVoltageSurgeFault);
     case ElectricalProtectionAlarmTrigger::kClearResidualCurrentFault:
-        bit.Set(AlarmBitmap::kResidualCurrentFault);
-        activate = false;
-        break;
+        return deactivate(AlarmBitmap::kResidualCurrentFault);
     case ElectricalProtectionAlarmTrigger::kClearArcFault:
-        bit.Set(AlarmBitmap::kArcFault);
-        activate = false;
-        break;
+        return deactivate(AlarmBitmap::kArcFault);
     case ElectricalProtectionAlarmTrigger::kClearSelfTest:
-        bit.Set(AlarmBitmap::kSelfTest);
-        activate = false;
-        break;
+        return deactivate(AlarmBitmap::kSelfTest);
     default:
         return false;
     }
-
-    return (activate ? cluster.ActivateAlarms(bit) : cluster.DeactivateAlarms(bit)) == CHIP_NO_ERROR;
 }

--- a/examples/electrical-protection-app/electrical-protection-common/src/electrical-protection-alarm-stub.cpp
+++ b/examples/electrical-protection-app/electrical-protection-common/src/electrical-protection-alarm-stub.cpp
@@ -96,6 +96,7 @@ bool HandleElectricalProtectionAlarmTestEventTrigger(uint64_t eventTrigger)
     auto & cluster = gInstance->Cluster();
 
     BitMask<AlarmBitmap> bit;
+    bool activate = true;
     switch (static_cast<ElectricalProtectionAlarmTrigger>(eventTrigger))
     {
     case ElectricalProtectionAlarmTrigger::kClearAll:
@@ -121,9 +122,37 @@ bool HandleElectricalProtectionAlarmTestEventTrigger(uint64_t eventTrigger)
     case ElectricalProtectionAlarmTrigger::kSetSelfTest:
         bit.Set(AlarmBitmap::kSelfTest);
         break;
+    case ElectricalProtectionAlarmTrigger::kClearShortCircuitFault:
+        bit.Set(AlarmBitmap::kShortCircuitFault);
+        activate = false;
+        break;
+    case ElectricalProtectionAlarmTrigger::kClearOverLoadFault:
+        bit.Set(AlarmBitmap::kOverLoadFault);
+        activate = false;
+        break;
+    case ElectricalProtectionAlarmTrigger::kClearOverVoltageFault:
+        bit.Set(AlarmBitmap::kOverVoltageFault);
+        activate = false;
+        break;
+    case ElectricalProtectionAlarmTrigger::kClearVoltageSurgeFault:
+        bit.Set(AlarmBitmap::kVoltageSurgeFault);
+        activate = false;
+        break;
+    case ElectricalProtectionAlarmTrigger::kClearResidualCurrentFault:
+        bit.Set(AlarmBitmap::kResidualCurrentFault);
+        activate = false;
+        break;
+    case ElectricalProtectionAlarmTrigger::kClearArcFault:
+        bit.Set(AlarmBitmap::kArcFault);
+        activate = false;
+        break;
+    case ElectricalProtectionAlarmTrigger::kClearSelfTest:
+        bit.Set(AlarmBitmap::kSelfTest);
+        activate = false;
+        break;
     default:
         return false;
     }
 
-    return cluster.ActivateAlarms(bit) == CHIP_NO_ERROR;
+    return (activate ? cluster.ActivateAlarms(bit) : cluster.DeactivateAlarms(bit)) == CHIP_NO_ERROR;
 }

--- a/src/app/clusters/electrical-protection-alarm-server/ElectricalProtectionAlarmTestEventTriggerHandler.h
+++ b/src/app/clusters/electrical-protection-alarm-server/ElectricalProtectionAlarmTestEventTriggerHandler.h
@@ -31,8 +31,9 @@ bool HandleElectricalProtectionAlarmTestEventTrigger(uint64_t eventTrigger);
 namespace chip {
 
 /// EventTrigger codes for the Electrical Protection Alarm cluster. The top two bytes carry the
-/// cluster id (0x00A3) to namespace the trigger; the low byte selects the alarm bit to set, or 0 to
-/// clear all alarms.
+/// cluster id (0x00A3) to namespace the trigger. In the low byte, 0x00 clears every alarm, 0x01
+/// through 0x07 set a single alarm bit, and 0x11 through 0x17 clear that same bit. The per-alarm
+/// clear codes are what TC-EPALM-3.1 through 3.7 use to drive a Notify event back to Inactive.
 enum class ElectricalProtectionAlarmTrigger : uint64_t
 {
     kClearAll                = 0x00a3'0000'0000'0000,
@@ -43,6 +44,14 @@ enum class ElectricalProtectionAlarmTrigger : uint64_t
     kSetResidualCurrentFault = 0x00a3'0000'0000'0005,
     kSetArcFault             = 0x00a3'0000'0000'0006,
     kSetSelfTest             = 0x00a3'0000'0000'0007,
+
+    kClearShortCircuitFault    = 0x00a3'0000'0000'0011,
+    kClearOverLoadFault        = 0x00a3'0000'0000'0012,
+    kClearOverVoltageFault     = 0x00a3'0000'0000'0013,
+    kClearVoltageSurgeFault    = 0x00a3'0000'0000'0014,
+    kClearResidualCurrentFault = 0x00a3'0000'0000'0015,
+    kClearArcFault             = 0x00a3'0000'0000'0016,
+    kClearSelfTest             = 0x00a3'0000'0000'0017,
 };
 
 class ElectricalProtectionAlarmTestEventTriggerHandler : public TestEventTriggerHandler


### PR DESCRIPTION
#### Summary

##### Problem

The Electrical Protection Alarm trigger handler can set each of the seven alarm bits individually (`0x00A3…0001` through `0007`), but the only way to clear one is `kClearAll` (`0x00A3…0000`), which clears all of them at once.

- TC-EPALM-3.1 through 3.7, added by [chip-test-plans #6302](https://github.com/CHIP-Specifications/chip-test-plans/pull/6302), each raise one alarm and then lower it, to observe the `Notify` event carrying that bit first in `Active` and then in `Inactive`.
- They reference per-alarm clear codes `0x00A3…0011` through `0017`. Those codes do not exist, so **none of those seven test cases can be automated today**.
- `kClearAll` is not a substitute: it clears every bit, so it cannot show that lowering one alarm leaves the others untouched.

##### Solution

- Adds the seven per-alarm clear codes and routes them to the cluster's existing `DeactivateAlarms()`.
- `kClearAll` is unchanged, so existing behavior and TC-EPALM-2.2 are unaffected.
- Low byte layout is now: `0x00` clears every alarm, `0x01`–`0x07` set one bit, `0x11`–`0x17` clear that same bit.

#### Testing

Built `chip-electrical-protection-app` and exercised every new code against it. Each set trigger raises exactly its own bit and each clear trigger lowers exactly that bit, ending with `State` at 0:

```
ShortCircuitFault      set   -> State=0x01     clear -> State=0x00
OverLoadFault          set   -> State=0x02     clear -> State=0x00
OverVoltageFault       set   -> State=0x04     clear -> State=0x00
VoltageSurgeFault      set   -> State=0x08     clear -> State=0x00
ResidualCurrentFault   set   -> State=0x10     clear -> State=0x00
ArcFault               set   -> State=0x20     clear -> State=0x00
SelfTest               set   -> State=0x40     clear -> State=0x00
```

TC-EPALM-2.2 (#73812) re-run against the same build and still passes, confirming `kClearAll` and the set triggers are unchanged.