### PR TITLE
Reject out-of-range SmokeSensitivityLevel writes

### DIFF
--- a/src/app/clusters/smoke-co-alarm-server/SmokeCoAlarmCluster.cpp
+++ b/src/app/clusters/smoke-co-alarm-server/SmokeCoAlarmCluster.cpp
@@ -389,6 +389,9 @@ DataModel::ActionReturnStatus SmokeCoAlarmCluster::WriteAttribute(const DataMode
 
     SensitivityEnum value;
     ReturnErrorOnFailure(decoder.Decode(value));
+    // The spec requires CONSTRAINT_ERROR when a client writes an enumeration value the server
+    // does not support.
+    VerifyOrReturnValue(value != SensitivityEnum::kUnknownEnumValue, Status::ConstraintError);
     SetSmokeSensitivityLevel(value);
     return Status::Success;
 }

--- a/src/app/clusters/smoke-co-alarm-server/tests/TestSmokeCoAlarmCluster.cpp
+++ b/src/app/clusters/smoke-co-alarm-server/tests/TestSmokeCoAlarmCluster.cpp
@@ -344,3 +344,33 @@ TEST_F(TestSmokeCoAlarmCluster, RemainingAlarmAttributes_ReadBack)
 
     EXPECT_EQ(cluster.GetExpiryDate(), 0u);
 }
+
+TEST_F(TestSmokeCoAlarmCluster, WriteAttribute_SmokeSensitivityLevel_OutOfRangeRejected)
+{
+    // Move off the kStandard default first, so the "unchanged" assertions below cannot be
+    // satisfied by a write that stores nothing at all.
+    ASSERT_EQ(tester.WriteAttribute(Attributes::SmokeSensitivityLevel::Id, to_underlying(SensitivityEnum::kLow)),
+              CHIP_NO_ERROR);
+
+    // SensitivityEnum is 0..2; a value outside that range must be answered ConstraintError and must
+    // not be stored, rather than being folded onto kUnknownEnumValue and kept.
+    for (uint8_t outOfRange : { static_cast<uint8_t>(3), static_cast<uint8_t>(7), static_cast<uint8_t>(255) })
+    {
+        EXPECT_EQ(tester.WriteAttribute(Attributes::SmokeSensitivityLevel::Id, outOfRange),
+                  CHIP_IM_GLOBAL_STATUS(ConstraintError));
+
+        uint8_t level{};
+        ASSERT_EQ(tester.ReadAttribute(Attributes::SmokeSensitivityLevel::Id, level), CHIP_NO_ERROR);
+        EXPECT_EQ(level, to_underlying(SensitivityEnum::kLow));
+    }
+
+    // In-range values still have to be accepted, so a guard cannot pass by rejecting everything.
+    for (SensitivityEnum inRange : { SensitivityEnum::kHigh, SensitivityEnum::kStandard, SensitivityEnum::kLow })
+    {
+        ASSERT_EQ(tester.WriteAttribute(Attributes::SmokeSensitivityLevel::Id, to_underlying(inRange)), CHIP_NO_ERROR);
+
+        uint8_t level{};
+        ASSERT_EQ(tester.ReadAttribute(Attributes::SmokeSensitivityLevel::Id, level), CHIP_NO_ERROR);
+        EXPECT_EQ(level, to_underlying(inRange));
+    }
+}

--- a/src/app/clusters/smoke-co-alarm-server/tests/TestSmokeCoAlarmCluster.cpp
+++ b/src/app/clusters/smoke-co-alarm-server/tests/TestSmokeCoAlarmCluster.cpp
@@ -349,15 +349,13 @@ TEST_F(TestSmokeCoAlarmCluster, WriteAttribute_SmokeSensitivityLevel_OutOfRangeR
 {
     // Move off the kStandard default first, so the "unchanged" assertions below cannot be
     // satisfied by a write that stores nothing at all.
-    ASSERT_EQ(tester.WriteAttribute(Attributes::SmokeSensitivityLevel::Id, to_underlying(SensitivityEnum::kLow)),
-              CHIP_NO_ERROR);
+    ASSERT_EQ(tester.WriteAttribute(Attributes::SmokeSensitivityLevel::Id, to_underlying(SensitivityEnum::kLow)), CHIP_NO_ERROR);
 
     // SensitivityEnum is 0..2; a value outside that range must be answered ConstraintError and must
     // not be stored, rather than being folded onto kUnknownEnumValue and kept.
     for (uint8_t outOfRange : { static_cast<uint8_t>(3), static_cast<uint8_t>(7), static_cast<uint8_t>(255) })
     {
-        EXPECT_EQ(tester.WriteAttribute(Attributes::SmokeSensitivityLevel::Id, outOfRange),
-                  CHIP_IM_GLOBAL_STATUS(ConstraintError));
+        EXPECT_EQ(tester.WriteAttribute(Attributes::SmokeSensitivityLevel::Id, outOfRange), CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
         uint8_t level{};
         ASSERT_EQ(tester.ReadAttribute(Attributes::SmokeSensitivityLevel::Id, level), CHIP_NO_ERROR);


### PR DESCRIPTION
#### Summary

##### Problem

-   `SensitivityEnum` is `0..2`, but `DataModel::Decode` maps any other value onto `kUnknownEnumValue` and returns success. A write of `3`-`255` to `SmokeSensitivityLevel` is therefore answered `Success` and the sentinel is stored.
-   Reads of the attribute then fail with `CONSTRAINT_ERROR` from `AttributeValueEncoder`, which declines to encode the sentinel, leaving the attribute unreadable until a valid value is written.

##### Solution

-   Reject values outside the defined range with `CONSTRAINT_ERROR`, matching the existing convention in `FanControlCluster`.

#### Testing

-   Added `WriteAttribute_SmokeSensitivityLevel_OutOfRangeRejected` in `src/app/clusters/smoke-co-alarm-server/tests/TestSmokeCoAlarmCluster.cpp`: writes of `3`, `7` and `255` are rejected and leave the stored value unchanged, and `0`/`1`/`2` still write and read back.
