### PR TITLE
[Cirque] Update Bazel installation in Docker image

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-209 : [Telink] Update Docker image(Zephyr update)
+210 : [Cirque] Update Bazel installation in Docker image

--- a/integrations/docker/images/stage-2/chip-build-cirque/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-cirque/Dockerfile
@@ -6,10 +6,10 @@ LABEL org.opencontainers.image.source https://github.com/project-chip/connectedh
 RUN set -x \
    && apt-get update \
    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-   curl gnupg \
-   && curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg \
-   && mv bazel.gpg /etc/apt/trusted.gpg.d/ \
-   && echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
+   apt-transport-https curl gnupg \
+   && curl -fsSL https://releases.bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel-archive-keyring.gpg \
+   && mv bazel-archive-keyring.gpg /usr/share/keyrings/ \
+   && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
    && apt-get update \
    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
    bazel \


### PR DESCRIPTION
#### Summary

Updates the Bazel installation steps in the Cirque Docker image to follow current official Ubuntu installation instructions.

##### Problem

- The Bazel GPG key URL (`https://bazel.build/bazel-release.pub.gpg`) previously used in the Dockerfile now returns 404, causing Cirque Docker image builds to fail.
- See https://github.com/bazelbuild/bazel/issues/30604#issuecomment-5204650729

##### Solution

- Switched GPG key download URL to `https://releases.bazel.build/bazel-release.pub.gpg` and stored keyring at `/usr/share/keyrings/bazel-archive-keyring.gpg`.
- Updated repository source to reference `signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg`.
- Installed `apt-transport-https` prerequisite package.
- Bumped docker image version to 210.

#### Testing

- Verified GPG key URL reachability with `curl -fsSLI https://releases.bazel.build/bazel-release.pub.gpg` (HTTP 200 OK).
