### PR TITLE
[silabs] Fix RHT sensor silabs

### DIFF
--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -540,7 +540,6 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform_core/platform/driver/i2c/inc",
         "${efr32_sdk_root}/platform_core/platform/driver/i2c/src",
         "${efr32_sdk_root}/platform_core/platform/driver/i2cspm/inc",
-        "${efr32_sdk_root}/platform_core/platform/peripheral/inc",
         "${efr32_sdk_root}/bluetooth_le_middleware/common/sensor_rht",
         "${efr32_sdk_root}/bluetooth_le_middleware/common/sensor_rht/config",
         "${efr32_sdk_root}/boards/hardware/driver/si70xx/inc",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -537,7 +537,10 @@ template("efr32_sdk") {
 
     if (sl_enable_si70xx_sensor) {
       _include_dirs += [
+        "${efr32_sdk_root}/platform_core/platform/driver/i2c/inc",
+        "${efr32_sdk_root}/platform_core/platform/driver/i2c/src",
         "${efr32_sdk_root}/platform_core/platform/driver/i2cspm/inc",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/inc",
         "${efr32_sdk_root}/bluetooth_le_middleware/common/sensor_rht",
         "${efr32_sdk_root}/bluetooth_le_middleware/common/sensor_rht/config",
         "${efr32_sdk_root}/boards/hardware/driver/si70xx/inc",
@@ -1306,7 +1309,9 @@ template("efr32_sdk") {
       sources += [
         "${efr32_sdk_root}/boards/hardware/driver/si70xx/src/sl_si70xx.c",
         "${efr32_sdk_root}/platform_core/platform/common/src/sl_status.c",
+        "${efr32_sdk_root}/platform_core/platform/driver/i2c/src/sl_i2c.c",
         "${efr32_sdk_root}/platform_core/platform/driver/i2cspm/src/sl_i2cspm.c",
+        "${efr32_sdk_root}/platform_core/platform/peripheral/src/sl_hal_i2c.c",
         "${matter_support_root}/board-support/efr32/${silabs_family}/${silabs_board}/autogen/sl_i2cspm_init.c",
       ]
 


### PR DESCRIPTION
### Summary

While this sensor is in EOL, it still works. Update the required file to enable it.

### Related issues

None

### Testing
Tested with a BRD4002A and a BRD2601B
