### PR TITLE
Fix SmokeCoAlarm attribute range checks in TC-SMOKECO-2.1

### DIFF
--- a/src/python_testing/TC_SMOKECO_2_1.py
+++ b/src/python_testing/TC_SMOKECO_2_1.py
@@ -143,7 +143,7 @@ class TC_SMOKECO_2_1(SmokeCoBaseTest):
 
         self.step(13)
         if await self.feature_guard(endpoint=self.get_endpoint(), cluster=Clusters.SmokeCoAlarm, feature_int=Clusters.SmokeCoAlarm.Bitmaps.Feature.kSmokeAlarm):
-            await self.read_attribute_check_range(self.smokeco_cluster.Attributes.SmokeSensitivityLevel, enum=self.smokeco_enums.AlarmStateEnum)
+            await self.read_attribute_check_range(self.smokeco_cluster.Attributes.SmokeSensitivityLevel, enum=self.smokeco_enums.SensitivityEnum)
         else:
             self.skip_step(13)
 

--- a/src/python_testing/support_modules/smokeco_support.py
+++ b/src/python_testing/support_modules/smokeco_support.py
@@ -114,7 +114,7 @@ class SmokeCoBaseTest(MatterBaseTest):
     async def read_attribute_check_range(self, attribute, enum):
         """Reads an attribute from the SmokeCluster and validate against a range."""
         attr = await self.read_smokeco_attribute_expect_success(attribute=attribute)
-        is_valid = any(attr == item.value and str(item.name).lower() != "unknown" for item in enum)
+        is_valid = any(attr == item.value for item in enum if item is not enum.kUnknownEnumValue)
         asserts.assert_true(is_valid, f"Value {attr} is not in the range for the Enum {enum}")
 
     async def read_attribute_check_bool(self, attribute):


### PR DESCRIPTION
#### Summary

Two defects in TC-SMOKECO-2.1's attribute range checking, both of which make the check pass on values it is meant to reject.

##### Problem

-   `read_attribute_check_range` excluded the sentinel with `str(item.name).lower() != "unknown"`, but the generated member is `kUnknownEnumValue`, whose lowercase form is `"kunknownenumvalue"`. The comparison is therefore always true and the sentinel is counted as in range, so a DUT reporting it passes. The helper is used for ten attributes.
-   Step 13 validated `SmokeSensitivityLevel` against `AlarmStateEnum` instead of `SensitivityEnum`. Both span `0..2`, so the step passed by coincidence rather than by checking the right set.

The test plan already specifies the intended behaviour for step 13 (`smco.adoc`: `DUTreply` a value between 0 and 2); this only aligns the script with it.

##### Solution

-   Compare against the actual generated member name.
-   Pass `SensitivityEnum` for `SmokeSensitivityLevel`.

#### Testing

-   Existing coverage: `TC_SMOKECO_2_1.py` step 13 and the nine other `read_attribute_check_range` call sites, all of which keep passing for in-range values.
-   The predicate change was checked directly against `SensitivityEnum`: values `0`/`1`/`2` are accepted before and after, and `3` (`kUnknownEnumValue`) goes from accepted to rejected.
