### PR TITLE
[all-device-app] Add identify delegate to all-device-app

### DIFF
--- a/examples/all-devices-app/all-devices-common/device-factory/DeviceFactory.h
+++ b/examples/all-devices-app/all-devices-common/device-factory/DeviceFactory.h
@@ -232,7 +232,7 @@ private:
             RegisterCreator("ambient-context-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
                 return std::make_unique<Clusters::AmbientContextSensing::LoggingAmbientContextSensor>(mContext->timerDelegate,
-                                                                                                     mContext->platformIdentify);
+                                                                                                      mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_BRIDGED_NODE)
@@ -532,9 +532,9 @@ private:
         {
             RegisterCreator("rain-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<BooleanStateSensor>(
-                    mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRainSensor, 1),
-                    mContext->platformIdentify);
+                return std::make_unique<BooleanStateSensor>(mContext->timerDelegate,
+                                                            Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRainSensor, 1),
+                                                            mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_WATER_FREEZE_DETECTOR)

--- a/examples/all-devices-app/all-devices-common/device-factory/DeviceFactory.h
+++ b/examples/all-devices-app/all-devices-common/device-factory/DeviceFactory.h
@@ -21,6 +21,7 @@
 #include <app/clusters/bindings/BindingManager.h>
 #include <app/clusters/bindings/binding-table.h>
 #include <app_config/enabled_devices.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/aggregator/Aggregator.h>
 #include <device/types/air-purifier/impl/LoggingAirPurifier.h>
 #include <device/types/air-quality-sensor/AirQualitySensor.h>
@@ -102,6 +103,7 @@ public:
         Clusters::Binding::Table & bindingTable;
         Clusters::Binding::Manager & bindingManager;
         TestEventTriggerDelegate & testEventTriggerDelegate;
+        PlatformIdentifyIntegration & platformIdentify;
     };
 
     static DeviceFactory & GetInstance()
@@ -187,7 +189,7 @@ private:
         {
             RegisterCreator("aggregator", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<Aggregator>(mContext->timerDelegate);
+                return std::make_unique<Aggregator>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_AIR_PURIFIER)
@@ -198,6 +200,7 @@ private:
                     .groupDataProvider = mContext->groupDataProvider,
                     .fabricTable       = mContext->fabricTable,
                     .timerDelegate     = mContext->timerDelegate,
+                    .platformIdentify  = mContext->platformIdentify,
                 });
             });
         }
@@ -220,14 +223,16 @@ private:
                                 .medium    = MeasurementMediumEnum::kAir,
                                 .unit      = MeasurementUnitEnum::kPpm,
                             },
-                    });
+                    },
+                    mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_AMBIENT_CONTEXT_SENSOR)
         {
             RegisterCreator("ambient-context-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<Clusters::AmbientContextSensing::LoggingAmbientContextSensor>(mContext->timerDelegate);
+                return std::make_unique<Clusters::AmbientContextSensing::LoggingAmbientContextSensor>(mContext->timerDelegate,
+                                                                                                     mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_BRIDGED_NODE)
@@ -246,7 +251,8 @@ private:
             RegisterCreator("contact-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
                 return std::make_unique<BooleanStateSensor>(
-                    mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kContactSensor, 1));
+                    mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kContactSensor, 1),
+                    mContext->platformIdentify);
             });
             RegisterAccessorCreator("contact-sensor", [](DeviceInterface & device) {
                 return std::make_unique<BooleanStateSensorAccessor>(static_cast<BooleanStateSensor &>(device));
@@ -257,7 +263,8 @@ private:
             RegisterCreator("water-leak-detector", [this]() {
                 VerifyOrDie(mContext.has_value());
                 return std::make_unique<BooleanStateSensor>(
-                    mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kWaterLeakDetector, 1));
+                    mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kWaterLeakDetector, 1),
+                    mContext->platformIdentify);
             });
             RegisterAccessorCreator("water-leak-detector", [](DeviceInterface & device) {
                 return std::make_unique<BooleanStateSensorAccessor>(static_cast<BooleanStateSensor &>(device));
@@ -267,7 +274,7 @@ private:
         {
             RegisterCreator("occupancy-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<LoggingOccupancySensor>(mContext->timerDelegate);
+                return std::make_unique<LoggingOccupancySensor>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_CHIME)
@@ -278,21 +285,22 @@ private:
                     { 0, "Ding Dong"_span },
                     { 1, "Ring Ring"_span },
                 };
-                return std::make_unique<Chime>(mContext->timerDelegate, Span<const Chime::Sound>(kDefaultSounds));
+                return std::make_unique<Chime>(mContext->timerDelegate, mContext->platformIdentify,
+                                               Span<const Chime::Sound>(kDefaultSounds));
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_COOKTOP)
         {
             RegisterCreator("cooktop", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<LoggingCooktop>(mContext->timerDelegate);
+                return std::make_unique<LoggingCooktop>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_DEVICE_ENERGY_MANAGEMENT)
         {
             RegisterCreator("device-energy-management", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<EnergyManagement>(mContext->timerDelegate);
+                return std::make_unique<EnergyManagement>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_DIMMABLE_LIGHT)
@@ -304,6 +312,7 @@ private:
                         .groupDataProvider = mContext->groupDataProvider,
                         .fabricTable       = mContext->fabricTable,
                         .timerDelegate     = mContext->timerDelegate,
+                        .platformIdentify  = mContext->platformIdentify,
                     },
                     DimmableLoad::Config{ .levelControl = DimmableLoad::LevelControlConfig::CiPicsDefaults() });
             });
@@ -317,6 +326,7 @@ private:
                         .groupDataProvider = mContext->groupDataProvider,
                         .fabricTable       = mContext->fabricTable,
                         .timerDelegate     = mContext->timerDelegate,
+                        .platformIdentify  = mContext->platformIdentify,
                     },
                     DimmableLoad::Config{ .levelControl = DimmableLoad::LevelControlConfig::CiPicsDefaults() });
             });
@@ -340,6 +350,7 @@ private:
                         .groupDataProvider = mContext->groupDataProvider,
                         .fabricTable       = mContext->fabricTable,
                         .timerDelegate     = mContext->timerDelegate,
+                        .platformIdentify  = mContext->platformIdentify,
                     },
                     DimmableLoad::Config{ .levelControl = DimmableLoad::LevelControlConfig::CiPicsDefaults() });
             });
@@ -352,6 +363,7 @@ private:
                     .groupDataProvider = mContext->groupDataProvider,
                     .fabricTable       = mContext->fabricTable,
                     .timerDelegate     = mContext->timerDelegate,
+                    .platformIdentify  = mContext->platformIdentify,
                 });
             });
         }
@@ -371,6 +383,7 @@ private:
                     .groupDataProvider = mContext->groupDataProvider,
                     .fabricTable       = mContext->fabricTable,
                     .timerDelegate     = mContext->timerDelegate,
+                    .platformIdentify  = mContext->platformIdentify,
                 });
             });
         }
@@ -379,7 +392,8 @@ private:
             RegisterCreator("on-off-light-switch", [this]() {
                 VerifyOrDie(mContext.has_value());
                 return std::make_unique<OnOffLightSwitch>(mContext->timerDelegate, mContext->platformManager,
-                                                          mContext->bindingTable, mContext->bindingManager);
+                                                          mContext->bindingTable, mContext->bindingManager,
+                                                          mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_ON_OFF_PLUG_IN_UNIT)
@@ -390,6 +404,7 @@ private:
                     .groupDataProvider = mContext->groupDataProvider,
                     .fabricTable       = mContext->fabricTable,
                     .timerDelegate     = mContext->timerDelegate,
+                    .platformIdentify  = mContext->platformIdentify,
                 });
             });
         }
@@ -404,23 +419,29 @@ private:
         {
             RegisterCreator("oven", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<LoggingOven>(mContext->timerDelegate);
+                return std::make_unique<LoggingOven>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_REFRIGERATOR)
         {
             RegisterCreator("refrigerator", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<LoggingRefrigerator>(mContext->timerDelegate);
+                return std::make_unique<LoggingRefrigerator>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_SOIL_SENSOR)
         {
-            RegisterCreator("soil-sensor", []() { return std::make_unique<IncreasingMoistureSoilSensor>(); });
+            RegisterCreator("soil-sensor", [this]() {
+                VerifyOrDie(mContext.has_value());
+                return std::make_unique<IncreasingMoistureSoilSensor>(mContext->platformIdentify);
+            });
         }
         if constexpr (ALL_DEVICES_ENABLE_TEMPERATURE_SENSOR)
         {
-            RegisterCreator("temperature-sensor", []() { return std::make_unique<IncreasingTemperatureSensor>(); });
+            RegisterCreator("temperature-sensor", [this]() {
+                VerifyOrDie(mContext.has_value());
+                return std::make_unique<IncreasingTemperatureSensor>(mContext->platformIdentify);
+            });
         }
         if constexpr (ALL_DEVICES_ENABLE_ELECTRICAL_SENSOR)
         {
@@ -437,6 +458,7 @@ private:
                     .groupDataProvider   = mContext->groupDataProvider,
                     .fabricTable         = mContext->fabricTable,
                     .timerDelegate       = mContext->timerDelegate,
+                    .platformIdentify    = mContext->platformIdentify,
                     .includeOnOffCluster = true,
                 });
             });
@@ -455,6 +477,7 @@ private:
                     .groupDataProvider   = mContext->groupDataProvider,
                     .fabricTable         = mContext->fabricTable,
                     .timerDelegate       = mContext->timerDelegate,
+                    .platformIdentify    = mContext->platformIdentify,
                     .includeOnOffCluster = true,
                     .tagList             = Span(&kFanTag, 1),
                 });
@@ -471,6 +494,7 @@ private:
                     .groupDataProvider   = mContext->groupDataProvider,
                     .fabricTable         = mContext->fabricTable,
                     .timerDelegate       = mContext->timerDelegate,
+                    .platformIdentify    = mContext->platformIdentify,
                     .includeOnOffCluster = false,
                     .tagList             = Span(&kFanNoOnOffTag, 1),
                 });
@@ -480,7 +504,7 @@ private:
         {
             RegisterCreator("generic-switch", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<GenericSwitch>(mContext->timerDelegate);
+                return std::make_unique<GenericSwitch>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
 
@@ -488,7 +512,8 @@ private:
         {
             RegisterCreator("proximity-ranger", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<LoggingProximityRanger>(mContext->timerDelegate, mContext->storageDelegate);
+                return std::make_unique<LoggingProximityRanger>(mContext->timerDelegate, mContext->storageDelegate,
+                                                                mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_POWER_SOURCE)
@@ -499,7 +524,7 @@ private:
         {
             RegisterCreator("smoke-co-alarm", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<LoggingOnlySmokeCoAlarm>(mContext->timerDelegate);
+                return std::make_unique<LoggingOnlySmokeCoAlarm>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
 
@@ -507,8 +532,9 @@ private:
         {
             RegisterCreator("rain-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<BooleanStateSensor>(mContext->timerDelegate,
-                                                            Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRainSensor, 1));
+                return std::make_unique<BooleanStateSensor>(
+                    mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRainSensor, 1),
+                    mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_WATER_FREEZE_DETECTOR)
@@ -516,21 +542,22 @@ private:
             RegisterCreator("water-freeze-detector", [this]() {
                 VerifyOrDie(mContext.has_value());
                 return std::make_unique<BooleanStateSensor>(
-                    mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kWaterFreezeDetector, 1));
+                    mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kWaterFreezeDetector, 1),
+                    mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_WATER_VALVE)
         {
             RegisterCreator("water-valve", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<WaterValve>(mContext->timerDelegate);
+                return std::make_unique<WaterValve>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_HUMIDITY_SENSOR)
         {
             RegisterCreator("humidity-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<IncreasingHumiditySensor>(mContext->timerDelegate);
+                return std::make_unique<IncreasingHumiditySensor>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_LAUNDRY_DRYER)
@@ -554,7 +581,7 @@ private:
         {
             RegisterCreator("light-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<IncreasingLightSensor>(mContext->timerDelegate);
+                return std::make_unique<IncreasingLightSensor>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_MICROWAVE_OVEN)
@@ -571,14 +598,14 @@ private:
         {
             RegisterCreator("pressure-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<IncreasingPressureSensor>(mContext->timerDelegate);
+                return std::make_unique<IncreasingPressureSensor>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_FLOW_SENSOR)
         {
             RegisterCreator("flow-sensor", [this]() {
                 VerifyOrDie(mContext.has_value());
-                return std::make_unique<IncreasingFlowSensor>(mContext->timerDelegate);
+                return std::make_unique<IncreasingFlowSensor>(mContext->timerDelegate, mContext->platformIdentify);
             });
         }
         if constexpr (ALL_DEVICES_ENABLE_ROBOTIC_VACUUM_CLEANER)

--- a/examples/all-devices-app/all-devices-common/device/api/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/api/BUILD.gn
@@ -49,3 +49,21 @@ source_set("single-endpoint-device") {
     "${chip_root}/src/lib/support",
   ]
 }
+
+source_set("platform-identify-integration") {
+  sources = [
+    "PlatformIdentifyIntegration.cpp",
+    "PlatformIdentifyIntegration.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app/clusters/identify-server",
+    "${chip_root}/src/lib/core:error",
+    "${chip_root}/src/lib/support",
+  ]
+
+  public_configs = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device:includes",
+    "${chip_root}/src:includes",
+  ]
+}

--- a/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
+++ b/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
@@ -19,13 +19,8 @@
 namespace chip {
 namespace app {
 
-PlatformIdentifyIntegration & PlatformIdentifyIntegration::GetInstance()
-{
-    static PlatformIdentifyIntegration sInstance;
-    return sInstance;
-}
-
-Clusters::IdentifyCluster::Config PlatformIdentifyIntegration::MakeConfig(EndpointId endpoint, TimerDelegate & timerDelegate) const
+Clusters::IdentifyCluster::Config PlatformIdentifyIntegration::MakeConfig(EndpointId endpoint,
+                                                                         TimerDelegate & timerDelegate) const
 {
     Clusters::IdentifyCluster::Config config(endpoint, timerDelegate);
     config.WithIdentifyType(mIdentifyType);

--- a/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
+++ b/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
@@ -25,8 +25,7 @@ PlatformIdentifyIntegration & PlatformIdentifyIntegration::GetInstance()
     return sInstance;
 }
 
-Clusters::IdentifyCluster::Config PlatformIdentifyIntegration::MakeConfig(EndpointId endpoint,
-                                                                         TimerDelegate & timerDelegate) const
+Clusters::IdentifyCluster::Config PlatformIdentifyIntegration::MakeConfig(EndpointId endpoint, TimerDelegate & timerDelegate) const
 {
     Clusters::IdentifyCluster::Config config(endpoint, timerDelegate);
     config.WithIdentifyType(mIdentifyType);

--- a/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
+++ b/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <device/api/PlatformIdentifyIntegration.h>
+
+namespace chip {
+namespace app {
+
+PlatformIdentifyIntegration & PlatformIdentifyIntegration::GetInstance()
+{
+    static PlatformIdentifyIntegration sInstance;
+    return sInstance;
+}
+
+Clusters::IdentifyCluster::Config PlatformIdentifyIntegration::MakeConfig(EndpointId endpoint,
+                                                                         TimerDelegate & timerDelegate) const
+{
+    Clusters::IdentifyCluster::Config config(endpoint, timerDelegate);
+    config.WithIdentifyType(mIdentifyType);
+    if (mPlatformDelegate != nullptr)
+    {
+        config.WithDelegate(mPlatformDelegate);
+    }
+    return config;
+}
+
+void PlatformIdentifyIntegration::NotifyIdentifyStart(Clusters::IdentifyCluster & cluster)
+{
+    if (mPlatformDelegate != nullptr)
+    {
+        mPlatformDelegate->OnIdentifyStart(cluster);
+    }
+}
+
+void PlatformIdentifyIntegration::NotifyIdentifyStop(Clusters::IdentifyCluster & cluster)
+{
+    if (mPlatformDelegate != nullptr)
+    {
+        mPlatformDelegate->OnIdentifyStop(cluster);
+    }
+}
+
+void PlatformIdentifyIntegration::NotifyTriggerEffect(Clusters::IdentifyCluster & cluster)
+{
+    if (mPlatformDelegate != nullptr)
+    {
+        mPlatformDelegate->OnTriggerEffect(cluster);
+    }
+}
+
+} // namespace app
+} // namespace chip

--- a/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
+++ b/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
@@ -31,7 +31,7 @@ Clusters::IdentifyCluster::Config PlatformIdentifyIntegration::MakeConfig(Endpoi
     return config;
 }
 
-void PlatformIdentifyIntegration::NotifyIdentifyStart(Clusters::IdentifyCluster & cluster)
+void PlatformIdentifyIntegration::NotifyIdentifyStart(Clusters::IdentifyCluster & cluster) const
 {
     if (mPlatformDelegate != nullptr)
     {
@@ -39,7 +39,7 @@ void PlatformIdentifyIntegration::NotifyIdentifyStart(Clusters::IdentifyCluster 
     }
 }
 
-void PlatformIdentifyIntegration::NotifyIdentifyStop(Clusters::IdentifyCluster & cluster)
+void PlatformIdentifyIntegration::NotifyIdentifyStop(Clusters::IdentifyCluster & cluster) const
 {
     if (mPlatformDelegate != nullptr)
     {
@@ -47,9 +47,9 @@ void PlatformIdentifyIntegration::NotifyIdentifyStop(Clusters::IdentifyCluster &
     }
 }
 
-void PlatformIdentifyIntegration::NotifyTriggerEffect(Clusters::IdentifyCluster & cluster)
+void PlatformIdentifyIntegration::NotifyTriggerEffect(Clusters::IdentifyCluster & cluster) const
 {
-    if (mPlatformDelegate != nullptr)
+    if (mPlatformDelegate != nullptr && mPlatformDelegate->IsTriggerEffectEnabled())
     {
         mPlatformDelegate->OnTriggerEffect(cluster);
     }

--- a/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
+++ b/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.cpp
@@ -19,8 +19,7 @@
 namespace chip {
 namespace app {
 
-Clusters::IdentifyCluster::Config PlatformIdentifyIntegration::MakeConfig(EndpointId endpoint,
-                                                                         TimerDelegate & timerDelegate) const
+Clusters::IdentifyCluster::Config PlatformIdentifyIntegration::MakeConfig(EndpointId endpoint, TimerDelegate & timerDelegate) const
 {
     Clusters::IdentifyCluster::Config config(endpoint, timerDelegate);
     config.WithIdentifyType(mIdentifyType);

--- a/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.h
+++ b/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.h
@@ -28,20 +28,27 @@ namespace app {
  * Platform-provided defaults for code-driven `IdentifyCluster` instances
  * created by devices in the `all-devices-app` reference application.
  *
- * Platforms (e.g. `silabs/`, `esp32/`) may install a global identify
+ * An instance of this class is owned by the application entry point
+ * (typically the platform's `main` or `AppTask`) and is passed explicitly
+ * into the device factory / device constructors that require it. There
+ * is no global singleton: the owner constructs and configures the
+ * instance and then registers it with `DeviceFactory::Context` so that
+ * every device receives the same platform integration.
+ *
+ * Platforms (e.g. `silabs/`, `esp32/`) may install a platform identify
  * delegate at boot (typically driving a status LED) and advertise the
  * appropriate `Identify::IdentifyTypeEnum` (e.g. `kVisibleIndicator`).
  * Device types pick these up when they Create() their `IdentifyCluster`
  * via `MakeConfig(...)`, without every device constructor having to
- * accept a delegate.
+ * accept a delegate directly.
  *
  * Defaults (nullptr delegate, `kNone` type) preserve prior behavior for
  * platforms that do not install anything.
  *
- * Usage inside a device `Register()`:
+ * Usage inside a device `Register()` (with a reference stored as
+ * `mPlatformIdentify` on the device):
  * @code
- *   mIdentifyCluster.Create(
- *       PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+ *   mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
  * @endcode
  *
  * Devices that own their own `IdentifyDelegate` (e.g. `LoggingOnOffLoad`)
@@ -53,7 +60,7 @@ namespace app {
 class PlatformIdentifyIntegration
 {
 public:
-    static PlatformIdentifyIntegration & GetInstance();
+    PlatformIdentifyIntegration() = default;
 
     void SetDelegate(Clusters::IdentifyDelegate * delegate) { mPlatformDelegate = delegate; }
     Clusters::IdentifyDelegate * GetDelegate() const { return mPlatformDelegate; }
@@ -77,8 +84,6 @@ public:
     void NotifyTriggerEffect(Clusters::IdentifyCluster & cluster);
 
 private:
-    PlatformIdentifyIntegration() = default;
-
     Clusters::IdentifyDelegate * mPlatformDelegate     = nullptr;
     Clusters::Identify::IdentifyTypeEnum mIdentifyType = Clusters::Identify::IdentifyTypeEnum::kNone;
 };

--- a/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.h
+++ b/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.h
@@ -1,0 +1,87 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/clusters/identify-server/IdentifyCluster.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/TimerDelegate.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * Platform-provided defaults for code-driven `IdentifyCluster` instances
+ * created by devices in the `all-devices-app` reference application.
+ *
+ * Platforms (e.g. `silabs/`, `esp32/`) may install a global identify
+ * delegate at boot (typically driving a status LED) and advertise the
+ * appropriate `Identify::IdentifyTypeEnum` (e.g. `kVisibleIndicator`).
+ * Device types pick these up when they Create() their `IdentifyCluster`
+ * via `MakeConfig(...)`, without every device constructor having to
+ * accept a delegate.
+ *
+ * Defaults (nullptr delegate, `kNone` type) preserve prior behavior for
+ * platforms that do not install anything.
+ *
+ * Usage inside a device `Register()`:
+ * @code
+ *   mIdentifyCluster.Create(
+ *       PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+ * @endcode
+ *
+ * Devices that own their own `IdentifyDelegate` (e.g. `LoggingOnOffLoad`)
+ * keep it wired via `IdentifyCluster::Config::WithDelegate(...)` for
+ * cluster-level callbacks and additionally notify the platform via
+ * `NotifyIdentifyStart/Stop/TriggerEffect(...)` so the platform LED
+ * indicator still runs on those endpoints.
+ */
+class PlatformIdentifyIntegration
+{
+public:
+    static PlatformIdentifyIntegration & GetInstance();
+
+    void SetDelegate(Clusters::IdentifyDelegate * delegate) { mPlatformDelegate = delegate; }
+    Clusters::IdentifyDelegate * GetDelegate() const { return mPlatformDelegate; }
+
+    void SetIdentifyType(Clusters::Identify::IdentifyTypeEnum type) { mIdentifyType = type; }
+    Clusters::Identify::IdentifyTypeEnum GetIdentifyType() const { return mIdentifyType; }
+
+    /**
+     * Build an `IdentifyCluster::Config` seeded with the platform's identify
+     * type and delegate. Devices without a per-endpoint delegate should call
+     * this directly. Devices with a per-endpoint delegate should
+     * `.WithDelegate(...)` after this call and additionally use the Notify*
+     * helpers to fan out to the platform.
+     */
+    Clusters::IdentifyCluster::Config MakeConfig(EndpointId endpoint, TimerDelegate & timerDelegate) const;
+
+    /// Forward cluster-level identify events to the installed platform
+    /// delegate. Safe to call when no platform delegate is installed (no-op).
+    void NotifyIdentifyStart(Clusters::IdentifyCluster & cluster);
+    void NotifyIdentifyStop(Clusters::IdentifyCluster & cluster);
+    void NotifyTriggerEffect(Clusters::IdentifyCluster & cluster);
+
+private:
+    PlatformIdentifyIntegration() = default;
+
+    Clusters::IdentifyDelegate * mPlatformDelegate     = nullptr;
+    Clusters::Identify::IdentifyTypeEnum mIdentifyType = Clusters::Identify::IdentifyTypeEnum::kNone;
+};
+
+} // namespace app
+} // namespace chip

--- a/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.h
+++ b/examples/all-devices-app/all-devices-common/device/api/PlatformIdentifyIntegration.h
@@ -16,7 +16,6 @@
  */
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/TimerDelegate.h>
@@ -79,9 +78,9 @@ public:
 
     /// Forward cluster-level identify events to the installed platform
     /// delegate. Safe to call when no platform delegate is installed (no-op).
-    void NotifyIdentifyStart(Clusters::IdentifyCluster & cluster);
-    void NotifyIdentifyStop(Clusters::IdentifyCluster & cluster);
-    void NotifyTriggerEffect(Clusters::IdentifyCluster & cluster);
+    void NotifyIdentifyStart(Clusters::IdentifyCluster & cluster) const;
+    void NotifyIdentifyStop(Clusters::IdentifyCluster & cluster) const;
+    void NotifyTriggerEffect(Clusters::IdentifyCluster & cluster) const;
 
 private:
     Clusters::IdentifyDelegate * mPlatformDelegate     = nullptr;

--- a/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/BUILD.gn
@@ -24,6 +24,7 @@ source_set("dimmable-load") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/groups-server",
     "${chip_root}/src/app/clusters/identify-server",
@@ -45,6 +46,7 @@ source_set("logging") {
 
   public_deps = [
     ":dimmable-load",
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/src/app/clusters/groups-server",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/level-control",

--- a/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.cpp
@@ -40,9 +40,8 @@ CHIP_ERROR DimmableLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModel
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
-                                .MakeConfig(endpoint, mContext.timerDelegate)
-                                .WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(
+        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mScenesTableProvider.SetEndpoint(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.cpp
@@ -39,7 +39,8 @@ CHIP_ERROR DimmableLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModel
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(mContext.platformIdentify.MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(
+        mContext.platformIdentify.MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mScenesTableProvider.SetEndpoint(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/dimmable-load/DimmableLoad.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -39,7 +40,9 @@ CHIP_ERROR DimmableLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModel
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
+                                .MakeConfig(endpoint, mContext.timerDelegate)
+                                .WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mScenesTableProvider.SetEndpoint(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/dimmable-load/DimmableLoad.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -40,8 +39,7 @@ CHIP_ERROR DimmableLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModel
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(
-        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(mContext.platformIdentify.MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mScenesTableProvider.SetEndpoint(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.h
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/DimmableLoad.h
@@ -28,6 +28,7 @@
 #include <app/clusters/scenes-server/SceneTableImpl.h>
 #include <app/clusters/scenes-server/ScenesManagementCluster.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -103,6 +104,7 @@ public:
         Credentials::GroupDataProvider & groupDataProvider;
         FabricTable & fabricTable;
         TimerDelegate & timerDelegate;
+        PlatformIdentifyIntegration & platformIdentify;
     };
 
     struct Delegates
@@ -128,6 +130,8 @@ protected:
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointComposition composition = {}) override;
     void Unregister(CodeDrivenDataModelProvider & provider) override;
+
+    const Context & GetContext() const { return mContext; }
 
 private:
     Clusters::OnOffDelegate & mOnOffDelegate;

--- a/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/impl/LoggingDimmableLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/impl/LoggingDimmableLoad.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/dimmable-load/impl/LoggingDimmableLoad.h>
 #include <devices/Types.h>
 #include <lib/support/StringBuilder.h>
@@ -122,13 +121,13 @@ DataModel::ActionReturnStatus LoggingDimmableLoad::TriggerDyingLight(OnOff::Dyin
 void LoggingDimmableLoad::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "LoggingDimmableLoad: Identify START");
-    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
+    GetContext().platformIdentify.NotifyIdentifyStart(cluster);
 }
 
 void LoggingDimmableLoad::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "LoggingDimmableLoad: Identify STOP");
-    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
+    GetContext().platformIdentify.NotifyIdentifyStop(cluster);
 }
 
 void LoggingDimmableLoad::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
@@ -170,7 +169,7 @@ void LoggingDimmableLoad::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
         break;
     }
     ChipLogProgress(DeviceLayer, "LoggingDimmableLoad: TriggerEffect: %s", msg.c_str());
-    PlatformIdentifyIntegration::GetInstance().NotifyTriggerEffect(cluster);
+    GetContext().platformIdentify.NotifyTriggerEffect(cluster);
 }
 
 bool LoggingDimmableLoad::IsTriggerEffectEnabled() const

--- a/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/impl/LoggingDimmableLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/dimmable-load/impl/LoggingDimmableLoad.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/dimmable-load/impl/LoggingDimmableLoad.h>
 #include <devices/Types.h>
 #include <lib/support/StringBuilder.h>
@@ -121,11 +122,13 @@ DataModel::ActionReturnStatus LoggingDimmableLoad::TriggerDyingLight(OnOff::Dyin
 void LoggingDimmableLoad::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "LoggingDimmableLoad: Identify START");
+    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
 }
 
 void LoggingDimmableLoad::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "LoggingDimmableLoad: Identify STOP");
+    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
 }
 
 void LoggingDimmableLoad::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
@@ -167,6 +170,7 @@ void LoggingDimmableLoad::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
         break;
     }
     ChipLogProgress(DeviceLayer, "LoggingDimmableLoad: TriggerEffect: %s", msg.c_str());
+    PlatformIdentifyIntegration::GetInstance().NotifyTriggerEffect(cluster);
 }
 
 bool LoggingDimmableLoad::IsTriggerEffectEnabled() const

--- a/examples/all-devices-app/all-devices-common/device/capabilities/fan-load/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/fan-load/BUILD.gn
@@ -21,6 +21,7 @@ source_set("fan-load") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/fan-control-server",
     "${chip_root}/src/app/clusters/groups-server",

--- a/examples/all-devices-app/all-devices-common/device/capabilities/fan-load/FanLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/fan-load/FanLoad.cpp
@@ -15,7 +15,6 @@
  */
 
 #include <clusters/FanControl/Enums.h>
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/fan-load/FanLoad.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -43,7 +42,7 @@ CHIP_ERROR FanLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvi
         RegisterDescriptor(endpoint, provider, EndpointComposition(composition.parentId, composition.pattern, mContext.tagList)));
 
     // Identify
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mContext.platformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // ScenesManagement

--- a/examples/all-devices-app/all-devices-common/device/capabilities/fan-load/FanLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/fan-load/FanLoad.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <clusters/FanControl/Enums.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/fan-load/FanLoad.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -42,7 +43,7 @@ CHIP_ERROR FanLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvi
         RegisterDescriptor(endpoint, provider, EndpointComposition(composition.parentId, composition.pattern, mContext.tagList)));
 
     // Identify
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // ScenesManagement

--- a/examples/all-devices-app/all-devices-common/device/capabilities/fan-load/FanLoad.h
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/fan-load/FanLoad.h
@@ -24,6 +24,7 @@
 #include <app/clusters/scenes-server/SceneTableImpl.h>
 #include <app/clusters/scenes-server/ScenesManagementCluster.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -59,6 +60,7 @@ public:
         Credentials::GroupDataProvider & groupDataProvider;
         FabricTable & fabricTable;
         TimerDelegate & timerDelegate;
+        PlatformIdentifyIntegration & platformIdentify;
         bool includeOnOffCluster                                                = true;
         Span<const Clusters::Globals::Structs::SemanticTagStruct::Type> tagList = {};
     };

--- a/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/BUILD.gn
@@ -24,6 +24,7 @@ source_set("on-off-load") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/groups-server",
     "${chip_root}/src/app/clusters/identify-server",
@@ -44,6 +45,7 @@ source_set("logging") {
 
   public_deps = [
     ":on-off-load",
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/on-off-server",
     "${chip_root}/src/lib/support",

--- a/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/on-off-load/OnOffLoad.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -39,8 +38,7 @@ CHIP_ERROR OnOffLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModelPro
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(
-        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(mContext.platformIdentify.MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mScenesTableProvider.SetEndpoint(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/on-off-load/OnOffLoad.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -38,7 +39,9 @@ CHIP_ERROR OnOffLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModelPro
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
+                                .MakeConfig(endpoint, mContext.timerDelegate)
+                                .WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mScenesTableProvider.SetEndpoint(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.cpp
@@ -38,7 +38,8 @@ CHIP_ERROR OnOffLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModelPro
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(mContext.platformIdentify.MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(
+        mContext.platformIdentify.MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mScenesTableProvider.SetEndpoint(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.cpp
@@ -39,9 +39,8 @@ CHIP_ERROR OnOffLoad::Register(chip::EndpointId endpoint, CodeDrivenDataModelPro
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
-                                .MakeConfig(endpoint, mContext.timerDelegate)
-                                .WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(
+        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mContext.timerDelegate).WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mScenesTableProvider.SetEndpoint(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.h
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/OnOffLoad.h
@@ -26,6 +26,7 @@
 #include <app/clusters/scenes-server/SceneTableImpl.h>
 #include <app/clusters/scenes-server/ScenesManagementCluster.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -61,6 +62,7 @@ public:
         Credentials::GroupDataProvider & groupDataProvider;
         FabricTable & fabricTable;
         TimerDelegate & timerDelegate;
+        PlatformIdentifyIntegration & platformIdentify;
     };
 
     OnOffLoad(Span<const DataModel::DeviceTypeEntry> deviceTypes, Clusters::OnOffDelegate & onOffDelegate,
@@ -78,6 +80,8 @@ protected:
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointComposition composition = {}) override;
     void Unregister(CodeDrivenDataModelProvider & provider) override;
+
+    const Context & GetContext() const { return mContext; }
 
 private:
     Clusters::OnOffDelegate & mOnOffDelegate;

--- a/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/impl/LoggingOnOffLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/impl/LoggingOnOffLoad.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/on-off-load/impl/LoggingOnOffLoad.h>
 #include <devices/Types.h>
 #include <lib/support/StringBuilder.h>
@@ -87,11 +88,13 @@ DataModel::ActionReturnStatus LoggingOnOffLoad::TriggerDyingLight(OnOff::DyingLi
 void LoggingOnOffLoad::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "LoggingOnOffLoad: Identify START");
+    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
 }
 
 void LoggingOnOffLoad::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "LoggingOnOffLoad: Identify STOP");
+    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
 }
 
 void LoggingOnOffLoad::OnTriggerEffect(Clusters::IdentifyCluster & cluster)

--- a/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/impl/LoggingOnOffLoad.cpp
+++ b/examples/all-devices-app/all-devices-common/device/capabilities/on-off-load/impl/LoggingOnOffLoad.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/capabilities/on-off-load/impl/LoggingOnOffLoad.h>
 #include <devices/Types.h>
 #include <lib/support/StringBuilder.h>
@@ -88,13 +87,13 @@ DataModel::ActionReturnStatus LoggingOnOffLoad::TriggerDyingLight(OnOff::DyingLi
 void LoggingOnOffLoad::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "LoggingOnOffLoad: Identify START");
-    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
+    GetContext().platformIdentify.NotifyIdentifyStart(cluster);
 }
 
 void LoggingOnOffLoad::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "LoggingOnOffLoad: Identify STOP");
-    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
+    GetContext().platformIdentify.NotifyIdentifyStop(cluster);
 }
 
 void LoggingOnOffLoad::OnTriggerEffect(Clusters::IdentifyCluster & cluster)

--- a/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.cpp
@@ -32,16 +32,18 @@ namespace {
 class AggregatorIdentifyDelegate : public IdentifyDelegate
 {
 public:
+    explicit AggregatorIdentifyDelegate(PlatformIdentifyIntegration & platformIdentify) : mPlatformIdentify(platformIdentify) {}
+
     void OnIdentifyStart(IdentifyCluster & cluster) override
     {
         ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Identify START", cluster.GetPaths()[0].mEndpointId);
-        PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
+        mPlatformIdentify.NotifyIdentifyStart(cluster);
     }
 
     void OnIdentifyStop(IdentifyCluster & cluster) override
     {
         ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Identify STOP", cluster.GetPaths()[0].mEndpointId);
-        PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
+        mPlatformIdentify.NotifyIdentifyStop(cluster);
     }
 
     void OnTriggerEffect(IdentifyCluster & cluster) override
@@ -86,22 +88,20 @@ public:
 
         ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Trigger effect: %s", cluster.GetPaths()[0].mEndpointId,
                         msg.c_str());
-        PlatformIdentifyIntegration::GetInstance().NotifyTriggerEffect(cluster);
+        mPlatformIdentify.NotifyTriggerEffect(cluster);
     }
 
     bool IsTriggerEffectEnabled() const override { return true; }
-};
 
-AggregatorIdentifyDelegate & GetIdentifyDelegate()
-{
-    static AggregatorIdentifyDelegate gIdentifyDelegate;
-    return gIdentifyDelegate;
-}
+private:
+    PlatformIdentifyIntegration & mPlatformIdentify;
+};
 
 } // namespace
 
-Aggregator::Aggregator(TimerDelegate & timerDelegate) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kAggregator, 1)), mTimerDelegate(timerDelegate)
+Aggregator::Aggregator(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kAggregator, 1)), mTimerDelegate(timerDelegate),
+    mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR Aggregator::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -112,8 +112,8 @@ CHIP_ERROR Aggregator::Register(EndpointId endpoint, CodeDrivenDataModelProvider
     composition.pattern = DataModel::EndpointCompositionPattern::kFullFamily;
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(
-        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate).WithDelegate(&GetIdentifyDelegate()));
+    static AggregatorIdentifyDelegate sIdentifyDelegate(mPlatformIdentify);
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate).WithDelegate(&sIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));

--- a/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.cpp
@@ -27,81 +27,65 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-namespace {
-
-class AggregatorIdentifyDelegate : public IdentifyDelegate
+void Aggregator::AggregatorIdentifyDelegate::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
-public:
-    explicit AggregatorIdentifyDelegate(PlatformIdentifyIntegration & platformIdentify) : mPlatformIdentify(platformIdentify) {}
+    ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Identify START", cluster.GetPaths()[0].mEndpointId);
+    mPlatformIdentify.NotifyIdentifyStart(cluster);
+}
 
-    void OnIdentifyStart(IdentifyCluster & cluster) override
+void Aggregator::AggregatorIdentifyDelegate::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
+{
+    ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Identify STOP", cluster.GetPaths()[0].mEndpointId);
+    mPlatformIdentify.NotifyIdentifyStop(cluster);
+}
+
+void Aggregator::AggregatorIdentifyDelegate::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
+{
+    StringBuilder<48> msg;
+
+    switch (cluster.GetEffectIdentifier())
     {
-        ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Identify START", cluster.GetPaths()[0].mEndpointId);
-        mPlatformIdentify.NotifyIdentifyStart(cluster);
+    case Identify::EffectIdentifierEnum::kBlink:
+        msg.Add("BlinkEffect");
+        break;
+    case Identify::EffectIdentifierEnum::kBreathe:
+        msg.Add("BreatheEffect");
+        break;
+    case Identify::EffectIdentifierEnum::kOkay:
+        msg.Add("OkayEffect");
+        break;
+    case Identify::EffectIdentifierEnum::kChannelChange:
+        msg.Add("ChannelChangeEffect");
+        break;
+    case Identify::EffectIdentifierEnum::kFinishEffect:
+        msg.Add("FinishEffect");
+        break;
+    case Identify::EffectIdentifierEnum::kStopEffect:
+        msg.Add("StopEffect");
+        break;
+    default:
+        msg.AddFormat("UnknownEffect(%d)", static_cast<int>(cluster.GetEffectIdentifier()));
+        break;
+    }
+    msg.Add(" / ");
+
+    switch (cluster.GetEffectVariant())
+    {
+    case Identify::EffectVariantEnum::kDefault:
+        msg.Add("DefaultVariant");
+        break;
+    default:
+        msg.AddFormat("UnknownVariant(%d)", static_cast<int>(cluster.GetEffectVariant()));
+        break;
     }
 
-    void OnIdentifyStop(IdentifyCluster & cluster) override
-    {
-        ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Identify STOP", cluster.GetPaths()[0].mEndpointId);
-        mPlatformIdentify.NotifyIdentifyStop(cluster);
-    }
-
-    void OnTriggerEffect(IdentifyCluster & cluster) override
-    {
-        StringBuilder<48> msg;
-
-        switch (cluster.GetEffectIdentifier())
-        {
-        case Identify::EffectIdentifierEnum::kBlink:
-            msg.Add("BlinkEffect");
-            break;
-        case Identify::EffectIdentifierEnum::kBreathe:
-            msg.Add("BreatheEffect");
-            break;
-        case Identify::EffectIdentifierEnum::kOkay:
-            msg.Add("OkayEffect");
-            break;
-        case Identify::EffectIdentifierEnum::kChannelChange:
-            msg.Add("ChannelChangeEffect");
-            break;
-        case Identify::EffectIdentifierEnum::kFinishEffect:
-            msg.Add("FinishEffect");
-            break;
-        case Identify::EffectIdentifierEnum::kStopEffect:
-            msg.Add("StopEffect");
-            break;
-        default:
-            msg.AddFormat("UnknownEffect(%d)", static_cast<int>(cluster.GetEffectIdentifier()));
-            break;
-        }
-        msg.Add(" / ");
-
-        switch (cluster.GetEffectVariant())
-        {
-        case Identify::EffectVariantEnum::kDefault:
-            msg.Add("DefaultVariant");
-            break;
-        default:
-            msg.AddFormat("UnknownVariant(%d)", static_cast<int>(cluster.GetEffectVariant()));
-            break;
-        }
-
-        ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Trigger effect: %s", cluster.GetPaths()[0].mEndpointId,
-                        msg.c_str());
-        mPlatformIdentify.NotifyTriggerEffect(cluster);
-    }
-
-    bool IsTriggerEffectEnabled() const override { return true; }
-
-private:
-    PlatformIdentifyIntegration & mPlatformIdentify;
-};
-
-} // namespace
+    ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Trigger effect: %s", cluster.GetPaths()[0].mEndpointId, msg.c_str());
+    mPlatformIdentify.NotifyTriggerEffect(cluster);
+}
 
 Aggregator::Aggregator(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kAggregator, 1)), mTimerDelegate(timerDelegate),
-    mPlatformIdentify(platformIdentify)
+    mPlatformIdentify(platformIdentify), mIdentifyDelegate(platformIdentify)
 {}
 
 CHIP_ERROR Aggregator::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -112,8 +96,7 @@ CHIP_ERROR Aggregator::Register(EndpointId endpoint, CodeDrivenDataModelProvider
     composition.pattern = DataModel::EndpointCompositionPattern::kFullFamily;
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    static AggregatorIdentifyDelegate sIdentifyDelegate(mPlatformIdentify);
-    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate).WithDelegate(&sIdentifyDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));

--- a/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.cpp
@@ -112,9 +112,8 @@ CHIP_ERROR Aggregator::Register(EndpointId endpoint, CodeDrivenDataModelProvider
     composition.pattern = DataModel::EndpointCompositionPattern::kFullFamily;
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
-                                .MakeConfig(endpoint, mTimerDelegate)
-                                .WithDelegate(&GetIdentifyDelegate()));
+    mIdentifyCluster.Create(
+        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate).WithDelegate(&GetIdentifyDelegate()));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));

--- a/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/aggregator/Aggregator.h>
 #include <devices/Types.h>
 #include <lib/support/CodeUtils.h>
@@ -34,11 +35,13 @@ public:
     void OnIdentifyStart(IdentifyCluster & cluster) override
     {
         ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Identify START", cluster.GetPaths()[0].mEndpointId);
+        PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
     }
 
     void OnIdentifyStop(IdentifyCluster & cluster) override
     {
         ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Identify STOP", cluster.GetPaths()[0].mEndpointId);
+        PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
     }
 
     void OnTriggerEffect(IdentifyCluster & cluster) override
@@ -83,6 +86,7 @@ public:
 
         ChipLogProgress(DeviceLayer, "Aggregator [Endpoint %d]: Trigger effect: %s", cluster.GetPaths()[0].mEndpointId,
                         msg.c_str());
+        PlatformIdentifyIntegration::GetInstance().NotifyTriggerEffect(cluster);
     }
 
     bool IsTriggerEffectEnabled() const override { return true; }
@@ -108,7 +112,9 @@ CHIP_ERROR Aggregator::Register(EndpointId endpoint, CodeDrivenDataModelProvider
     composition.pattern = DataModel::EndpointCompositionPattern::kFullFamily;
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate).WithDelegate(&GetIdentifyDelegate()));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
+                                .MakeConfig(endpoint, mTimerDelegate)
+                                .WithDelegate(&GetIdentifyDelegate()));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     ReturnErrorOnFailure(provider.AddEndpoint(mEndpointRegistration));

--- a/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.h
+++ b/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.h
@@ -51,8 +51,23 @@ public:
     Clusters::IdentifyCluster & IdentifyCluster() { return mIdentifyCluster.Cluster(); }
 
 protected:
+    class AggregatorIdentifyDelegate : public Clusters::IdentifyDelegate
+    {
+    public:
+        explicit AggregatorIdentifyDelegate(PlatformIdentifyIntegration & platformIdentify) : mPlatformIdentify(platformIdentify) {}
+
+        void OnIdentifyStart(Clusters::IdentifyCluster & cluster) override;
+        void OnIdentifyStop(Clusters::IdentifyCluster & cluster) override;
+        void OnTriggerEffect(Clusters::IdentifyCluster & cluster) override;
+        bool IsTriggerEffectEnabled() const override { return true; }
+
+    private:
+        PlatformIdentifyIntegration & mPlatformIdentify;
+    };
+
     TimerDelegate & mTimerDelegate;
     PlatformIdentifyIntegration & mPlatformIdentify;
+    AggregatorIdentifyDelegate mIdentifyDelegate;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
 };
 

--- a/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.h
+++ b/examples/all-devices-app/all-devices-common/device/types/aggregator/Aggregator.h
@@ -19,6 +19,7 @@
 
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -39,7 +40,7 @@ namespace app {
 class Aggregator : public SingleEndpoint
 {
 public:
-    Aggregator(TimerDelegate & timerDelegate);
+    Aggregator(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~Aggregator() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -51,6 +52,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
 };
 

--- a/examples/all-devices-app/all-devices-common/device/types/aggregator/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/aggregator/BUILD.gn
@@ -21,6 +21,7 @@ source_set("aggregator") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/data-model-providers/codedriven",

--- a/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/AirQualitySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/AirQualitySensor.cpp
@@ -26,8 +26,8 @@ namespace app {
 
 AirQualitySensor::AirQualitySensor(TimerDelegate & timerDelegate, const Config & config,
                                    PlatformIdentifyIntegration & platformIdentify) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kAirQualitySensor, 1)), mTimerDelegate(timerDelegate),
-    mPlatformIdentify(platformIdentify), mConfig(config)
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kAirQualitySensor, 1)),
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mConfig(config)
 {}
 
 CHIP_ERROR AirQualitySensor::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,

--- a/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/AirQualitySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/AirQualitySensor.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/air-quality-sensor/AirQualitySensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -25,9 +24,10 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-AirQualitySensor::AirQualitySensor(TimerDelegate & timerDelegate, const Config & config) :
+AirQualitySensor::AirQualitySensor(TimerDelegate & timerDelegate, const Config & config,
+                                   PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kAirQualitySensor, 1)), mTimerDelegate(timerDelegate),
-    mConfig(config)
+    mPlatformIdentify(platformIdentify), mConfig(config)
 {}
 
 CHIP_ERROR AirQualitySensor::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -35,7 +35,7 @@ CHIP_ERROR AirQualitySensor::Register(chip::EndpointId endpoint, CodeDrivenDataM
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mAirQualityCluster.Create(endpoint, mConfig.airQualityFeatures);

--- a/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/AirQualitySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/AirQualitySensor.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/air-quality-sensor/AirQualitySensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -34,7 +35,7 @@ CHIP_ERROR AirQualitySensor::Register(chip::EndpointId endpoint, CodeDrivenDataM
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mAirQualityCluster.Create(endpoint, mConfig.airQualityFeatures);

--- a/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/AirQualitySensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/AirQualitySensor.h
@@ -21,6 +21,7 @@
 #include <app/clusters/concentration-measurement-server/ConcentrationMeasurementCluster.h>
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -38,7 +39,7 @@ public:
         ConcentrationCluster::Config co2Config;
     };
 
-    AirQualitySensor(TimerDelegate & timerDelegate, const Config & config);
+    AirQualitySensor(TimerDelegate & timerDelegate, const Config & config, PlatformIdentifyIntegration & platformIdentify);
     ~AirQualitySensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -50,6 +51,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     Config mConfig;
 
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/air-quality-sensor/BUILD.gn
@@ -21,6 +21,7 @@ source_set("air-quality-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/air-quality-server",
     "${chip_root}/src/app/clusters/concentration-measurement-server",

--- a/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/AmbientContextSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/AmbientContextSensor.cpp
@@ -24,9 +24,10 @@ using namespace chip::app::Clusters;
 namespace chip::app {
 
 AmbientContextSensor::AmbientContextSensor(AmbientContextSensingConfig config, TimerDelegate & timerDelegate,
-                                           AmbientContextSensing::AmbientContextSensingDelegate & delegate) :
+                                           AmbientContextSensing::AmbientContextSensingDelegate & delegate,
+                                           PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kAmbientContextSensor, 1)),
-    mConfig(config), mTimerDelegate(timerDelegate), mDelegate(delegate)
+    mConfig(config), mTimerDelegate(timerDelegate), mDelegate(delegate), mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR AmbientContextSensor::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -35,7 +36,7 @@ CHIP_ERROR AmbientContextSensor::Register(chip::EndpointId endpoint, CodeDrivenD
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     // Create the identify cluster.
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // Create the ambient context sensing cluster

--- a/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/AmbientContextSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/AmbientContextSensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/ambient-context-sensor/AmbientContextSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -34,7 +35,7 @@ CHIP_ERROR AmbientContextSensor::Register(chip::EndpointId endpoint, CodeDrivenD
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     // Create the identify cluster.
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // Create the ambient context sensing cluster

--- a/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/AmbientContextSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/AmbientContextSensor.h
@@ -18,6 +18,7 @@
 
 #include <app/clusters/ambient-context-sensing-server/AmbientContextSensingCluster.h>
 #include <app/clusters/identify-server/IdentifyCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -29,7 +30,8 @@ public:
     using AmbientContextSensingConfig = Clusters::AmbientContextSensingCluster::Config;
 
     AmbientContextSensor(AmbientContextSensingConfig config, TimerDelegate & timerDelegate,
-                         Clusters::AmbientContextSensing::AmbientContextSensingDelegate & delegate);
+                         Clusters::AmbientContextSensing::AmbientContextSensingDelegate & delegate,
+                         PlatformIdentifyIntegration & platformIdentify);
     ~AmbientContextSensor() override = default;
 
     // DeviceInterface pure virtual lifecycle hooks
@@ -44,6 +46,7 @@ protected:
     AmbientContextSensingConfig mConfig;
     TimerDelegate & mTimerDelegate;
     Clusters::AmbientContextSensing::AmbientContextSensingDelegate & mDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::AmbientContextSensingCluster> mAmbientContextSensingCluster;
 };

--- a/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("ambient-context-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/ambient-context-sensing-server",
     "${chip_root}/src/app/clusters/identify-server",

--- a/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/impl/LoggingAmbientContextSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/impl/LoggingAmbientContextSensor.cpp
@@ -21,7 +21,8 @@
 
 namespace chip::app::Clusters::AmbientContextSensing {
 
-LoggingAmbientContextSensor::LoggingAmbientContextSensor(TimerDelegate & timerDelegate) :
+LoggingAmbientContextSensor::LoggingAmbientContextSensor(TimerDelegate & timerDelegate,
+                                                         PlatformIdentifyIntegration & platformIdentify) :
     AmbientContextSensor(AmbientContextSensingConfig{ timerDelegate }
                              .WithFeatures(BitMask<AmbientContextSensing::Feature>(kFeatureAllForLog))
                              .WithHoldTime(10,
@@ -30,7 +31,7 @@ LoggingAmbientContextSensor::LoggingAmbientContextSensor(TimerDelegate & timerDe
                                                .holdTimeMax     = 300,
                                                .holdTimeDefault = 10,
                                            }),
-                         timerDelegate, *this),
+                         timerDelegate, *this, platformIdentify),
     mAmbientContextTypeSupportedBuf{}, mPredictActivityBuf{}, mSensorFusionSupportedBuf{}
 {}
 

--- a/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/impl/LoggingAmbientContextSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/ambient-context-sensor/impl/LoggingAmbientContextSensor.h
@@ -18,6 +18,7 @@
 
 #include <app/clusters/ambient-context-sensing-server/AmbientContextSensingCluster.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/ambient-context-sensor/AmbientContextSensor.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -31,7 +32,7 @@ namespace chip::app::Clusters::AmbientContextSensing {
 class LoggingAmbientContextSensor : public AmbientContextSensor, public AmbientContextSensingDelegate
 {
 public:
-    LoggingAmbientContextSensor(TimerDelegate & timerDelegate);
+    LoggingAmbientContextSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~LoggingAmbientContextSensor() override = default;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("boolean-state-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/boolean-state-server",
     "${chip_root}/src/app/clusters/identify-server",

--- a/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BooleanStateSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BooleanStateSensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/boolean-state-sensor/BooleanStateSensor.h>
 
 using namespace chip::app::Clusters;
@@ -28,7 +29,7 @@ CHIP_ERROR BooleanStateSensor::Register(chip::EndpointId endpoint, CodeDrivenDat
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mBooleanStateCluster.Create(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BooleanStateSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BooleanStateSensor.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/boolean-state-sensor/BooleanStateSensor.h>
 
 using namespace chip::app::Clusters;
@@ -29,7 +28,7 @@ CHIP_ERROR BooleanStateSensor::Register(chip::EndpointId endpoint, CodeDrivenDat
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mBooleanStateCluster.Create(endpoint);

--- a/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BooleanStateSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BooleanStateSensor.h
@@ -39,7 +39,8 @@ public:
     /// data for the Span of deviceTypes remains valid for the entire lifetime of the BooleanStateSensor object instance.
     BooleanStateSensor(TimerDelegate & timerDelegate, Span<const DataModel::DeviceTypeEntry> deviceType,
                        PlatformIdentifyIntegration & platformIdentify) :
-        SingleEndpoint(deviceType), mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify)
+        SingleEndpoint(deviceType),
+        mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify)
     {}
     ~BooleanStateSensor() override = default;
 

--- a/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BooleanStateSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/boolean-state-sensor/BooleanStateSensor.h
@@ -18,6 +18,7 @@
 
 #include <app/clusters/boolean-state-server/BooleanStateCluster.h>
 #include <app/clusters/identify-server/IdentifyCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 #include <memory>
@@ -36,8 +37,9 @@ public:
     /// class for the sensor types that share the same core functionality through the identify and
     /// boolean state clusters. The caller creating a BooleanStateSensor MUST ensure that the underlying
     /// data for the Span of deviceTypes remains valid for the entire lifetime of the BooleanStateSensor object instance.
-    BooleanStateSensor(TimerDelegate & timerDelegate, Span<const DataModel::DeviceTypeEntry> deviceType) :
-        SingleEndpoint(deviceType), mTimerDelegate(timerDelegate)
+    BooleanStateSensor(TimerDelegate & timerDelegate, Span<const DataModel::DeviceTypeEntry> deviceType,
+                       PlatformIdentifyIntegration & platformIdentify) :
+        SingleEndpoint(deviceType), mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify)
     {}
     ~BooleanStateSensor() override = default;
 
@@ -51,6 +53,7 @@ public:
 
 private:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::BooleanStateCluster> mBooleanStateCluster;
 };

--- a/examples/all-devices-app/all-devices-common/device/types/chime/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/chime/BUILD.gn
@@ -22,6 +22,7 @@ source_set("chime") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/chime-server",
     "${chip_root}/src/app/clusters/identify-server",

--- a/examples/all-devices-app/all-devices-common/device/types/chime/Chime.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/chime/Chime.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/chime/Chime.h>
 #include <devices/Types.h>
 #include <lib/support/StringBuilder.h>
@@ -32,7 +33,7 @@ CHIP_ERROR Chime::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvide
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mChimeCluster.Create(endpoint, *this);

--- a/examples/all-devices-app/all-devices-common/device/types/chime/Chime.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/chime/Chime.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/chime/Chime.h>
 #include <devices/Types.h>
 #include <lib/support/StringBuilder.h>
@@ -25,15 +24,16 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-Chime::Chime(TimerDelegate & timerDelegate, Span<const Sound> sounds) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kChime, 1)), mTimerDelegate(timerDelegate), mSounds(sounds)
+Chime::Chime(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, Span<const Sound> sounds) :
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kChime, 1)), mTimerDelegate(timerDelegate),
+    mPlatformIdentify(platformIdentify), mSounds(sounds)
 {}
 
 CHIP_ERROR Chime::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mChimeCluster.Create(endpoint, *this);

--- a/examples/all-devices-app/all-devices-common/device/types/chime/Chime.h
+++ b/examples/all-devices-app/all-devices-common/device/types/chime/Chime.h
@@ -19,6 +19,7 @@
 #include <app/clusters/chime-server/ChimeCluster.h>
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/Span.h>
 #include <lib/support/TimerDelegate.h>
@@ -36,7 +37,7 @@ public:
     };
 
     // Note: sounds array must outlive the Chime lifetime (i.e. often static or similar)
-    Chime(TimerDelegate & timerDelegate, Span<const Sound> sounds);
+    Chime(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, Span<const Sound> sounds);
     ~Chime() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -52,6 +53,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     Span<const Sound> mSounds;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::ChimeCluster> mChimeCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/BUILD.gn
@@ -24,6 +24,7 @@ source_set("cooktop") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/on-off-server",

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
@@ -33,9 +33,8 @@ CHIP_ERROR CookSurfacePart::Register(EndpointId endpoint, CodeDrivenDataModelPro
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
-                                .MakeConfig(endpoint, mTimerDelegate)
-                                .WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(
+        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
     mOnOffCluster.Create(endpoint, Clusters::OnOffCluster::Context{ .timerDelegate = mTimerDelegate });
     mOnOffCluster.Cluster().AddDelegate(&mOnOffDelegate);
 

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
@@ -16,7 +16,6 @@
 
 #include "Cooktop.h"
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <devices/Types.h>
 
 namespace chip::app {
@@ -24,17 +23,18 @@ namespace chip::app {
 // CookSurfacePart
 
 CookSurfacePart::CookSurfacePart(TimerDelegate & timerDelegate, Clusters::OnOffDelegate & onOffDelegate,
-                                 Clusters::IdentifyDelegate & identifyDelegate) :
+                                 Clusters::IdentifyDelegate & identifyDelegate,
+                                 PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kCookSurface, 1)),
-    mTimerDelegate(timerDelegate), mOnOffDelegate(onOffDelegate), mIdentifyDelegate(identifyDelegate)
+    mTimerDelegate(timerDelegate), mOnOffDelegate(onOffDelegate), mIdentifyDelegate(identifyDelegate),
+    mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR CookSurfacePart::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(
-        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
     mOnOffCluster.Create(endpoint, Clusters::OnOffCluster::Context{ .timerDelegate = mTimerDelegate });
     mOnOffCluster.Cluster().AddDelegate(&mOnOffDelegate);
 

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
@@ -23,8 +23,7 @@ namespace chip::app {
 // CookSurfacePart
 
 CookSurfacePart::CookSurfacePart(TimerDelegate & timerDelegate, Clusters::OnOffDelegate & onOffDelegate,
-                                 Clusters::IdentifyDelegate & identifyDelegate,
-                                 PlatformIdentifyIntegration & platformIdentify) :
+                                 Clusters::IdentifyDelegate & identifyDelegate, PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kCookSurface, 1)),
     mTimerDelegate(timerDelegate), mOnOffDelegate(onOffDelegate), mIdentifyDelegate(identifyDelegate),
     mPlatformIdentify(platformIdentify)

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.cpp
@@ -16,6 +16,7 @@
 
 #include "Cooktop.h"
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <devices/Types.h>
 
 namespace chip::app {
@@ -32,7 +33,9 @@ CHIP_ERROR CookSurfacePart::Register(EndpointId endpoint, CodeDrivenDataModelPro
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(Clusters::IdentifyCluster::Config(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
+                                .MakeConfig(endpoint, mTimerDelegate)
+                                .WithDelegate(&mIdentifyDelegate));
     mOnOffCluster.Create(endpoint, Clusters::OnOffCluster::Context{ .timerDelegate = mTimerDelegate });
     mOnOffCluster.Cluster().AddDelegate(&mOnOffDelegate);
 

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.h
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/Cooktop.h
@@ -20,6 +20,7 @@
 #include <app/clusters/on-off-server/OnOffCluster.h>
 #include <app/clusters/on-off-server/OnOffDelegate.h>
 #include <device/api/Interface.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <devices/Types.h>
 #include <lib/support/TimerDelegate.h>
@@ -32,7 +33,7 @@ public:
     using SingleEndpoint::Register;
 
     CookSurfacePart(TimerDelegate & timerDelegate, Clusters::OnOffDelegate & onOffDelegate,
-                    Clusters::IdentifyDelegate & identifyDelegate);
+                    Clusters::IdentifyDelegate & identifyDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~CookSurfacePart() override = default;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition) override;
@@ -46,6 +47,7 @@ private:
     TimerDelegate & mTimerDelegate;
     Clusters::OnOffDelegate & mOnOffDelegate;
     Clusters::IdentifyDelegate & mIdentifyDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
 
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::OnOffCluster> mOnOffCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
@@ -16,6 +16,8 @@
 
 #include "LoggingCooktop.h"
 
+#include <device/api/PlatformIdentifyIntegration.h>
+
 namespace chip::app {
 
 // LoggingCookSurfacePart
@@ -37,16 +39,19 @@ void LoggingCookSurfacePart::OnOffStartup(bool on)
 void LoggingCookSurfacePart::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "CookSurface (%s): OnIdentifyStart", mName);
+    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
 }
 
 void LoggingCookSurfacePart::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "CookSurface (%s): OnIdentifyStop", mName);
+    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
 }
 
 void LoggingCookSurfacePart::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "CookSurface (%s): OnTriggerEffect", mName);
+    PlatformIdentifyIntegration::GetInstance().NotifyTriggerEffect(cluster);
 }
 
 namespace {

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
@@ -16,14 +16,13 @@
 
 #include "LoggingCooktop.h"
 
-#include <device/api/PlatformIdentifyIntegration.h>
-
 namespace chip::app {
 
 // LoggingCookSurfacePart
 
-LoggingCookSurfacePart::LoggingCookSurfacePart(TimerDelegate & timerDelegate, const char * name) :
-    CookSurfacePart(timerDelegate, *this, *this), mName(name)
+LoggingCookSurfacePart::LoggingCookSurfacePart(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
+                                               const char * name) :
+    CookSurfacePart(timerDelegate, *this, *this, platformIdentify), mPlatformIdentify(platformIdentify), mName(name)
 {}
 
 void LoggingCookSurfacePart::OnOnOffChanged(bool on)
@@ -39,19 +38,19 @@ void LoggingCookSurfacePart::OnOffStartup(bool on)
 void LoggingCookSurfacePart::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "CookSurface (%s): OnIdentifyStart", mName);
-    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
+    mPlatformIdentify.NotifyIdentifyStart(cluster);
 }
 
 void LoggingCookSurfacePart::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "CookSurface (%s): OnIdentifyStop", mName);
-    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
+    mPlatformIdentify.NotifyIdentifyStop(cluster);
 }
 
 void LoggingCookSurfacePart::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "CookSurface (%s): OnTriggerEffect", mName);
-    PlatformIdentifyIntegration::GetInstance().NotifyTriggerEffect(cluster);
+    mPlatformIdentify.NotifyTriggerEffect(cluster);
 }
 
 namespace {
@@ -72,7 +71,8 @@ const Clusters::Globals::Structs::SemanticTagStruct::Type kSurface2Tag = {
 
 // LoggingCooktop
 
-LoggingCooktop::LoggingCooktop(TimerDelegate & timerDelegate) : mSurface1(timerDelegate, "Left"), mSurface2(timerDelegate, "Right")
+LoggingCooktop::LoggingCooktop(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    mSurface1(timerDelegate, platformIdentify, "Left"), mSurface2(timerDelegate, platformIdentify, "Right")
 {}
 
 CHIP_ERROR LoggingCooktop::RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider)

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.cpp
@@ -22,7 +22,8 @@ namespace chip::app {
 
 LoggingCookSurfacePart::LoggingCookSurfacePart(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
                                                const char * name) :
-    CookSurfacePart(timerDelegate, *this, *this, platformIdentify), mPlatformIdentify(platformIdentify), mName(name)
+    CookSurfacePart(timerDelegate, *this, *this, platformIdentify),
+    mPlatformIdentify(platformIdentify), mName(name)
 {}
 
 void LoggingCookSurfacePart::OnOnOffChanged(bool on)

--- a/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.h
+++ b/examples/all-devices-app/all-devices-common/device/types/cooktop/impl/LoggingCooktop.h
@@ -24,7 +24,7 @@ namespace chip::app {
 class LoggingCookSurfacePart : public CookSurfacePart, public Clusters::OnOffDelegate, public Clusters::IdentifyDelegate
 {
 public:
-    LoggingCookSurfacePart(TimerDelegate & timerDelegate, const char * name);
+    LoggingCookSurfacePart(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, const char * name);
     ~LoggingCookSurfacePart() override = default;
 
     // OnOffDelegate
@@ -38,13 +38,14 @@ public:
     bool IsTriggerEffectEnabled() const override { return true; }
 
 private:
+    PlatformIdentifyIntegration & mPlatformIdentify;
     const char * mName;
 };
 
 class LoggingCooktop : public Cooktop
 {
 public:
-    explicit LoggingCooktop(TimerDelegate & timerDelegate);
+    LoggingCooktop(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~LoggingCooktop() override = default;
 
     LoggingCookSurfacePart & Surface1() { return mSurface1; }

--- a/examples/all-devices-app/all-devices-common/device/types/device-energy-management/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/device-energy-management/BUILD.gn
@@ -7,6 +7,7 @@ source_set("device-energy-management") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/device-energy-management-server",
     "${chip_root}/src/app/clusters/identify-server",

--- a/examples/all-devices-app/all-devices-common/device/types/device-energy-management/EnergyManagement.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/device-energy-management/EnergyManagement.cpp
@@ -22,8 +22,8 @@ using namespace chip::app::Clusters::DeviceEnergyManagement;
 namespace chip::app {
 
 EnergyManagement::EnergyManagement(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kDeviceEnergyManagement, 1)), mTimerDelegate(timerDelegate),
-    mPlatformIdentify(platformIdentify)
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kDeviceEnergyManagement, 1)),
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR EnergyManagement::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)

--- a/examples/all-devices-app/all-devices-common/device/types/device-energy-management/EnergyManagement.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/device-energy-management/EnergyManagement.cpp
@@ -14,7 +14,6 @@
  *    limitations under the License.
  */
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/device-energy-management/EnergyManagement.h>
 #include <devices/Types.h>
 
@@ -22,8 +21,9 @@ using namespace chip::app::Clusters::DeviceEnergyManagement;
 
 namespace chip::app {
 
-EnergyManagement::EnergyManagement(TimerDelegate & timerDelegate) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kDeviceEnergyManagement, 1)), mTimerDelegate(timerDelegate)
+EnergyManagement::EnergyManagement(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kDeviceEnergyManagement, 1)), mTimerDelegate(timerDelegate),
+    mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR EnergyManagement::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -34,7 +34,7 @@ CHIP_ERROR EnergyManagement::Register(EndpointId endpoint, CodeDrivenDataModelPr
     mProvider = &provider;
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     Clusters::DeviceEnergyManagementCluster::Config config(endpoint, BitMask<Feature>(), *this);

--- a/examples/all-devices-app/all-devices-common/device/types/device-energy-management/EnergyManagement.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/device-energy-management/EnergyManagement.cpp
@@ -14,6 +14,7 @@
  *    limitations under the License.
  */
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/device-energy-management/EnergyManagement.h>
 #include <devices/Types.h>
 
@@ -33,7 +34,7 @@ CHIP_ERROR EnergyManagement::Register(EndpointId endpoint, CodeDrivenDataModelPr
     mProvider = &provider;
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(Clusters::IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     Clusters::DeviceEnergyManagementCluster::Config config(endpoint, BitMask<Feature>(), *this);

--- a/examples/all-devices-app/all-devices-common/device/types/device-energy-management/EnergyManagement.h
+++ b/examples/all-devices-app/all-devices-common/device/types/device-energy-management/EnergyManagement.h
@@ -19,6 +19,7 @@
 #include <app/clusters/device-energy-management-server/DeviceEnergyManagementCluster.h>
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -27,7 +28,7 @@ namespace chip::app {
 class EnergyManagement : public SingleEndpoint, public Clusters::DeviceEnergyManagement::Delegate
 {
 public:
-    explicit EnergyManagement(TimerDelegate & timerDelegate);
+    explicit EnergyManagement(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~EnergyManagement() override = default;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;
@@ -68,6 +69,7 @@ public:
 
 private:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     CodeDrivenDataModelProvider * mProvider                  = nullptr;
     Clusters::DeviceEnergyManagement::ESAStateEnum mESAState = Clusters::DeviceEnergyManagement::ESAStateEnum::kOnline;
     DataModel::Nullable<Clusters::DeviceEnergyManagement::Structs::PowerAdjustCapabilityStruct::Type> mPowerAdjustmentCapability;

--- a/examples/all-devices-app/all-devices-common/device/types/flow-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/flow-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("flow-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/flow-measurement-server",
     "${chip_root}/src/app/clusters/identify-server",

--- a/examples/all-devices-app/all-devices-common/device/types/flow-sensor/FlowSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/flow-sensor/FlowSensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/flow-sensor/FlowSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -35,7 +36,7 @@ CHIP_ERROR FlowSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mFlowMeasurementCluster.Create(endpoint, mFlowConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/flow-sensor/FlowSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/flow-sensor/FlowSensor.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/flow-sensor/FlowSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -24,9 +23,10 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-FlowSensor::FlowSensor(TimerDelegate & timerDelegate, FlowMeasurementCluster::Config flowConfig) :
+FlowSensor::FlowSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
+                       FlowMeasurementCluster::Config flowConfig) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kFlowSensor, 1)), mTimerDelegate(timerDelegate),
-    mFlowConfig(flowConfig)
+    mPlatformIdentify(platformIdentify), mFlowConfig(flowConfig)
 {}
 
 CHIP_ERROR FlowSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -36,7 +36,7 @@ CHIP_ERROR FlowSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mFlowMeasurementCluster.Create(endpoint, mFlowConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/flow-sensor/FlowSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/flow-sensor/FlowSensor.cpp
@@ -25,8 +25,8 @@ namespace app {
 
 FlowSensor::FlowSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
                        FlowMeasurementCluster::Config flowConfig) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kFlowSensor, 1)), mTimerDelegate(timerDelegate),
-    mPlatformIdentify(platformIdentify), mFlowConfig(flowConfig)
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kFlowSensor, 1)),
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mFlowConfig(flowConfig)
 {}
 
 CHIP_ERROR FlowSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)

--- a/examples/all-devices-app/all-devices-common/device/types/flow-sensor/FlowSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/flow-sensor/FlowSensor.h
@@ -19,6 +19,7 @@
 
 #include <app/clusters/flow-measurement-server/FlowMeasurementCluster.h>
 #include <app/clusters/identify-server/IdentifyCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -30,7 +31,8 @@ namespace app {
 class FlowSensor : public SingleEndpoint
 {
 public:
-    FlowSensor(TimerDelegate & timerDelegate, Clusters::FlowMeasurementCluster::Config flowConfig);
+    FlowSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
+               Clusters::FlowMeasurementCluster::Config flowConfig);
     ~FlowSensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -44,6 +46,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     const Clusters::FlowMeasurementCluster::Config mFlowConfig;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::FlowMeasurementCluster> mFlowMeasurementCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/flow-sensor/impl/IncreasingFlowSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/flow-sensor/impl/IncreasingFlowSensor.cpp
@@ -41,7 +41,9 @@ const FlowMeasurementCluster::Config kDefaultFlowConfig = []() {
 
 } // namespace
 
-IncreasingFlowSensor::IncreasingFlowSensor(TimerDelegate & timerDelegate) : FlowSensor(timerDelegate, kDefaultFlowConfig) {}
+IncreasingFlowSensor::IncreasingFlowSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    FlowSensor(timerDelegate, platformIdentify, kDefaultFlowConfig)
+{}
 
 IncreasingFlowSensor::~IncreasingFlowSensor()
 {

--- a/examples/all-devices-app/all-devices-common/device/types/flow-sensor/impl/IncreasingFlowSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/flow-sensor/impl/IncreasingFlowSensor.h
@@ -30,7 +30,7 @@ namespace app {
 class IncreasingFlowSensor : public FlowSensor, public TimerContext
 {
 public:
-    IncreasingFlowSensor(TimerDelegate & timerDelegate);
+    IncreasingFlowSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~IncreasingFlowSensor() override;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/generic-switch/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/generic-switch/BUILD.gn
@@ -22,6 +22,7 @@ source_set("generic-switch") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/switch-server",

--- a/examples/all-devices-app/all-devices-common/device/types/generic-switch/GenericSwitch.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/generic-switch/GenericSwitch.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/generic-switch/GenericSwitch.h>
 #include <devices/Types.h>
 
@@ -22,8 +21,9 @@ using namespace chip::app::Clusters;
 
 namespace chip::app {
 
-GenericSwitch::GenericSwitch(TimerDelegate & timerDelegate) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kGenericSwitch, 1)), mTimerDelegate(timerDelegate)
+GenericSwitch::GenericSwitch(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kGenericSwitch, 1)), mTimerDelegate(timerDelegate),
+    mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR GenericSwitch::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -34,7 +34,7 @@ CHIP_ERROR GenericSwitch::Register(chip::EndpointId endpoint, CodeDrivenDataMode
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mSwitchCluster.Create(endpoint, BitFlags<Switch::Feature>(Switch::Feature::kLatchingSwitch),

--- a/examples/all-devices-app/all-devices-common/device/types/generic-switch/GenericSwitch.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/generic-switch/GenericSwitch.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/generic-switch/GenericSwitch.h>
 #include <devices/Types.h>
 
@@ -33,7 +34,7 @@ CHIP_ERROR GenericSwitch::Register(chip::EndpointId endpoint, CodeDrivenDataMode
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mSwitchCluster.Create(endpoint, BitFlags<Switch::Feature>(Switch::Feature::kLatchingSwitch),

--- a/examples/all-devices-app/all-devices-common/device/types/generic-switch/GenericSwitch.h
+++ b/examples/all-devices-app/all-devices-common/device/types/generic-switch/GenericSwitch.h
@@ -18,6 +18,7 @@
 
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/switch-server/SwitchCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -27,7 +28,7 @@ namespace app {
 class GenericSwitch : public SingleEndpoint
 {
 public:
-    GenericSwitch(TimerDelegate & timerDelegate);
+    GenericSwitch(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~GenericSwitch() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -41,6 +42,7 @@ public:
 
 private:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::SwitchCluster> mSwitchCluster;
 };

--- a/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("humidity-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/relative-humidity-measurement-server",

--- a/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/HumiditySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/HumiditySensor.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/humidity-sensor/HumiditySensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -24,9 +23,10 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-HumiditySensor::HumiditySensor(TimerDelegate & timerDelegate, RelativeHumidityMeasurementCluster::Config humidityConfig) :
+HumiditySensor::HumiditySensor(TimerDelegate & timerDelegate, RelativeHumidityMeasurementCluster::Config humidityConfig,
+                               PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kHumiditySensor, 1)), mTimerDelegate(timerDelegate),
-    mHumidityConfig(humidityConfig)
+    mPlatformIdentify(platformIdentify), mHumidityConfig(humidityConfig)
 {}
 
 CHIP_ERROR HumiditySensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -36,7 +36,7 @@ CHIP_ERROR HumiditySensor::Register(EndpointId endpoint, CodeDrivenDataModelProv
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mRelativeHumidityMeasurementCluster.Create(endpoint, mHumidityConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/HumiditySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/HumiditySensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/humidity-sensor/HumiditySensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -35,7 +36,7 @@ CHIP_ERROR HumiditySensor::Register(EndpointId endpoint, CodeDrivenDataModelProv
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mRelativeHumidityMeasurementCluster.Create(endpoint, mHumidityConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/HumiditySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/HumiditySensor.cpp
@@ -25,8 +25,8 @@ namespace app {
 
 HumiditySensor::HumiditySensor(TimerDelegate & timerDelegate, RelativeHumidityMeasurementCluster::Config humidityConfig,
                                PlatformIdentifyIntegration & platformIdentify) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kHumiditySensor, 1)), mTimerDelegate(timerDelegate),
-    mPlatformIdentify(platformIdentify), mHumidityConfig(humidityConfig)
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kHumiditySensor, 1)),
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mHumidityConfig(humidityConfig)
 {}
 
 CHIP_ERROR HumiditySensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)

--- a/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/HumiditySensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/HumiditySensor.h
@@ -19,6 +19,7 @@
 
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/relative-humidity-measurement-server/RelativeHumidityMeasurementCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -30,7 +31,8 @@ namespace app {
 class HumiditySensor : public SingleEndpoint
 {
 public:
-    HumiditySensor(TimerDelegate & timerDelegate, Clusters::RelativeHumidityMeasurementCluster::Config humidityConfig);
+    HumiditySensor(TimerDelegate & timerDelegate, Clusters::RelativeHumidityMeasurementCluster::Config humidityConfig,
+                   PlatformIdentifyIntegration & platformIdentify);
     ~HumiditySensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -47,6 +49,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     const Clusters::RelativeHumidityMeasurementCluster::Config mHumidityConfig;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::RelativeHumidityMeasurementCluster> mRelativeHumidityMeasurementCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/impl/IncreasingHumiditySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/impl/IncreasingHumiditySensor.cpp
@@ -41,8 +41,8 @@ const RelativeHumidityMeasurementCluster::Config kDefaultHumidityConfig = []() {
 
 } // namespace
 
-IncreasingHumiditySensor::IncreasingHumiditySensor(TimerDelegate & timerDelegate) :
-    HumiditySensor(timerDelegate, kDefaultHumidityConfig)
+IncreasingHumiditySensor::IncreasingHumiditySensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    HumiditySensor(timerDelegate, kDefaultHumidityConfig, platformIdentify)
 {}
 
 IncreasingHumiditySensor::~IncreasingHumiditySensor()

--- a/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/impl/IncreasingHumiditySensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/humidity-sensor/impl/IncreasingHumiditySensor.h
@@ -30,7 +30,7 @@ namespace app {
 class IncreasingHumiditySensor : public HumiditySensor, public TimerContext
 {
 public:
-    IncreasingHumiditySensor(TimerDelegate & timerDelegate);
+    IncreasingHumiditySensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~IncreasingHumiditySensor() override;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/light-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/light-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("light-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/illuminance-measurement-server",

--- a/examples/all-devices-app/all-devices-common/device/types/light-sensor/LightSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/light-sensor/LightSensor.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/light-sensor/LightSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -25,9 +24,11 @@ namespace chip {
 namespace app {
 
 LightSensor::LightSensor(TimerDelegate & timerDelegate, IlluminanceMeasurementCluster::StartupConfiguration lightConfig,
-                         IlluminanceMeasurementCluster::OptionalAttributeSet optionalAttributes) :
+                         IlluminanceMeasurementCluster::OptionalAttributeSet optionalAttributes,
+                         PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kLightSensor, 1)),
-    mTimerDelegate(timerDelegate), mLightConfig(lightConfig), mOptionalAttributes(optionalAttributes)
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mLightConfig(lightConfig),
+    mOptionalAttributes(optionalAttributes)
 {}
 
 CHIP_ERROR LightSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -37,7 +38,7 @@ CHIP_ERROR LightSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvide
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mIlluminanceMeasurementCluster.Create(endpoint, mOptionalAttributes, mLightConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/light-sensor/LightSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/light-sensor/LightSensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/light-sensor/LightSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -36,7 +37,7 @@ CHIP_ERROR LightSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvide
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mIlluminanceMeasurementCluster.Create(endpoint, mOptionalAttributes, mLightConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/light-sensor/LightSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/light-sensor/LightSensor.h
@@ -19,6 +19,7 @@
 
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/illuminance-measurement-server/IlluminanceMeasurementCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -31,7 +32,8 @@ class LightSensor : public SingleEndpoint
 {
 public:
     LightSensor(TimerDelegate & timerDelegate, Clusters::IlluminanceMeasurementCluster::StartupConfiguration lightConfig,
-                Clusters::IlluminanceMeasurementCluster::OptionalAttributeSet optionalAttributes = {});
+                Clusters::IlluminanceMeasurementCluster::OptionalAttributeSet optionalAttributes,
+                PlatformIdentifyIntegration & platformIdentify);
     ~LightSensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -45,6 +47,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     const Clusters::IlluminanceMeasurementCluster::StartupConfiguration mLightConfig;
     const Clusters::IlluminanceMeasurementCluster::OptionalAttributeSet mOptionalAttributes;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/light-sensor/impl/IncreasingLightSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/light-sensor/impl/IncreasingLightSensor.cpp
@@ -42,17 +42,18 @@ const IlluminanceMeasurementCluster::StartupConfiguration kDefaultLightConfig = 
 } // namespace
 
 IncreasingLightSensor::IncreasingLightSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
-    LightSensor(timerDelegate, kDefaultLightConfig,
-                []() {
-                    IlluminanceMeasurementCluster::OptionalAttributeSet optionalAttributes;
-                    // Enable optional Tolerance and LightSensorType attributes.
-                    // These optional attributes are enabled to support the Illuminance Measurement
-                    // YAML certification tests (Test_TC_ILL_2_1.yaml) executed against this simulated device.
-                    optionalAttributes.Set<IlluminanceMeasurement::Attributes::Tolerance::Id>();
-                    optionalAttributes.Set<IlluminanceMeasurement::Attributes::LightSensorType::Id>();
-                    return optionalAttributes;
-                }(),
-                platformIdentify)
+    LightSensor(
+        timerDelegate, kDefaultLightConfig,
+        []() {
+            IlluminanceMeasurementCluster::OptionalAttributeSet optionalAttributes;
+            // Enable optional Tolerance and LightSensorType attributes.
+            // These optional attributes are enabled to support the Illuminance Measurement
+            // YAML certification tests (Test_TC_ILL_2_1.yaml) executed against this simulated device.
+            optionalAttributes.Set<IlluminanceMeasurement::Attributes::Tolerance::Id>();
+            optionalAttributes.Set<IlluminanceMeasurement::Attributes::LightSensorType::Id>();
+            return optionalAttributes;
+        }(),
+        platformIdentify)
 {}
 
 IncreasingLightSensor::~IncreasingLightSensor()

--- a/examples/all-devices-app/all-devices-common/device/types/light-sensor/impl/IncreasingLightSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/light-sensor/impl/IncreasingLightSensor.cpp
@@ -41,16 +41,18 @@ const IlluminanceMeasurementCluster::StartupConfiguration kDefaultLightConfig = 
 
 } // namespace
 
-IncreasingLightSensor::IncreasingLightSensor(TimerDelegate & timerDelegate) :
-    LightSensor(timerDelegate, kDefaultLightConfig, []() {
-        IlluminanceMeasurementCluster::OptionalAttributeSet optionalAttributes;
-        // Enable optional Tolerance and LightSensorType attributes.
-        // These optional attributes are enabled to support the Illuminance Measurement
-        // YAML certification tests (Test_TC_ILL_2_1.yaml) executed against this simulated device.
-        optionalAttributes.Set<IlluminanceMeasurement::Attributes::Tolerance::Id>();
-        optionalAttributes.Set<IlluminanceMeasurement::Attributes::LightSensorType::Id>();
-        return optionalAttributes;
-    }())
+IncreasingLightSensor::IncreasingLightSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    LightSensor(timerDelegate, kDefaultLightConfig,
+                []() {
+                    IlluminanceMeasurementCluster::OptionalAttributeSet optionalAttributes;
+                    // Enable optional Tolerance and LightSensorType attributes.
+                    // These optional attributes are enabled to support the Illuminance Measurement
+                    // YAML certification tests (Test_TC_ILL_2_1.yaml) executed against this simulated device.
+                    optionalAttributes.Set<IlluminanceMeasurement::Attributes::Tolerance::Id>();
+                    optionalAttributes.Set<IlluminanceMeasurement::Attributes::LightSensorType::Id>();
+                    return optionalAttributes;
+                }(),
+                platformIdentify)
 {}
 
 IncreasingLightSensor::~IncreasingLightSensor()

--- a/examples/all-devices-app/all-devices-common/device/types/light-sensor/impl/IncreasingLightSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/light-sensor/impl/IncreasingLightSensor.h
@@ -30,7 +30,7 @@ namespace app {
 class IncreasingLightSensor : public LightSensor, public TimerContext
 {
 public:
-    IncreasingLightSensor(TimerDelegate & timerDelegate);
+    IncreasingLightSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~IncreasingLightSensor() override;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("occupancy-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/occupancy-sensor-server",

--- a/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/occupancy-sensor/OccupancySensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -24,9 +23,10 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-OccupancySensor::OccupancySensor(OccupancySensingConfig config, TimerDelegate & timerDelegate) :
+OccupancySensor::OccupancySensor(OccupancySensingConfig config, TimerDelegate & timerDelegate,
+                                 PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kOccupancySensor, 1)), mConfig(config),
-    mTimerDelegate(timerDelegate)
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR OccupancySensor::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -38,7 +38,7 @@ CHIP_ERROR OccupancySensor::Register(chip::EndpointId endpoint, CodeDrivenDataMo
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     // Create the identify cluster.
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // Update the config with the actual endpoint ID

--- a/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/occupancy-sensor/OccupancySensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -37,7 +38,7 @@ CHIP_ERROR OccupancySensor::Register(chip::EndpointId endpoint, CodeDrivenDataMo
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     // Create the identify cluster.
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // Update the config with the actual endpoint ID

--- a/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.cpp
@@ -25,8 +25,8 @@ namespace app {
 
 OccupancySensor::OccupancySensor(OccupancySensingConfig config, TimerDelegate & timerDelegate,
                                  PlatformIdentifyIntegration & platformIdentify) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kOccupancySensor, 1)), mConfig(config),
-    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify)
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kOccupancySensor, 1)),
+    mConfig(config), mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR OccupancySensor::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,

--- a/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.h
@@ -30,8 +30,7 @@ class OccupancySensor : public SingleEndpoint
 public:
     using OccupancySensingConfig = Clusters::OccupancySensingCluster::Config;
 
-    OccupancySensor(OccupancySensingConfig config, TimerDelegate & timerDelegate,
-                    PlatformIdentifyIntegration & platformIdentify);
+    OccupancySensor(OccupancySensingConfig config, TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~OccupancySensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,

--- a/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/OccupancySensor.h
@@ -18,6 +18,7 @@
 
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/occupancy-sensor-server/OccupancySensingCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -29,7 +30,8 @@ class OccupancySensor : public SingleEndpoint
 public:
     using OccupancySensingConfig = Clusters::OccupancySensingCluster::Config;
 
-    OccupancySensor(OccupancySensingConfig config, TimerDelegate & timerDelegate);
+    OccupancySensor(OccupancySensingConfig config, TimerDelegate & timerDelegate,
+                    PlatformIdentifyIntegration & platformIdentify);
     ~OccupancySensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -44,6 +46,7 @@ public:
 protected:
     OccupancySensingConfig mConfig;
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::OccupancySensingCluster> mOccupancySensingCluster;
 };

--- a/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/impl/LoggingOccupancySensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/impl/LoggingOccupancySensor.cpp
@@ -24,7 +24,7 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-LoggingOccupancySensor::LoggingOccupancySensor(TimerDelegate & timerDelegate) :
+LoggingOccupancySensor::LoggingOccupancySensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
     OccupancySensor(
         // Initialize with kInvalidEndpointId. The actual endpoint ID will be set
         // when Register() is called by the application with a valid endpoint ID.
@@ -38,7 +38,7 @@ LoggingOccupancySensor::LoggingOccupancySensor(TimerDelegate & timerDelegate) :
                           },
                           timerDelegate)
             .WithDelegate(this),
-        timerDelegate)
+        timerDelegate, platformIdentify)
 {}
 
 CHIP_ERROR LoggingOccupancySensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,

--- a/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/impl/LoggingOccupancySensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/occupancy-sensor/impl/LoggingOccupancySensor.h
@@ -30,7 +30,7 @@ namespace app {
 class LoggingOccupancySensor : public OccupancySensor, public Clusters::OccupancySensingDelegate
 {
 public:
-    LoggingOccupancySensor(TimerDelegate & timerDelegate);
+    LoggingOccupancySensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~LoggingOccupancySensor() override = default;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/on-off-light-switch/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/on-off-light-switch/BUILD.gn
@@ -21,6 +21,7 @@ source_set("on-off-light-switch") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/bindings",
     "${chip_root}/src/app/clusters/identify-server",

--- a/examples/all-devices-app/all-devices-common/device/types/on-off-light-switch/OnOffLightSwitch.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/on-off-light-switch/OnOffLightSwitch.cpp
@@ -21,6 +21,7 @@
 #include <app/clusters/bindings/binding-table.h>
 #include <clusters/Identify/Ids.h>
 #include <clusters/OnOff/Ids.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <devices/Types.h>
 #include <platform/PlatformManager.h>
 
@@ -46,7 +47,7 @@ CHIP_ERROR OnOffLightSwitch::Register(chip::EndpointId endpoint, CodeDrivenDataM
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mBindingCluster.Create(

--- a/examples/all-devices-app/all-devices-common/device/types/on-off-light-switch/OnOffLightSwitch.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/on-off-light-switch/OnOffLightSwitch.cpp
@@ -21,7 +21,6 @@
 #include <app/clusters/bindings/binding-table.h>
 #include <clusters/Identify/Ids.h>
 #include <clusters/OnOff/Ids.h>
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <devices/Types.h>
 #include <platform/PlatformManager.h>
 
@@ -34,9 +33,11 @@ const ClusterId kClientClusters[] = { OnOff::Id, Identify::Id };
 } // namespace
 
 OnOffLightSwitch::OnOffLightSwitch(TimerDelegate & timerDelegate, DeviceLayer::PlatformManager & platformManager,
-                                   Clusters::Binding::Table & bindingTable, Clusters::Binding::Manager & bindingManager) :
+                                   Clusters::Binding::Table & bindingTable, Clusters::Binding::Manager & bindingManager,
+                                   PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kOnOffLightSwitch, 1)),
-    mTimerDelegate(timerDelegate), mPlatformManager(platformManager), mBindingTable(bindingTable), mBindingManager(bindingManager)
+    mTimerDelegate(timerDelegate), mPlatformManager(platformManager), mBindingTable(bindingTable), mBindingManager(bindingManager),
+    mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR OnOffLightSwitch::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -47,7 +48,7 @@ CHIP_ERROR OnOffLightSwitch::Register(chip::EndpointId endpoint, CodeDrivenDataM
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mBindingCluster.Create(

--- a/examples/all-devices-app/all-devices-common/device/types/on-off-light-switch/OnOffLightSwitch.h
+++ b/examples/all-devices-app/all-devices-common/device/types/on-off-light-switch/OnOffLightSwitch.h
@@ -21,6 +21,7 @@
 #include <app/clusters/bindings/BindingManager.h>
 #include <app/clusters/bindings/binding-table.h>
 #include <app/clusters/identify-server/IdentifyCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 #include <platform/PlatformManager.h>
@@ -31,7 +32,8 @@ class OnOffLightSwitch : public SingleEndpoint
 {
 public:
     OnOffLightSwitch(TimerDelegate & timerDelegate, DeviceLayer::PlatformManager & platformManager,
-                     Clusters::Binding::Table & bindingTable, Clusters::Binding::Manager & bindingManager);
+                     Clusters::Binding::Table & bindingTable, Clusters::Binding::Manager & bindingManager,
+                     PlatformIdentifyIntegration & platformIdentify);
     ~OnOffLightSwitch() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -50,6 +52,7 @@ private:
     DeviceLayer::PlatformManager & mPlatformManager;
     Clusters::Binding::Table & mBindingTable;
     Clusters::Binding::Manager & mBindingManager;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::BindingCluster> mBindingCluster;
 };

--- a/examples/all-devices-app/all-devices-common/device/types/oven/impl/LoggingOven.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/oven/impl/LoggingOven.cpp
@@ -18,10 +18,13 @@
 
 namespace chip::app {
 
-LoggingOven::LoggingOven(TimerDelegate & timerDelegate) : LoggingOven(timerDelegate, Config{}) {}
+LoggingOven::LoggingOven(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    LoggingOven(timerDelegate, platformIdentify, Config{})
+{}
 
-LoggingOven::LoggingOven(TimerDelegate & timerDelegate, Config config) :
-    mCavity(timerDelegate, config.cavityConfig, "Cavity"), mSurface(timerDelegate, "Top Surface")
+LoggingOven::LoggingOven(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, Config config) :
+    mCavity(timerDelegate, platformIdentify, config.cavityConfig, "Cavity"),
+    mSurface(timerDelegate, platformIdentify, "Top Surface")
 {}
 
 CHIP_ERROR LoggingOven::RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider)

--- a/examples/all-devices-app/all-devices-common/device/types/oven/impl/LoggingOven.h
+++ b/examples/all-devices-app/all-devices-common/device/types/oven/impl/LoggingOven.h
@@ -30,8 +30,8 @@ public:
         TemperatureControlledCabinetPart::Config cavityConfig;
     };
 
-    explicit LoggingOven(TimerDelegate & timerDelegate);
-    LoggingOven(TimerDelegate & timerDelegate, Config config);
+    LoggingOven(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
+    LoggingOven(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, Config config);
     ~LoggingOven() override = default;
 
     LoggingTemperatureControlledCabinetPart & Cavity() { return mCavity; }

--- a/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("pressure-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/pressure-measurement-server",

--- a/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/PressureSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/PressureSensor.cpp
@@ -25,8 +25,8 @@ namespace app {
 
 PressureSensor::PressureSensor(TimerDelegate & timerDelegate, PressureMeasurementCluster::Config pressureConfig,
                                PlatformIdentifyIntegration & platformIdentify) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kPressureSensor, 1)), mTimerDelegate(timerDelegate),
-    mPlatformIdentify(platformIdentify), mPressureConfig(pressureConfig)
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kPressureSensor, 1)),
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mPressureConfig(pressureConfig)
 {}
 
 CHIP_ERROR PressureSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)

--- a/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/PressureSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/PressureSensor.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/pressure-sensor/PressureSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -24,9 +23,10 @@ using namespace chip::app::Clusters;
 namespace chip {
 namespace app {
 
-PressureSensor::PressureSensor(TimerDelegate & timerDelegate, PressureMeasurementCluster::Config pressureConfig) :
+PressureSensor::PressureSensor(TimerDelegate & timerDelegate, PressureMeasurementCluster::Config pressureConfig,
+                               PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kPressureSensor, 1)), mTimerDelegate(timerDelegate),
-    mPressureConfig(pressureConfig)
+    mPlatformIdentify(platformIdentify), mPressureConfig(pressureConfig)
 {}
 
 CHIP_ERROR PressureSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -36,7 +36,7 @@ CHIP_ERROR PressureSensor::Register(EndpointId endpoint, CodeDrivenDataModelProv
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mPressureMeasurementCluster.Create(endpoint, mPressureConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/PressureSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/PressureSensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/pressure-sensor/PressureSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -35,7 +36,7 @@ CHIP_ERROR PressureSensor::Register(EndpointId endpoint, CodeDrivenDataModelProv
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mPressureMeasurementCluster.Create(endpoint, mPressureConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/PressureSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/PressureSensor.h
@@ -19,6 +19,7 @@
 
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/pressure-measurement-server/PressureMeasurementCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -30,7 +31,8 @@ namespace app {
 class PressureSensor : public SingleEndpoint
 {
 public:
-    PressureSensor(TimerDelegate & timerDelegate, Clusters::PressureMeasurementCluster::Config pressureConfig);
+    PressureSensor(TimerDelegate & timerDelegate, Clusters::PressureMeasurementCluster::Config pressureConfig,
+                   PlatformIdentifyIntegration & platformIdentify);
     ~PressureSensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -44,6 +46,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     const Clusters::PressureMeasurementCluster::Config mPressureConfig;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::PressureMeasurementCluster> mPressureMeasurementCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/impl/IncreasingPressureSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/impl/IncreasingPressureSensor.cpp
@@ -41,8 +41,8 @@ const PressureMeasurementCluster::Config kDefaultPressureConfig = []() {
 
 } // namespace
 
-IncreasingPressureSensor::IncreasingPressureSensor(TimerDelegate & timerDelegate) :
-    PressureSensor(timerDelegate, kDefaultPressureConfig)
+IncreasingPressureSensor::IncreasingPressureSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    PressureSensor(timerDelegate, kDefaultPressureConfig, platformIdentify)
 {}
 
 IncreasingPressureSensor::~IncreasingPressureSensor()

--- a/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/impl/IncreasingPressureSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/pressure-sensor/impl/IncreasingPressureSensor.h
@@ -30,7 +30,7 @@ namespace app {
 class IncreasingPressureSensor : public PressureSensor, public TimerContext
 {
 public:
-    IncreasingPressureSensor(TimerDelegate & timerDelegate);
+    IncreasingPressureSensor(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~IncreasingPressureSensor() override;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/BUILD.gn
@@ -22,6 +22,7 @@ source_set("proximity-ranger") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/proximity-ranging-server",

--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/ProximityRanger.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/ProximityRanger.cpp
@@ -48,8 +48,7 @@ BitMask<ProximityRanging::Feature> ProximityRanger::DeriveFeatures() const
     return features;
 }
 
-ProximityRanger::ProximityRanger(TimerDelegate & timerDelegate,
-                                 std::vector<Clusters::ProximityRanging::RangingAdapter *> adapters,
+ProximityRanger::ProximityRanger(TimerDelegate & timerDelegate, std::vector<Clusters::ProximityRanging::RangingAdapter *> adapters,
                                  PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kProximityRanger, 1)),
     mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mAdapters(std::move(adapters))

--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/ProximityRanger.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/ProximityRanger.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/proximity-ranger/ProximityRanger.h>
 #include <devices/Types.h>
 #include <lib/support/CodeUtils.h>
@@ -50,9 +49,10 @@ BitMask<ProximityRanging::Feature> ProximityRanger::DeriveFeatures() const
 }
 
 ProximityRanger::ProximityRanger(TimerDelegate & timerDelegate,
-                                 std::vector<Clusters::ProximityRanging::RangingAdapter *> adapters) :
+                                 std::vector<Clusters::ProximityRanging::RangingAdapter *> adapters,
+                                 PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kProximityRanger, 1)),
-    mTimerDelegate(timerDelegate), mAdapters(std::move(adapters))
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mAdapters(std::move(adapters))
 {}
 
 CHIP_ERROR ProximityRanger::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -65,7 +65,7 @@ CHIP_ERROR ProximityRanger::Register(chip::EndpointId endpoint, CodeDrivenDataMo
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mProximityRangingCluster.Create(

--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/ProximityRanger.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/ProximityRanger.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/proximity-ranger/ProximityRanger.h>
 #include <devices/Types.h>
 #include <lib/support/CodeUtils.h>
@@ -64,7 +65,7 @@ CHIP_ERROR ProximityRanger::Register(chip::EndpointId endpoint, CodeDrivenDataMo
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mProximityRangingCluster.Create(

--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/ProximityRanger.h
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/ProximityRanger.h
@@ -18,6 +18,7 @@
 
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/proximity-ranging-server/ProximityRangingCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -41,7 +42,8 @@ public:
      * The cluster's feature map is derived from the technologies of the
      * supplied adapters, so the caller does not pass a feature mask in.
      */
-    ProximityRanger(TimerDelegate & timerDelegate, std::vector<Clusters::ProximityRanging::RangingAdapter *> adapters);
+    ProximityRanger(TimerDelegate & timerDelegate, std::vector<Clusters::ProximityRanging::RangingAdapter *> adapters,
+                    PlatformIdentifyIntegration & platformIdentify);
     ~ProximityRanger() override = default;
 
     // Non-copyable / non-movable: copying or moving this device would invalidate the
@@ -73,6 +75,7 @@ private:
     BitMask<Clusters::ProximityRanging::Feature> DeriveFeatures() const;
 
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     const std::vector<Clusters::ProximityRanging::RangingAdapter *> mAdapters;
 
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/impl/LoggingProximityRanger.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/impl/LoggingProximityRanger.cpp
@@ -25,8 +25,9 @@ namespace app {
 // taking their addresses here is well-defined. The base only stores the
 // pointer list — it does not dereference until Register() runs, by which
 // point all members are fully constructed.
-LoggingProximityRanger::LoggingProximityRanger(TimerDelegate & timerDelegate, PersistentStorageDelegate & storage) :
-    ProximityRanger(timerDelegate, { &mBleRangingAdapter, &mWiFiRangingAdapter, &mBltcsRangingAdapter }),
+LoggingProximityRanger::LoggingProximityRanger(TimerDelegate & timerDelegate, PersistentStorageDelegate & storage,
+                                               PlatformIdentifyIntegration & platformIdentify) :
+    ProximityRanger(timerDelegate, { &mBleRangingAdapter, &mWiFiRangingAdapter, &mBltcsRangingAdapter }, platformIdentify),
     mBleRangingAdapter(Clusters::ProximityRanging::RangingTechEnum::kBLEBeaconRSSIRanging, timerDelegate, &storage,
                        /*periodicRangingSupport=*/true),
     mWiFiRangingAdapter(Clusters::ProximityRanging::RangingTechEnum::kWiFiRoundTripTimeRanging, timerDelegate),

--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/impl/LoggingProximityRanger.h
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/impl/LoggingProximityRanger.h
@@ -33,7 +33,8 @@ namespace app {
 class LoggingProximityRanger : public ProximityRanger
 {
 public:
-    LoggingProximityRanger(TimerDelegate & timerDelegate, PersistentStorageDelegate & storage);
+    LoggingProximityRanger(TimerDelegate & timerDelegate, PersistentStorageDelegate & storage,
+                           PlatformIdentifyIntegration & platformIdentify);
     ~LoggingProximityRanger() override = default;
 
     // Non-copyable / non-movable: would invalidate the adapter pointers that the base

--- a/examples/all-devices-app/all-devices-common/device/types/refrigerator/impl/LoggingRefrigerator.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/refrigerator/impl/LoggingRefrigerator.cpp
@@ -18,10 +18,13 @@
 
 namespace chip::app {
 
-LoggingRefrigerator::LoggingRefrigerator(TimerDelegate & timerDelegate) : LoggingRefrigerator(timerDelegate, Config{}) {}
+LoggingRefrigerator::LoggingRefrigerator(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    LoggingRefrigerator(timerDelegate, platformIdentify, Config{})
+{}
 
-LoggingRefrigerator::LoggingRefrigerator(TimerDelegate & timerDelegate, Config config) :
-    mCabinet(timerDelegate, config.cabinetConfig, "Cabinet")
+LoggingRefrigerator::LoggingRefrigerator(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
+                                         Config config) :
+    mCabinet(timerDelegate, platformIdentify, config.cabinetConfig, "Cabinet")
 {}
 
 CHIP_ERROR LoggingRefrigerator::RegisterParts(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider)

--- a/examples/all-devices-app/all-devices-common/device/types/refrigerator/impl/LoggingRefrigerator.h
+++ b/examples/all-devices-app/all-devices-common/device/types/refrigerator/impl/LoggingRefrigerator.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/refrigerator/Refrigerator.h>
 #include <device/types/temperature-controlled-cabinet/impl/LoggingTemperatureControlledCabinetPart.h>
 
@@ -44,8 +45,8 @@ public:
         TemperatureControlledCabinetPart::Config cabinetConfig = DefaultCabinetConfig();
     };
 
-    explicit LoggingRefrigerator(TimerDelegate & timerDelegate);
-    LoggingRefrigerator(TimerDelegate & timerDelegate, Config config);
+    LoggingRefrigerator(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
+    LoggingRefrigerator(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, Config config);
     ~LoggingRefrigerator() override = default;
 
     LoggingTemperatureControlledCabinetPart & Cabinet() { return mCabinet; }

--- a/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/BUILD.gn
@@ -21,6 +21,7 @@ source_set("smoke-co-alarm") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/concentration-measurement-server",
     "${chip_root}/src/app/clusters/identify-server",

--- a/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/SmokeCoAlarm.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/SmokeCoAlarm.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "SmokeCoAlarm.h"
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -54,9 +53,11 @@ SmokeCoAlarmCluster::Config DefaultSmokeConfig()
 
 } // namespace
 
-SmokeCoAlarm::SmokeCoAlarm(TimerDelegate & timerDelegate, Clusters::SmokeCoAlarmDelegate & smokeCoAlarmDelegate) :
+SmokeCoAlarm::SmokeCoAlarm(TimerDelegate & timerDelegate, Clusters::SmokeCoAlarmDelegate & smokeCoAlarmDelegate,
+                           PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kSmokeCoAlarm, 1)), mTimerDelegate(timerDelegate),
-    mSmokeCoAlarmDelegate(smokeCoAlarmDelegate), mCoConfig(DefaultCoConfig()), mSmokeConfig(DefaultSmokeConfig())
+    mPlatformIdentify(platformIdentify), mSmokeCoAlarmDelegate(smokeCoAlarmDelegate), mCoConfig(DefaultCoConfig()),
+    mSmokeConfig(DefaultSmokeConfig())
 {}
 
 CHIP_ERROR SmokeCoAlarm::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -64,7 +65,7 @@ CHIP_ERROR SmokeCoAlarm::Register(chip::EndpointId endpoint, CodeDrivenDataModel
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mSmokeCoAlarmCluster.Create(endpoint, mSmokeConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/SmokeCoAlarm.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/SmokeCoAlarm.cpp
@@ -55,9 +55,9 @@ SmokeCoAlarmCluster::Config DefaultSmokeConfig()
 
 SmokeCoAlarm::SmokeCoAlarm(TimerDelegate & timerDelegate, Clusters::SmokeCoAlarmDelegate & smokeCoAlarmDelegate,
                            PlatformIdentifyIntegration & platformIdentify) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kSmokeCoAlarm, 1)), mTimerDelegate(timerDelegate),
-    mPlatformIdentify(platformIdentify), mSmokeCoAlarmDelegate(smokeCoAlarmDelegate), mCoConfig(DefaultCoConfig()),
-    mSmokeConfig(DefaultSmokeConfig())
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kSmokeCoAlarm, 1)),
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mSmokeCoAlarmDelegate(smokeCoAlarmDelegate),
+    mCoConfig(DefaultCoConfig()), mSmokeConfig(DefaultSmokeConfig())
 {}
 
 CHIP_ERROR SmokeCoAlarm::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,

--- a/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/SmokeCoAlarm.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/SmokeCoAlarm.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "SmokeCoAlarm.h"
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -63,7 +64,7 @@ CHIP_ERROR SmokeCoAlarm::Register(chip::EndpointId endpoint, CodeDrivenDataModel
 {
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     mSmokeCoAlarmCluster.Create(endpoint, mSmokeConfig);

--- a/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/SmokeCoAlarm.h
+++ b/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/SmokeCoAlarm.h
@@ -21,6 +21,7 @@
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/smoke-co-alarm-server/SmokeCoAlarmCluster.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -35,7 +36,8 @@ class SmokeCoAlarm : public SingleEndpoint
 public:
     using ConcentrationCluster = Clusters::ConcentrationMeasurement::ConcentrationMeasurementCluster;
 
-    SmokeCoAlarm(TimerDelegate & timerDelegate, Clusters::SmokeCoAlarmDelegate & smokeCoAlarmDelegate);
+    SmokeCoAlarm(TimerDelegate & timerDelegate, Clusters::SmokeCoAlarmDelegate & smokeCoAlarmDelegate,
+                 PlatformIdentifyIntegration & platformIdentify);
     ~SmokeCoAlarm() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -48,6 +50,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     Clusters::SmokeCoAlarmDelegate & mSmokeCoAlarmDelegate;
     ConcentrationCluster::Config mCoConfig;
     Clusters::SmokeCoAlarmCluster::Config mSmokeConfig;

--- a/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/impl/LoggingOnlySmokeCoAlarm.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/impl/LoggingOnlySmokeCoAlarm.cpp
@@ -36,7 +36,9 @@ namespace app {
 // The device is its own delegate: SmokeCoAlarm only stores the reference, so passing *this
 // (the not-yet-fully-constructed SmokeCoAlarmDelegate base) is safe as long as it is not used until
 // the cluster is registered.
-LoggingOnlySmokeCoAlarm::LoggingOnlySmokeCoAlarm(TimerDelegate & timerDelegate) : SmokeCoAlarm(timerDelegate, *this) {}
+LoggingOnlySmokeCoAlarm::LoggingOnlySmokeCoAlarm(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    SmokeCoAlarm(timerDelegate, *this, platformIdentify)
+{}
 
 LoggingOnlySmokeCoAlarm::~LoggingOnlySmokeCoAlarm()
 {

--- a/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/impl/LoggingOnlySmokeCoAlarm.h
+++ b/examples/all-devices-app/all-devices-common/device/types/smoke-co-alarm/impl/LoggingOnlySmokeCoAlarm.h
@@ -37,7 +37,7 @@ class LoggingOnlySmokeCoAlarm : public Clusters::SmokeCoAlarmDelegate, public Sm
 public:
     static constexpr uint16_t kSelfTestTimeoutSec = 10;
 
-    explicit LoggingOnlySmokeCoAlarm(TimerDelegate & timerDelegate);
+    explicit LoggingOnlySmokeCoAlarm(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~LoggingOnlySmokeCoAlarm() override;
 
     // SmokeCoAlarmDelegate

--- a/examples/all-devices-app/all-devices-common/device/types/soil-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/soil-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("soil-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/soil-measurement-server",

--- a/examples/all-devices-app/all-devices-common/device/types/soil-sensor/SoilSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/soil-sensor/SoilSensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/soil-sensor/SoilSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -39,7 +40,7 @@ CHIP_ERROR SoilSensor::Register(chip::EndpointId endpoint, CodeDrivenDataModelPr
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     // Create the identify cluster.
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // Create the temperature measurement cluster

--- a/examples/all-devices-app/all-devices-common/device/types/soil-sensor/SoilSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/soil-sensor/SoilSensor.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/soil-sensor/SoilSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -27,9 +26,10 @@ namespace chip {
 namespace app {
 
 SoilSensor::SoilSensor(TimerDelegate & timerDelegate, SoilMoistureMeasurementLimits::TypeInfo::Type moistureLimits,
-                       TemperatureMeasurementCluster::StartupConfiguration tempConfig) :
+                       TemperatureMeasurementCluster::StartupConfiguration tempConfig,
+                       PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kSoilSensor, 1)),
-    mTimerDelegate(timerDelegate), mMoistureLimits(moistureLimits), mTempConfig(tempConfig)
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mMoistureLimits(moistureLimits), mTempConfig(tempConfig)
 {}
 
 CHIP_ERROR SoilSensor::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -40,7 +40,7 @@ CHIP_ERROR SoilSensor::Register(chip::EndpointId endpoint, CodeDrivenDataModelPr
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     // Create the identify cluster.
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // Create the temperature measurement cluster

--- a/examples/all-devices-app/all-devices-common/device/types/soil-sensor/SoilSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/soil-sensor/SoilSensor.h
@@ -19,6 +19,7 @@
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/soil-measurement-server/SoilMeasurementCluster.h>
 #include <app/clusters/temperature-measurement-server/TemperatureMeasurementCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -30,7 +31,8 @@ class SoilSensor : public SingleEndpoint
 public:
     SoilSensor(TimerDelegate & timerDelegate,
                Clusters::SoilMeasurement::Attributes::SoilMoistureMeasurementLimits::TypeInfo::Type moistureLimits,
-               Clusters::TemperatureMeasurementCluster::StartupConfiguration tempConfig);
+               Clusters::TemperatureMeasurementCluster::StartupConfiguration tempConfig,
+               PlatformIdentifyIntegration & platformIdentify);
     ~SoilSensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -45,6 +47,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     Clusters::SoilMeasurement::Attributes::SoilMoistureMeasurementLimits::TypeInfo::Type mMoistureLimits;
     Clusters::TemperatureMeasurementCluster::StartupConfiguration mTempConfig;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/soil-sensor/impl/IncreasingMoistureSoilSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/soil-sensor/impl/IncreasingMoistureSoilSensor.cpp
@@ -50,8 +50,8 @@ const TemperatureMeasurementCluster::StartupConfiguration kDefaultTemperatureCon
 
 } // namespace
 
-IncreasingMoistureSoilSensor::IncreasingMoistureSoilSensor() :
-    SoilSensor(mTimerDelegate, kDefaultSoilMoistureMeasurementLimits, kDefaultTemperatureConfig)
+IncreasingMoistureSoilSensor::IncreasingMoistureSoilSensor(PlatformIdentifyIntegration & platformIdentify) :
+    SoilSensor(mTimerDelegate, kDefaultSoilMoistureMeasurementLimits, kDefaultTemperatureConfig, platformIdentify)
 {}
 
 IncreasingMoistureSoilSensor::~IncreasingMoistureSoilSensor()

--- a/examples/all-devices-app/all-devices-common/device/types/soil-sensor/impl/IncreasingMoistureSoilSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/soil-sensor/impl/IncreasingMoistureSoilSensor.h
@@ -30,7 +30,7 @@ namespace app {
 class IncreasingMoistureSoilSensor : public SoilSensor, public TimerContext
 {
 public:
-    IncreasingMoistureSoilSensor();
+    IncreasingMoistureSoilSensor(PlatformIdentifyIntegration & platformIdentify);
     ~IncreasingMoistureSoilSensor() override;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/BUILD.gn
@@ -24,6 +24,7 @@ source_set("temperature-controlled-cabinet") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/operational-state-server",

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.cpp
@@ -16,6 +16,7 @@
 
 #include "TemperatureControlledCabinetPart.h"
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <devices/Types.h>
 
 namespace chip::app {
@@ -40,7 +41,9 @@ CHIP_ERROR TemperatureControlledCabinetPart::Register(EndpointId endpoint, CodeD
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(Clusters::IdentifyCluster::Config(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
+                                .MakeConfig(endpoint, mTimerDelegate)
+                                .WithDelegate(&mIdentifyDelegate));
     mTemperatureControlCluster.Create(
         endpoint, BitFlags<Clusters::TemperatureControl::Feature>(Clusters::TemperatureControl::Feature::kTemperatureNumber),
         Clusters::TemperatureControlCluster::StartupConfiguration{

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.cpp
@@ -16,22 +16,22 @@
 
 #include "TemperatureControlledCabinetPart.h"
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <devices/Types.h>
 
 namespace chip::app {
 
 TemperatureControlledCabinetPart::TemperatureControlledCabinetPart(
     TimerDelegate & timerDelegate, Clusters::OperationalState::OperationalStateCluster::Delegate & opStateDelegate,
-    Clusters::IdentifyDelegate & identifyDelegate) :
-    TemperatureControlledCabinetPart(timerDelegate, Config{}, opStateDelegate, identifyDelegate)
+    Clusters::IdentifyDelegate & identifyDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    TemperatureControlledCabinetPart(timerDelegate, Config{}, opStateDelegate, identifyDelegate, platformIdentify)
 {}
 
 TemperatureControlledCabinetPart::TemperatureControlledCabinetPart(
     TimerDelegate & timerDelegate, Config config, Clusters::OperationalState::OperationalStateCluster::Delegate & opStateDelegate,
-    Clusters::IdentifyDelegate & identifyDelegate) :
+    Clusters::IdentifyDelegate & identifyDelegate, PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kTemperatureControlledCabinet, 1)),
-    mTimerDelegate(timerDelegate), mConfig(config), mIdentifyDelegate(identifyDelegate), mOperationalStateDelegate(opStateDelegate)
+    mTimerDelegate(timerDelegate), mConfig(config), mIdentifyDelegate(identifyDelegate), mPlatformIdentify(platformIdentify),
+    mOperationalStateDelegate(opStateDelegate)
 {}
 
 CHIP_ERROR TemperatureControlledCabinetPart::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -41,8 +41,7 @@ CHIP_ERROR TemperatureControlledCabinetPart::Register(EndpointId endpoint, CodeD
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(
-        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
     mTemperatureControlCluster.Create(
         endpoint, BitFlags<Clusters::TemperatureControl::Feature>(Clusters::TemperatureControl::Feature::kTemperatureNumber),
         Clusters::TemperatureControlCluster::StartupConfiguration{

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.cpp
@@ -41,9 +41,8 @@ CHIP_ERROR TemperatureControlledCabinetPart::Register(EndpointId endpoint, CodeD
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance()
-                                .MakeConfig(endpoint, mTimerDelegate)
-                                .WithDelegate(&mIdentifyDelegate));
+    mIdentifyCluster.Create(
+        PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate).WithDelegate(&mIdentifyDelegate));
     mTemperatureControlCluster.Create(
         endpoint, BitFlags<Clusters::TemperatureControl::Feature>(Clusters::TemperatureControl::Feature::kTemperatureNumber),
         Clusters::TemperatureControlCluster::StartupConfiguration{

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h
@@ -20,6 +20,7 @@
 #include <app/clusters/operational-state-server/OperationalStateDelegate.h>
 #include <app/clusters/operational-state-server/OvenCavityOperationalStateCluster.h>
 #include <app/clusters/temperature-control-server/TemperatureControlCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -40,10 +41,12 @@ public:
 
     TemperatureControlledCabinetPart(TimerDelegate & timerDelegate,
                                      Clusters::OperationalState::OperationalStateCluster::Delegate & opStateDelegate,
-                                     Clusters::IdentifyDelegate & identifyDelegate);
+                                     Clusters::IdentifyDelegate & identifyDelegate,
+                                     PlatformIdentifyIntegration & platformIdentify);
     TemperatureControlledCabinetPart(TimerDelegate & timerDelegate, Config config,
                                      Clusters::OperationalState::OperationalStateCluster::Delegate & opStateDelegate,
-                                     Clusters::IdentifyDelegate & identifyDelegate);
+                                     Clusters::IdentifyDelegate & identifyDelegate,
+                                     PlatformIdentifyIntegration & platformIdentify);
     ~TemperatureControlledCabinetPart() override = default;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition) override;
@@ -71,6 +74,7 @@ private:
     TimerDelegate & mTimerDelegate;
     const Config mConfig;
     Clusters::IdentifyDelegate & mIdentifyDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
 
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::TemperatureControlCluster> mTemperatureControlCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/TemperatureControlledCabinetPart.h
@@ -41,12 +41,10 @@ public:
 
     TemperatureControlledCabinetPart(TimerDelegate & timerDelegate,
                                      Clusters::OperationalState::OperationalStateCluster::Delegate & opStateDelegate,
-                                     Clusters::IdentifyDelegate & identifyDelegate,
-                                     PlatformIdentifyIntegration & platformIdentify);
+                                     Clusters::IdentifyDelegate & identifyDelegate, PlatformIdentifyIntegration & platformIdentify);
     TemperatureControlledCabinetPart(TimerDelegate & timerDelegate, Config config,
                                      Clusters::OperationalState::OperationalStateCluster::Delegate & opStateDelegate,
-                                     Clusters::IdentifyDelegate & identifyDelegate,
-                                     PlatformIdentifyIntegration & platformIdentify);
+                                     Clusters::IdentifyDelegate & identifyDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~TemperatureControlledCabinetPart() override = default;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition) override;

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/impl/LoggingTemperatureControlledCabinetPart.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/impl/LoggingTemperatureControlledCabinetPart.cpp
@@ -16,6 +16,7 @@
 
 #include "LoggingTemperatureControlledCabinetPart.h"
 
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <lib/support/CodeUtils.h>
 
 namespace chip::app {
@@ -138,16 +139,19 @@ void LoggingTemperatureControlledCabinetPart::HandleStopStateCallback(Clusters::
 void LoggingTemperatureControlledCabinetPart::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "TempCabinet (%s): OnIdentifyStart", mName);
+    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
 }
 
 void LoggingTemperatureControlledCabinetPart::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "TempCabinet (%s): OnIdentifyStop", mName);
+    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
 }
 
 void LoggingTemperatureControlledCabinetPart::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "TempCabinet (%s): OnTriggerEffect", mName);
+    PlatformIdentifyIntegration::GetInstance().NotifyTriggerEffect(cluster);
 }
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/impl/LoggingTemperatureControlledCabinetPart.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/impl/LoggingTemperatureControlledCabinetPart.cpp
@@ -16,20 +16,22 @@
 
 #include "LoggingTemperatureControlledCabinetPart.h"
 
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <lib/support/CodeUtils.h>
 
 namespace chip::app {
 
-LoggingTemperatureControlledCabinetPart::LoggingTemperatureControlledCabinetPart(TimerDelegate & timerDelegate, const char * name) :
-    LoggingTemperatureControlledCabinetPart(timerDelegate, Config{}, name)
+LoggingTemperatureControlledCabinetPart::LoggingTemperatureControlledCabinetPart(TimerDelegate & timerDelegate,
+                                                                                 PlatformIdentifyIntegration & platformIdentify,
+                                                                                 const char * name) :
+    LoggingTemperatureControlledCabinetPart(timerDelegate, platformIdentify, Config{}, name)
 {}
 
-LoggingTemperatureControlledCabinetPart::LoggingTemperatureControlledCabinetPart(TimerDelegate & timerDelegate, Config config,
-                                                                                 const char * name) :
+LoggingTemperatureControlledCabinetPart::LoggingTemperatureControlledCabinetPart(TimerDelegate & timerDelegate,
+                                                                                 PlatformIdentifyIntegration & platformIdentify,
+                                                                                 Config config, const char * name) :
     TemperatureControlledCabinetPart(timerDelegate, config, static_cast<Clusters::OperationalState::Delegate &>(*this),
-                                     static_cast<Clusters::IdentifyDelegate &>(*this)),
-    mName(name), mTimerDelegate(timerDelegate)
+                                     static_cast<Clusters::IdentifyDelegate &>(*this), platformIdentify),
+    mName(name), mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify)
 {}
 
 LoggingTemperatureControlledCabinetPart::~LoggingTemperatureControlledCabinetPart()
@@ -139,19 +141,19 @@ void LoggingTemperatureControlledCabinetPart::HandleStopStateCallback(Clusters::
 void LoggingTemperatureControlledCabinetPart::OnIdentifyStart(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "TempCabinet (%s): OnIdentifyStart", mName);
-    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStart(cluster);
+    mPlatformIdentify.NotifyIdentifyStart(cluster);
 }
 
 void LoggingTemperatureControlledCabinetPart::OnIdentifyStop(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "TempCabinet (%s): OnIdentifyStop", mName);
-    PlatformIdentifyIntegration::GetInstance().NotifyIdentifyStop(cluster);
+    mPlatformIdentify.NotifyIdentifyStop(cluster);
 }
 
 void LoggingTemperatureControlledCabinetPart::OnTriggerEffect(Clusters::IdentifyCluster & cluster)
 {
     ChipLogProgress(DeviceLayer, "TempCabinet (%s): OnTriggerEffect", mName);
-    PlatformIdentifyIntegration::GetInstance().NotifyTriggerEffect(cluster);
+    mPlatformIdentify.NotifyTriggerEffect(cluster);
 }
 
 } // namespace chip::app

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/impl/LoggingTemperatureControlledCabinetPart.h
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-controlled-cabinet/impl/LoggingTemperatureControlledCabinetPart.h
@@ -28,8 +28,10 @@ class LoggingTemperatureControlledCabinetPart : public TemperatureControlledCabi
                                                 public TimerContext
 {
 public:
-    LoggingTemperatureControlledCabinetPart(TimerDelegate & timerDelegate, const char * name);
-    LoggingTemperatureControlledCabinetPart(TimerDelegate & timerDelegate, Config config, const char * name);
+    LoggingTemperatureControlledCabinetPart(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
+                                            const char * name);
+    LoggingTemperatureControlledCabinetPart(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
+                                            Config config, const char * name);
     ~LoggingTemperatureControlledCabinetPart() override;
 
     void Unregister(CodeDrivenDataModelProvider & provider) override;
@@ -61,6 +63,7 @@ private:
 
     const char * mName;
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     Clusters::OperationalState::OperationalStateEnum mOperationalState = Clusters::OperationalState::OperationalStateEnum::kStopped;
     DataModel::Nullable<uint32_t> mCountdownTime;
 };

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/BUILD.gn
@@ -22,6 +22,7 @@ source_set("temperature-sensor") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/temperature-measurement-server",

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/TemperatureSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/TemperatureSensor.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/temperature-sensor/TemperatureSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -37,7 +38,7 @@ CHIP_ERROR TemperatureSensor::Register(EndpointId endpoint, CodeDrivenDataModelP
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     // Create the identify cluster.
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // Create the temperature measurement cluster

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/TemperatureSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/TemperatureSensor.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/temperature-sensor/TemperatureSensor.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -25,9 +24,11 @@ namespace chip {
 namespace app {
 
 TemperatureSensor::TemperatureSensor(TimerDelegate & timerDelegate, TemperatureMeasurementCluster::StartupConfiguration tempConfig,
-                                     TemperatureMeasurementCluster::OptionalAttributeSet optionalAttributes) :
+                                     TemperatureMeasurementCluster::OptionalAttributeSet optionalAttributes,
+                                     PlatformIdentifyIntegration & platformIdentify) :
     SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kTemperatureSensor, 1)),
-    mTimerDelegate(timerDelegate), mTempConfig(tempConfig), mOptionalAttributes(optionalAttributes)
+    mTimerDelegate(timerDelegate), mPlatformIdentify(platformIdentify), mTempConfig(tempConfig),
+    mOptionalAttributes(optionalAttributes)
 {}
 
 CHIP_ERROR TemperatureSensor::Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -38,7 +39,7 @@ CHIP_ERROR TemperatureSensor::Register(EndpointId endpoint, CodeDrivenDataModelP
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
     // Create the identify cluster.
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     // Create the temperature measurement cluster

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/TemperatureSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/TemperatureSensor.h
@@ -18,6 +18,7 @@
 
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/temperature-measurement-server/TemperatureMeasurementCluster.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -28,7 +29,8 @@ class TemperatureSensor : public SingleEndpoint
 {
 public:
     TemperatureSensor(TimerDelegate & timerDelegate, Clusters::TemperatureMeasurementCluster::StartupConfiguration tempConfig,
-                      Clusters::TemperatureMeasurementCluster::OptionalAttributeSet optionalAttributes = {});
+                      Clusters::TemperatureMeasurementCluster::OptionalAttributeSet optionalAttributes,
+                      PlatformIdentifyIntegration & platformIdentify);
     ~TemperatureSensor() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -42,6 +44,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     Clusters::TemperatureMeasurementCluster::StartupConfiguration mTempConfig;
     Clusters::TemperatureMeasurementCluster::OptionalAttributeSet mOptionalAttributes;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/impl/IncreasingTemperatureSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/impl/IncreasingTemperatureSensor.cpp
@@ -37,15 +37,16 @@ const TemperatureMeasurementCluster::StartupConfiguration kDefaultTemperatureCon
 } // namespace
 
 IncreasingTemperatureSensor::IncreasingTemperatureSensor(PlatformIdentifyIntegration & platformIdentify) :
-    TemperatureSensor(mTimerDelegate, kDefaultTemperatureConfig,
-                      []() {
-                          TemperatureMeasurementCluster::OptionalAttributeSet optionalAttributes;
-                          // Enable optional Tolerance attribute to support YAML certification tests
-                          // (Test_TC_TMP_2_1.yaml) executed against this simulated device.
-                          optionalAttributes.Set<TemperatureMeasurement::Attributes::Tolerance::Id>();
-                          return optionalAttributes;
-                      }(),
-                      platformIdentify)
+    TemperatureSensor(
+        mTimerDelegate, kDefaultTemperatureConfig,
+        []() {
+            TemperatureMeasurementCluster::OptionalAttributeSet optionalAttributes;
+            // Enable optional Tolerance attribute to support YAML certification tests
+            // (Test_TC_TMP_2_1.yaml) executed against this simulated device.
+            optionalAttributes.Set<TemperatureMeasurement::Attributes::Tolerance::Id>();
+            return optionalAttributes;
+        }(),
+        platformIdentify)
 {}
 
 IncreasingTemperatureSensor::~IncreasingTemperatureSensor()

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/impl/IncreasingTemperatureSensor.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/impl/IncreasingTemperatureSensor.cpp
@@ -36,14 +36,16 @@ const TemperatureMeasurementCluster::StartupConfiguration kDefaultTemperatureCon
 
 } // namespace
 
-IncreasingTemperatureSensor::IncreasingTemperatureSensor() :
-    TemperatureSensor(mTimerDelegate, kDefaultTemperatureConfig, []() {
-        TemperatureMeasurementCluster::OptionalAttributeSet optionalAttributes;
-        // Enable optional Tolerance attribute to support YAML certification tests
-        // (Test_TC_TMP_2_1.yaml) executed against this simulated device.
-        optionalAttributes.Set<TemperatureMeasurement::Attributes::Tolerance::Id>();
-        return optionalAttributes;
-    }())
+IncreasingTemperatureSensor::IncreasingTemperatureSensor(PlatformIdentifyIntegration & platformIdentify) :
+    TemperatureSensor(mTimerDelegate, kDefaultTemperatureConfig,
+                      []() {
+                          TemperatureMeasurementCluster::OptionalAttributeSet optionalAttributes;
+                          // Enable optional Tolerance attribute to support YAML certification tests
+                          // (Test_TC_TMP_2_1.yaml) executed against this simulated device.
+                          optionalAttributes.Set<TemperatureMeasurement::Attributes::Tolerance::Id>();
+                          return optionalAttributes;
+                      }(),
+                      platformIdentify)
 {}
 
 IncreasingTemperatureSensor::~IncreasingTemperatureSensor()

--- a/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/impl/IncreasingTemperatureSensor.h
+++ b/examples/all-devices-app/all-devices-common/device/types/temperature-sensor/impl/IncreasingTemperatureSensor.h
@@ -30,7 +30,7 @@ namespace app {
 class IncreasingTemperatureSensor : public TemperatureSensor, public TimerContext
 {
 public:
-    IncreasingTemperatureSensor();
+    IncreasingTemperatureSensor(PlatformIdentifyIntegration & platformIdentify);
     ~IncreasingTemperatureSensor() override;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/water-valve/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/water-valve/BUILD.gn
@@ -22,6 +22,7 @@ source_set("water-valve") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/device/api:platform-identify-integration",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:single-endpoint-device",
     "${chip_root}/src/app/clusters/identify-server",
     "${chip_root}/src/app/clusters/valve-configuration-and-control-server",

--- a/examples/all-devices-app/all-devices-common/device/types/water-valve/WaterValve.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/water-valve/WaterValve.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/water-valve/WaterValve.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -23,8 +22,9 @@ using namespace chip::app::Clusters;
 
 namespace chip::app {
 
-WaterValve::WaterValve(TimerDelegate & timerDelegate) :
-    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kWaterValve, 1)), mTimerDelegate(timerDelegate)
+WaterValve::WaterValve(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify) :
+    SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kWaterValve, 1)), mTimerDelegate(timerDelegate),
+    mPlatformIdentify(platformIdentify)
 {}
 
 CHIP_ERROR WaterValve::Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
@@ -34,7 +34,7 @@ CHIP_ERROR WaterValve::Register(chip::EndpointId endpoint, CodeDrivenDataModelPr
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(mPlatformIdentify.MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     ValveConfigurationAndControlCluster::StartupConfiguration config{ DataModel::NullNullable,

--- a/examples/all-devices-app/all-devices-common/device/types/water-valve/WaterValve.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/water-valve/WaterValve.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/types/water-valve/WaterValve.h>
 #include <devices/Types.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -33,7 +34,7 @@ CHIP_ERROR WaterValve::Register(chip::EndpointId endpoint, CodeDrivenDataModelPr
 
     ReturnErrorOnFailure(RegisterDescriptor(endpoint, provider, composition));
 
-    mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
+    mIdentifyCluster.Create(PlatformIdentifyIntegration::GetInstance().MakeConfig(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
     ValveConfigurationAndControlCluster::StartupConfiguration config{ DataModel::NullNullable,

--- a/examples/all-devices-app/all-devices-common/device/types/water-valve/WaterValve.h
+++ b/examples/all-devices-app/all-devices-common/device/types/water-valve/WaterValve.h
@@ -19,6 +19,7 @@
 #include <app/clusters/identify-server/IdentifyCluster.h>
 #include <app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.h>
 #include <app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-delegate.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/SingleEndpoint.h>
 #include <lib/support/TimerDelegate.h>
 
@@ -27,7 +28,7 @@ namespace chip::app {
 class WaterValve : public SingleEndpoint, public Clusters::ValveConfigurationAndControl::Delegate
 {
 public:
-    WaterValve(TimerDelegate & timerDelegate);
+    WaterValve(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify);
     ~WaterValve() override = default;
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
@@ -46,6 +47,7 @@ public:
 
 protected:
     TimerDelegate & mTimerDelegate;
+    PlatformIdentifyIntegration & mPlatformIdentify;
     LazyRegisteredServerCluster<Clusters::IdentifyCluster> mIdentifyCluster;
     LazyRegisteredServerCluster<Clusters::ValveConfigurationAndControlCluster> mValveCluster;
 };

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -27,6 +27,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <device-factory/DeviceFactory.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/allocator/ConsecutiveEndpointIdAllocator.h>
 #include <device/types/root-node/WifiRootNode.h>
 #include <esp_heap_caps.h>
@@ -108,6 +109,7 @@ chip::app::CodeDrivenDataModelProvider * gDataModelProvider = nullptr;
 std::unique_ptr<DeviceInterface> gRootNode;
 std::unique_ptr<DeviceInterface> gConstructedDevice;
 DefaultTimerDelegate gTimerDelegate;
+chip::app::PlatformIdentifyIntegration gPlatformIdentify;
 
 void DeInitBLEIfCommissioned()
 {
@@ -313,6 +315,7 @@ void InitServer(intptr_t context)
         .bindingTable             = Clusters::Binding::Table::GetInstance(),
         .bindingManager           = Clusters::Binding::Manager::GetInstance(),
         .testEventTriggerDelegate = *initParams.testEventTriggerDelegate,
+        .platformIdentify         = gPlatformIdentify,
     });
 
 #if ALL_DEVICES_ENABLE_DIMMABLE_LIGHT
@@ -322,6 +325,7 @@ void InitServer(intptr_t context)
             .groupDataProvider = gGroupDataProvider,
             .fabricTable       = Server::GetInstance().GetFabricTable(),
             .timerDelegate     = gTimerDelegate,
+            .platformIdentify  = gPlatformIdentify,
         });
     });
 #endif

--- a/examples/all-devices-app/posix/PosixChime.cpp
+++ b/examples/all-devices-app/posix/PosixChime.cpp
@@ -38,8 +38,10 @@ Span<const Chime::Sound> MapSounds(PosixAudioManager & audioManager)
 }
 } // namespace
 
-PosixChime::PosixChime(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, PosixAudioManager & audioManager) :
-    Chime(timerDelegate, platformIdentify, MapSounds(audioManager)), mAudioManager(audioManager)
+PosixChime::PosixChime(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify,
+                       PosixAudioManager & audioManager) :
+    Chime(timerDelegate, platformIdentify, MapSounds(audioManager)),
+    mAudioManager(audioManager)
 {
     CHIP_ERROR err = mAudioManager.Init();
     if (err != CHIP_NO_ERROR)

--- a/examples/all-devices-app/posix/PosixChime.cpp
+++ b/examples/all-devices-app/posix/PosixChime.cpp
@@ -38,8 +38,8 @@ Span<const Chime::Sound> MapSounds(PosixAudioManager & audioManager)
 }
 } // namespace
 
-PosixChime::PosixChime(TimerDelegate & timerDelegate, PosixAudioManager & audioManager) :
-    Chime(timerDelegate, MapSounds(audioManager)), mAudioManager(audioManager)
+PosixChime::PosixChime(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, PosixAudioManager & audioManager) :
+    Chime(timerDelegate, platformIdentify, MapSounds(audioManager)), mAudioManager(audioManager)
 {
     CHIP_ERROR err = mAudioManager.Init();
     if (err != CHIP_NO_ERROR)

--- a/examples/all-devices-app/posix/darwin/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/darwin/DeviceFactoryPlatformOverride.cpp
@@ -25,7 +25,7 @@ namespace chip {
 namespace app {
 
 void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate,
-                                    PosixAudioManager & audioManager)
+                                    PosixAudioManager & audioManager, PlatformIdentifyIntegration & platformIdentify)
 {
     if constexpr (ALL_DEVICES_ENABLE_SPEAKER)
     {
@@ -36,8 +36,9 @@ void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentSto
 
     if constexpr (ALL_DEVICES_ENABLE_CHIME)
     {
-        DeviceFactory::GetInstance().RegisterCreator(
-            "chime", [&timerDelegate, &audioManager]() { return std::make_unique<PosixChime>(timerDelegate, audioManager); });
+        DeviceFactory::GetInstance().RegisterCreator("chime", [&timerDelegate, &platformIdentify, &audioManager]() {
+            return std::make_unique<PosixChime>(timerDelegate, platformIdentify, audioManager);
+        });
     }
 }
 

--- a/examples/all-devices-app/posix/include/DeviceFactoryPlatformOverride.h
+++ b/examples/all-devices-app/posix/include/DeviceFactoryPlatformOverride.h
@@ -20,12 +20,13 @@
 #include <lib/support/TimerDelegate.h>
 
 #include <PosixAudioManager.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 
 namespace chip {
 namespace app {
 
 void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate,
-                                    PosixAudioManager & audioManager);
+                                    PosixAudioManager & audioManager, PlatformIdentifyIntegration & platformIdentify);
 
 } // namespace app
 } // namespace chip

--- a/examples/all-devices-app/posix/include/PosixChime.h
+++ b/examples/all-devices-app/posix/include/PosixChime.h
@@ -27,7 +27,7 @@ namespace app {
 class PosixChime : public Chime
 {
 public:
-    PosixChime(TimerDelegate & timerDelegate, PosixAudioManager & audioManager);
+    PosixChime(TimerDelegate & timerDelegate, PlatformIdentifyIntegration & platformIdentify, PosixAudioManager & audioManager);
     ~PosixChime() override = default;
 
     Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) override;

--- a/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
@@ -25,7 +25,7 @@ namespace chip {
 namespace app {
 
 void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentStorageDelegate * storageDelegate,
-                                    PosixAudioManager & audioManager)
+                                    PosixAudioManager & audioManager, PlatformIdentifyIntegration & platformIdentify)
 {
     if constexpr (ALL_DEVICES_ENABLE_SPEAKER)
     {
@@ -36,8 +36,9 @@ void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, PersistentSto
 
     if constexpr (ALL_DEVICES_ENABLE_CHIME)
     {
-        DeviceFactory::GetInstance().RegisterCreator(
-            "chime", [&timerDelegate, &audioManager]() { return std::make_unique<PosixChime>(timerDelegate, audioManager); });
+        DeviceFactory::GetInstance().RegisterCreator("chime", [&timerDelegate, &platformIdentify, &audioManager]() {
+            return std::make_unique<PosixChime>(timerDelegate, platformIdentify, audioManager);
+        });
     }
 }
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -43,6 +43,7 @@
 #include <app_options/AppOptions.h>
 #include <app_options/DeviceTypeParser.h>
 #include <device-factory/DeviceFactory.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/allocator/DynamicEndpointIdAllocator.h>
 #include <oob-accessors/OOBAccessor.h>
 #include <oob-accessors/OOBAccessorRegistry.h>
@@ -81,6 +82,7 @@ AppMainLoopImplementation * gMainLoopImplementation = nullptr;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
 chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 DefaultTimerDelegate gTimerDelegate;
+chip::app::PlatformIdentifyIntegration gPlatformIdentify;
 chip::app::PosixAudioManager gAudioManager;
 
 // To hold SPAKE2+ verifier, discriminator, passcode
@@ -334,9 +336,10 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
         .bindingTable             = Binding::Table::GetInstance(),
         .bindingManager           = Binding::Manager::GetInstance(),
         .testEventTriggerDelegate = *initParams.testEventTriggerDelegate,
+        .platformIdentify         = gPlatformIdentify,
     });
 
-    RegisterDeviceFactoryOverrides(gTimerDelegate, initParams.persistentStorageDelegate, gAudioManager);
+    RegisterDeviceFactoryOverrides(gTimerDelegate, initParams.persistentStorageDelegate, gAudioManager, gPlatformIdentify);
 
 #if CHIP_CONFIG_ENABLE_GROUPCAST
     // TODO(#72056): Once groupcast is enabled by default, this should not be dependent on the app argument.

--- a/examples/all-devices-app/silabs/src/AppTask.cpp
+++ b/examples/all-devices-app/silabs/src/AppTask.cpp
@@ -45,6 +45,7 @@
 
 #include <app_config/enabled_devices.h>
 #include <device-factory/DeviceFactory.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/allocator/ConsecutiveEndpointIdAllocator.h>
 #include <device/types/root-node/RootNode.h>
 
@@ -70,6 +71,7 @@ using namespace ::chip::DeviceLayer::Silabs;
 namespace {
 chip::app::DefaultAttributePersistenceProvider sAttributePersistenceProvider;
 chip::app::DefaultSafeAttributePersistenceProvider sSafeAttributePersistenceProvider;
+chip::app::PlatformIdentifyIntegration sPlatformIdentify;
 std::unique_ptr<chip::app::CodeDrivenDataModelProvider> sDataModelProvider;
 std::unique_ptr<chip::app::DeviceInterface> sRootNode;
 std::vector<std::unique_ptr<chip::app::DeviceInterface>> sConstructedDevices;
@@ -207,6 +209,7 @@ CHIP_ERROR AppTask::InitCodeDrivenDataModel(chip::PersistentStorageDelegate & st
         .bindingTable             = chip::app::Clusters::Binding::Table::GetInstance(),
         .bindingManager           = chip::app::Clusters::Binding::Manager::GetInstance(),
         .testEventTriggerDelegate = sTestEventTriggerDelegate,
+        .platformIdentify         = sPlatformIdentify,
     });
 
     auto & deviceFactory = chip::app::DeviceFactory::GetInstance();

--- a/examples/all-devices-app/telink/CMakeLists.txt
+++ b/examples/all-devices-app/telink/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/persistence/DefaultAttributePersistenceProvider.cpp
 
                # all-devices common sources (interfaces, root node base, supported devices)
+               ${ALL_DEVICES_COMMON_DIR}/device/api/PlatformIdentifyIntegration.cpp
                ${ALL_DEVICES_DEVICE_SOURCES}
                ${ALL_DEVICES_CLUSTER_SOURCES})
 

--- a/examples/platform/telink/common/src/AllDevicesServer.cpp
+++ b/examples/platform/telink/common/src/AllDevicesServer.cpp
@@ -29,8 +29,8 @@
 #include <credentials/GroupDataProviderImpl.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
 #include <device-factory/DeviceFactory.h>
-#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/Interface.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/allocator/ConsecutiveEndpointIdAllocator.h>
 #include <device/api/allocator/EndpointIdAllocator.h>
 #include <device/types/root-node/RootNode.h>

--- a/examples/platform/telink/common/src/AllDevicesServer.cpp
+++ b/examples/platform/telink/common/src/AllDevicesServer.cpp
@@ -29,6 +29,7 @@
 #include <credentials/GroupDataProviderImpl.h>
 #include <data-model-providers/codedriven/CodeDrivenDataModelProvider.h>
 #include <device-factory/DeviceFactory.h>
+#include <device/api/PlatformIdentifyIntegration.h>
 #include <device/api/Interface.h>
 #include <device/api/allocator/ConsecutiveEndpointIdAllocator.h>
 #include <device/api/allocator/EndpointIdAllocator.h>
@@ -72,6 +73,7 @@ DefaultAttributePersistenceProvider gAttributePersistenceProvider;
 DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
 DefaultTimerDelegate gTimerDelegate;
+PlatformIdentifyIntegration gPlatformIdentify;
 
 std::unique_ptr<CodeDrivenDataModelProvider> gDataModelProvider;
 std::unique_ptr<DeviceInterface> gRootNodeDevice;
@@ -104,6 +106,7 @@ RootNode::Context MakeRootNodeContext(CommonCaseDeviceServerInitParams & initPar
         .eventManagement                     = EventManagement::GetInstance(),
         .timerDelegate                       = gTimerDelegate,
         .minGuaranteedSubscriptionsPerFabric = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
+        .platformIdentify                    = gPlatformIdentify,
     };
 }
 

--- a/examples/platform/telink/common/src/AllDevicesServer.cpp
+++ b/examples/platform/telink/common/src/AllDevicesServer.cpp
@@ -106,7 +106,6 @@ RootNode::Context MakeRootNodeContext(CommonCaseDeviceServerInitParams & initPar
         .eventManagement                     = EventManagement::GetInstance(),
         .timerDelegate                       = gTimerDelegate,
         .minGuaranteedSubscriptionsPerFabric = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
-        .platformIdentify                    = gPlatformIdentify,
     };
 }
 
@@ -169,6 +168,7 @@ CHIP_ERROR PopulateAllDevicesDataModelProvider(CommonCaseDeviceServerInitParams 
         .bindingTable             = Clusters::Binding::Table::GetInstance(),
         .bindingManager           = Clusters::Binding::Manager::GetInstance(),
         .testEventTriggerDelegate = *initParams.testEventTriggerDelegate,
+        .platformIdentify         = gPlatformIdentify,
     });
 
     VerifyOrReturnError(!gDeviceType.empty(), CHIP_ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
### Summary

This allows hardware specific implementation of the identify behavior.
### Related issues
None

### Testing
Tested with Silicon Labs MG24 and Home Assistant to issue the identify command