### PR TITLE
[All-devices-app] Add build time selection of default device behavior

### DIFF
--- a/examples/all-devices-app/all-devices-common/device-factory/enabled_devices.gni
+++ b/examples/all-devices-app/all-devices-common/device-factory/enabled_devices.gni
@@ -27,6 +27,14 @@ declare_args() {
   #   subset selected      →  "example-device-app"
   # Any non-empty value is used as-is regardless of the device list.
   all_devices_app_name = ""
+
+  # Ordered list of device types to instantiate at boot on platforms that
+  # honor this arg. Each entry is registered on a
+  # consecutive endpoint starting at endpoint 1. Empty list (default) means
+  # "use the factory's default single device".
+  # Every entry must also appear in all_devices_enabled_devices (or the list
+  # must be empty, i.e. "all enabled").
+  all_devices_default_devices = []
 }
 
 # Private helper — only used within this file.
@@ -242,5 +250,47 @@ template("enabled_devices_buildconfig_header") {
       _name = _available_device[1]
       defines += [ "ALL_DEVICES_ENABLE_${_name}=${_enabled}" ]
     }
+
+    # Validate that every entry in all_devices_default_devices is a known
+    # device type, and (when a subset is enabled) also actually enabled.
+    foreach(_requested, all_devices_default_devices) {
+      _found = false
+      foreach(_available_device, _available_devices) {
+        if (_requested == _available_device[0]) {
+          _found = true
+        }
+      }
+      assert(_found,
+             "all_devices_default_devices contains unknown device type: " +
+                 "\"${_requested}\". See _available_devices in " +
+                 "enabled_devices.gni for the accepted values.")
+
+      if (!_all_devices_all_enabled) {
+        _also_enabled = false
+        foreach(_device, all_devices_enabled_devices) {
+          if (_device == _requested) {
+            _also_enabled = true
+          }
+        }
+        assert(_also_enabled,
+               "all_devices_default_devices entry \"${_requested}\" is not " +
+                   "present in all_devices_enabled_devices; it would not be " +
+                   "registered in the DeviceFactory and could not be " +
+                   "instantiated.")
+      }
+    }
+
+    # Compile-time CSV + count of the default device set, consumed by
+    # platforms that pre-select their device types at build
+    # time rather than at runtime.
+    _default_devices_csv = string_join(",", all_devices_default_devices)
+    _default_devices_count = 0
+    foreach(_d, all_devices_default_devices) {
+      _default_devices_count = _default_devices_count + 1
+    }
+    defines += [
+      "ALL_DEVICES_DEFAULT_DEVICES=\"${_default_devices_csv}\"",
+      "ALL_DEVICES_DEFAULT_DEVICES_COUNT=${_default_devices_count}",
+    ]
   }
 }

--- a/examples/all-devices-app/silabs/README.md
+++ b/examples/all-devices-app/silabs/README.md
@@ -1,0 +1,95 @@
+# Matter All-Devices Application — Silabs (EFR32)
+
+This is the Silabs/EFR32 target for the `all-devices-app`. Refer to the
+top-level [all-devices-app README](../README.md) for a description of the
+Code-Driven paradigm, supported device types, CLI concepts, and the overall
+documentation suite under [`../docs/`](../docs/).
+
+Unlike the Linux/POSIX variant, the Silabs image cannot select device types
+from `argv` at boot. Instead the topology is chosen in one of two ways:
+
+1. **Runtime (Matter shell)** — flash the default image and use the `devtype`
+   shell command to store a single device type in KVS. The image will
+   instantiate that device on the next boot.
+2. **Build time (no shell required)** — bake a fixed, ordered list of device
+   types into the image via GN args. This is the recommended flow for
+   product-like builds and enables running multiple device types on
+   consecutive endpoints without any Matter-shell interaction.
+
+The build-time selection is driven by two GN args declared in
+[all-devices-common/device-factory/enabled_devices.gni](../all-devices-common/device-factory/enabled_devices.gni):
+
+-   `all_devices_enabled_devices` — subset of device types compiled into the
+    `DeviceFactory`. Empty (default) compiles all of them in.
+-   `all_devices_default_devices` — ordered list of device types instantiated
+    at boot, one per endpoint starting at endpoint 1. Empty (default) means
+    "fall back to the runtime KVS override / factory default single device".
+
+Every entry in `all_devices_default_devices` must also be present in
+`all_devices_enabled_devices` (unless the enabled list is empty). GN
+enforces this at `gen` time.
+
+## Build command (humidity + temperature sensor on BRD4187C)
+
+```bash
+./scripts/examples/gn_silabs_example.sh \
+    examples/all-devices-app/silabs \
+    out/all-devices-app \
+    BRD4187C \
+    'all_devices_enabled_devices=["humidity-sensor","temperature-sensor"]' \
+    'all_devices_default_devices=["humidity-sensor","temperature-sensor"]' \
+    'all_devices_app_name="humidity-and-temp-sensor"' \
+    'chip_build_libshell=false'
+```
+
+Result:
+
+-   Output image: `out/all-devices-app/thread/BRD4187C/humidity-and-temp-sensor.out`
+-   Endpoint layout on boot:
+
+    ```text
+    Endpoint 0 → Root Node
+    Endpoint 1 → humidity-sensor
+    Endpoint 2 → temperature-sensor
+    ```
+
+No Matter shell interaction is needed to select the device types — the
+mapping is fixed at build time. Dropping `chip_build_libshell=false` keeps
+the `devtype` shell command available but has no effect on the pre-baked
+topology (the build-time list takes precedence over any KVS override).
+
+## Building a single device type
+
+Same recipe with a single-element list, e.g. a temperature sensor only:
+
+```bash
+./scripts/examples/gn_silabs_example.sh \
+    examples/all-devices-app/silabs \
+    out/all-devices-app \
+    BRD4187C \
+    'all_devices_enabled_devices=["temperature-sensor"]' \
+    'all_devices_default_devices=["temperature-sensor"]' \
+    'all_devices_app_name="temperature-sensor-app"' \
+    'chip_build_libshell=false'
+```
+
+## Default image (runtime device selection)
+
+Omitting both args produces the full `matter-silabs-all-devices-example.out`
+image with every device type registered in the factory and runtime
+selection via the shell:
+
+```bash
+./scripts/examples/gn_silabs_example.sh \
+    examples/all-devices-app/silabs \
+    out/all-devices-app \
+    BRD4187C
+```
+
+Then, from the device shell:
+
+```text
+matterCli> devtype list
+matterCli> devtype set humidity-sensor
+matterCli> reboot
+```

--- a/examples/all-devices-app/silabs/README.md
+++ b/examples/all-devices-app/silabs/README.md
@@ -5,29 +5,29 @@ top-level [all-devices-app README](../README.md) for a description of the
 Code-Driven paradigm, supported device types, CLI concepts, and the overall
 documentation suite under [`../docs/`](../docs/).
 
-Unlike the Linux/POSIX variant, the Silabs image cannot select device types
-from `argv` at boot. Instead the topology is chosen in one of two ways:
+Unlike the Linux/POSIX variant, the Silabs image cannot select device types from
+`argv` at boot. Instead the topology is chosen in one of two ways:
 
 1. **Runtime (Matter shell)** — flash the default image and use the `devtype`
    shell command to store a single device type in KVS. The image will
    instantiate that device on the next boot.
 2. **Build time (no shell required)** — bake a fixed, ordered list of device
    types into the image via GN args. This is the recommended flow for
-   product-like builds and enables running multiple device types on
-   consecutive endpoints without any Matter-shell interaction.
+   product-like builds and enables running multiple device types on consecutive
+   endpoints without any Matter-shell interaction.
 
 The build-time selection is driven by two GN args declared in
 [all-devices-common/device-factory/enabled_devices.gni](../all-devices-common/device-factory/enabled_devices.gni):
 
 -   `all_devices_enabled_devices` — subset of device types compiled into the
     `DeviceFactory`. Empty (default) compiles all of them in.
--   `all_devices_default_devices` — ordered list of device types instantiated
-    at boot, one per endpoint starting at endpoint 1. Empty (default) means
-    "fall back to the runtime KVS override / factory default single device".
+-   `all_devices_default_devices` — ordered list of device types instantiated at
+    boot, one per endpoint starting at endpoint 1. Empty (default) means "fall
+    back to the runtime KVS override / factory default single device".
 
 Every entry in `all_devices_default_devices` must also be present in
-`all_devices_enabled_devices` (unless the enabled list is empty). GN
-enforces this at `gen` time.
+`all_devices_enabled_devices` (unless the enabled list is empty). GN enforces
+this at `gen` time.
 
 ## Build command (humidity + temperature sensor on BRD4187C)
 
@@ -44,7 +44,8 @@ enforces this at `gen` time.
 
 Result:
 
--   Output image: `out/all-devices-app/thread/BRD4187C/humidity-and-temp-sensor.out`
+-   Output image:
+    `out/all-devices-app/thread/BRD4187C/humidity-and-temp-sensor.out`
 -   Endpoint layout on boot:
 
     ```text
@@ -53,10 +54,10 @@ Result:
     Endpoint 2 → temperature-sensor
     ```
 
-No Matter shell interaction is needed to select the device types — the
-mapping is fixed at build time. Dropping `chip_build_libshell=false` keeps
-the `devtype` shell command available but has no effect on the pre-baked
-topology (the build-time list takes precedence over any KVS override).
+No Matter shell interaction is needed to select the device types — the mapping
+is fixed at build time. Dropping `chip_build_libshell=false` keeps the `devtype`
+shell command available but has no effect on the pre-baked topology (the
+build-time list takes precedence over any KVS override).
 
 ## Building a single device type
 
@@ -76,8 +77,8 @@ Same recipe with a single-element list, e.g. a temperature sensor only:
 ## Default image (runtime device selection)
 
 Omitting both args produces the full `matter-silabs-all-devices-example.out`
-image with every device type registered in the factory and runtime
-selection via the shell:
+image with every device type registered in the factory and runtime selection via
+the shell:
 
 ```bash
 ./scripts/examples/gn_silabs_example.sh \

--- a/examples/all-devices-app/silabs/args.gni
+++ b/examples/all-devices-app/silabs/args.gni
@@ -13,6 +13,8 @@
 # limitations under the License.
 import("//build_overrides/chip.gni")
 import("${chip_root}/config/standalone/args.gni")
+import(
+    "${chip_root}/examples/all-devices-app/all-devices-common/device-factory/enabled_devices.gni")
 import("${chip_root}/src/platform/silabs/efr32/args.gni")
 
 silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")

--- a/examples/all-devices-app/silabs/src/AppTask.cpp
+++ b/examples/all-devices-app/silabs/src/AppTask.cpp
@@ -170,6 +170,8 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
         .dacProvider                = *chip::Credentials::GetDeviceAttestationCredentialsProvider(),
         .eventManagement            = chip::app::EventManagement::GetInstance(),
         .timerDelegate              = sTimerDelegate,
+        .minGuaranteedSubscriptionsPerFabric =
+            chip::app::InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
     };
 
 #if CHIP_ENABLE_OPENTHREAD
@@ -211,7 +213,7 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
     auto instantiateDevice = [&](const std::string & type) -> CHIP_ERROR {
         if (!deviceFactory.IsValidDevice(type))
         {
-            ChipLogError(AppServer, "Invalid device type: %s, skipping", type.c_str());
+            ChipLogError(AppServer, "Invalid device type: %s", type.c_str());
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
         auto device = deviceFactory.Create(type);
@@ -230,6 +232,7 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
 
     if (!kBuildTimeDevices.empty())
     {
+        sConstructedDevices.reserve(ALL_DEVICES_DEFAULT_DEVICES_COUNT);
         std::string_view remaining = kBuildTimeDevices;
         while (!remaining.empty())
         {

--- a/examples/all-devices-app/silabs/src/AppTask.cpp
+++ b/examples/all-devices-app/silabs/src/AppTask.cpp
@@ -29,6 +29,8 @@
 #include <cstring>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/persistence/DefaultAttributePersistenceProvider.h>
@@ -38,9 +40,9 @@
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
 #include <platform/CHIPDeviceLayer.h>
-#include <platform/DiagnosticDataProvider.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 
+#include <app_config/enabled_devices.h>
 #include <device-factory/DeviceFactory.h>
 #include <device/api/allocator/ConsecutiveEndpointIdAllocator.h>
 #include <device/types/root-node/RootNode.h>
@@ -69,7 +71,7 @@ chip::app::DefaultAttributePersistenceProvider sAttributePersistenceProvider;
 chip::app::DefaultSafeAttributePersistenceProvider sSafeAttributePersistenceProvider;
 std::unique_ptr<chip::app::CodeDrivenDataModelProvider> sDataModelProvider;
 std::unique_ptr<chip::app::DeviceInterface> sRootNode;
-std::unique_ptr<chip::app::DeviceInterface> sConstructedDevice;
+std::vector<std::unique_ptr<chip::app::DeviceInterface>> sConstructedDevices;
 
 #if CHIP_ENABLE_OPENTHREAD
 chip::DeviceLayer::NetworkCommissioning::GenericThreadDriver sThreadDriver;
@@ -168,8 +170,6 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
         .dacProvider                = *chip::Credentials::GetDeviceAttestationCredentialsProvider(),
         .eventManagement            = chip::app::EventManagement::GetInstance(),
         .timerDelegate              = sTimerDelegate,
-        .minGuaranteedSubscriptionsPerFabric =
-            chip::app::InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
     };
 
 #if CHIP_ENABLE_OPENTHREAD
@@ -204,7 +204,51 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
         .bindingManager         = chip::app::Clusters::Binding::Manager::GetInstance(),
     });
 
-    std::string deviceType = chip::app::DeviceFactory::GetInstance().GetDefaultDevice();
+    auto & deviceFactory = chip::app::DeviceFactory::GetInstance();
+
+    ConsecutiveEndpointIdAllocator allocator(kDeviceEndpointId);
+
+    auto instantiateDevice = [&](const std::string & type) -> CHIP_ERROR {
+        if (!deviceFactory.IsValidDevice(type))
+        {
+            ChipLogError(AppServer, "Invalid device type: %s, skipping", type.c_str());
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        auto device = deviceFactory.Create(type);
+        VerifyOrReturnError(device != nullptr, CHIP_ERROR_NO_MEMORY);
+        ReturnErrorOnFailure(device->Register(allocator, *sDataModelProvider));
+        ChipLogProgress(AppServer, "Registered device type '%s'", type.c_str());
+        sConstructedDevices.push_back(std::move(device));
+        return CHIP_NO_ERROR;
+    };
+
+    // Build-time device list (see all_devices_default_devices in enabled_devices.gni).
+    // When the list is non-empty, it fully drives the device topology and the
+    // KVS override / factory default is ignored — matching the "no shell needed"
+    // build configuration.
+    constexpr std::string_view kBuildTimeDevices{ ALL_DEVICES_DEFAULT_DEVICES };
+
+    if (!kBuildTimeDevices.empty())
+    {
+        std::string_view remaining = kBuildTimeDevices;
+        while (!remaining.empty())
+        {
+            auto comma      = remaining.find(',');
+            auto tokenView  = remaining.substr(0, comma);
+            std::string tok(tokenView);
+            ReturnErrorOnFailure(instantiateDevice(tok));
+            if (comma == std::string_view::npos)
+            {
+                break;
+            }
+            remaining.remove_prefix(comma + 1);
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    // No build-time selection: fall back to the KVS-stored device type (set via
+    // the `devtype` shell command) or the factory default.
+    std::string deviceType = deviceFactory.GetDefaultDevice();
 
     char storedDeviceType[64] = {};
     uint16_t storedLen        = sizeof(storedDeviceType);
@@ -214,20 +258,13 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
         deviceType = std::string(storedDeviceType, strnlen(storedDeviceType, storedLen));
     }
 
-    auto & deviceFactory = chip::app::DeviceFactory::GetInstance();
     if (!deviceFactory.IsValidDevice(deviceType))
     {
         ChipLogError(AppServer, "Invalid device type: %s, falling back to default", deviceType.c_str());
         deviceType = deviceFactory.GetDefaultDevice();
     }
 
-    sConstructedDevice = deviceFactory.Create(deviceType);
-    VerifyOrReturnError(sConstructedDevice != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    ConsecutiveEndpointIdAllocator allocator(kDeviceEndpointId);
-    ReturnErrorOnFailure(sConstructedDevice->Register(allocator, *sDataModelProvider));
-
-    return CHIP_NO_ERROR;
+    return instantiateDevice(deviceType);
 }
 
 chip::app::CodeDrivenDataModelProvider * AppTask::GetDataModelProvider()

--- a/examples/all-devices-app/silabs/src/AppTask.cpp
+++ b/examples/all-devices-app/silabs/src/AppTask.cpp
@@ -233,8 +233,8 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
         std::string_view remaining = kBuildTimeDevices;
         while (!remaining.empty())
         {
-            auto comma      = remaining.find(',');
-            auto tokenView  = remaining.substr(0, comma);
+            auto comma     = remaining.find(',');
+            auto tokenView = remaining.substr(0, comma);
             std::string tok(tokenView);
             ReturnErrorOnFailure(instantiateDevice(tok));
             if (comma == std::string_view::npos)


### PR DESCRIPTION
### Summary

To close the gap between a sample apps and a real product this PR enables building the all-devices-app with a pre-defined instantiation of device-type. Once flashed the application will behave like the device-type selected at build type without the need to manually input it through CLI.

### Related issues

None
### Testing

Tested with Home-Assistant and a temperature&Humidity sensor combo app based on Silicon Labs hardware.
