### PR TITLE
[PowerTopology] Fix the status and the rollback on a rejected ElectricalCircuitNodes write

### DIFF
--- a/src/app/clusters/power-topology-server/PowerTopologyCluster.cpp
+++ b/src/app/clusters/power-topology-server/PowerTopologyCluster.cpp
@@ -220,6 +220,11 @@ DataModel::ActionReturnStatus PowerTopologyCluster::WriteElectricalCircuitNodes(
         size_t newCount = 0;
         ReturnErrorOnFailure(list.ComputeSize(&newCount));
 
+        // The spec constrains the attribute to "max 50" entries, so a longer list is a constraint
+        // violation regardless of how much room storage has. Capacity() is separate: it may be lowered
+        // by a constrained platform, and only running out of that room is resource exhaustion.
+        VerifyOrReturnValue(newCount <= kMaxCircuitNodes, Status::ConstraintError);
+
         const size_t otherFabricNodeCount = mCircuitNodeStorage->Count() - mCircuitNodeStorage->CountForFabric(fabricIndex);
         VerifyOrReturnValue(otherFabricNodeCount + newCount <= mCircuitNodeStorage->Capacity(), Status::ResourceExhausted);
 
@@ -250,6 +255,7 @@ DataModel::ActionReturnStatus PowerTopologyCluster::WriteElectricalCircuitNodes(
     {
         Structs::CircuitNodeStruct::DecodableType value;
         ReturnErrorOnFailure(decoder.Decode(value));
+        VerifyOrReturnValue(mCircuitNodeStorage->Count() < kMaxCircuitNodes, Status::ConstraintError);
         VerifyOrReturnValue(mCircuitNodeStorage->Count() < mCircuitNodeStorage->Capacity(), Status::ResourceExhausted);
 
         CircuitNodeStorage::Node node;

--- a/src/app/clusters/power-topology-server/PowerTopologyCluster.cpp
+++ b/src/app/clusters/power-topology-server/PowerTopologyCluster.cpp
@@ -149,6 +149,91 @@ void PowerTopologyCluster::Shutdown(ClusterShutdownType shutdownType)
     DefaultServerCluster::Shutdown(shutdownType);
 }
 
+bool PowerTopologyCluster::SnapshotNodesForFabric(FabricIndex fabricIndex)
+{
+    ReleaseNodeSnapshot();
+
+    const size_t count = mCircuitNodeStorage->CountForFabric(fabricIndex);
+    if (count == 0)
+    {
+        // Nothing to preserve, but rolling back to "no entries" is still a valid restore.
+        return true;
+    }
+
+    VerifyOrReturnValue(mNodeSnapshot.Calloc(count), false);
+
+    const size_t total = mCircuitNodeStorage->Count();
+    for (size_t i = 0; i < total && mNodeSnapshotCount < count; i++)
+    {
+        CircuitNodeStorage::Node node;
+        VerifyOrReturnValue(mCircuitNodeStorage->GetNodeAtIndex(i, node) == CHIP_NO_ERROR, false);
+        if (node.fabricIndex == fabricIndex)
+        {
+            mNodeSnapshot[mNodeSnapshotCount++] = node;
+        }
+    }
+
+    // CountForFabric() and the scan must agree, or the snapshot is not the fabric's full slice and
+    // restoring it would silently drop entries.
+    VerifyOrReturnValue(mNodeSnapshotCount == count, false);
+    return true;
+}
+
+void PowerTopologyCluster::ReleaseNodeSnapshot()
+{
+    mNodeSnapshot.Free();
+    mNodeSnapshotCount = 0;
+    mNodeSnapshotValid = false;
+}
+
+void PowerTopologyCluster::ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType,
+                                                          FabricIndex accessingFabric)
+{
+    if (path.mAttributeId != ElectricalCircuitNodes::Id || mCircuitNodeStorage == nullptr)
+    {
+        return;
+    }
+
+    switch (opType)
+    {
+    case DataModel::ListWriteOperation::kListWriteBegin:
+        mNodeSnapshotValid = SnapshotNodesForFabric(accessingFabric);
+        if (!mNodeSnapshotValid)
+        {
+            ChipLogError(Zcl,
+                         "PowerTopology: could not snapshot ElectricalCircuitNodes for fabric 0x%x; a failed write to it "
+                         "will not be rolled back",
+                         static_cast<unsigned>(accessingFabric));
+            ReleaseNodeSnapshot();
+        }
+        break;
+
+    case DataModel::ListWriteOperation::kListWriteFailure:
+        if (mNodeSnapshotValid)
+        {
+            const CHIP_ERROR err =
+                mCircuitNodeStorage->ReplaceNodesForFabric(accessingFabric, mNodeSnapshot.Get(), mNodeSnapshotCount);
+            if (err == CHIP_NO_ERROR)
+            {
+                // Earlier blocks of this write already reported their intermediate values, so the
+                // restored one has to be reported too.
+                NotifyAttributeChanged(ElectricalCircuitNodes::Id);
+            }
+            else
+            {
+                ChipLogError(Zcl, "PowerTopology: failed to roll back ElectricalCircuitNodes for fabric 0x%x: %" CHIP_ERROR_FORMAT,
+                             static_cast<unsigned>(accessingFabric), err.Format());
+            }
+        }
+        ReleaseNodeSnapshot();
+        break;
+
+    case DataModel::ListWriteOperation::kListWriteSuccess:
+        ReleaseNodeSnapshot();
+        break;
+    }
+}
+
 void PowerTopologyCluster::OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex)
 {
     VerifyOrReturn(mCircuitNodeStorage != nullptr);

--- a/src/app/clusters/power-topology-server/PowerTopologyCluster.cpp
+++ b/src/app/clusters/power-topology-server/PowerTopologyCluster.cpp
@@ -149,7 +149,7 @@ void PowerTopologyCluster::Shutdown(ClusterShutdownType shutdownType)
     DefaultServerCluster::Shutdown(shutdownType);
 }
 
-bool PowerTopologyCluster::SnapshotNodesForFabric(FabricIndex fabricIndex)
+CHIP_ERROR PowerTopologyCluster::SnapshotNodesForFabric(FabricIndex fabricIndex)
 {
     ReleaseNodeSnapshot();
 
@@ -157,16 +157,16 @@ bool PowerTopologyCluster::SnapshotNodesForFabric(FabricIndex fabricIndex)
     if (count == 0)
     {
         // Nothing to preserve, but rolling back to "no entries" is still a valid restore.
-        return true;
+        return CHIP_NO_ERROR;
     }
 
-    VerifyOrReturnValue(mNodeSnapshot.Calloc(count), false);
+    VerifyOrReturnError(mNodeSnapshot.Calloc(count), CHIP_ERROR_NO_MEMORY);
 
     const size_t total = mCircuitNodeStorage->Count();
     for (size_t i = 0; i < total && mNodeSnapshotCount < count; i++)
     {
         CircuitNodeStorage::Node node;
-        VerifyOrReturnValue(mCircuitNodeStorage->GetNodeAtIndex(i, node) == CHIP_NO_ERROR, false);
+        ReturnErrorOnFailure(mCircuitNodeStorage->GetNodeAtIndex(i, node));
         if (node.fabricIndex == fabricIndex)
         {
             mNodeSnapshot[mNodeSnapshotCount++] = node;
@@ -175,8 +175,8 @@ bool PowerTopologyCluster::SnapshotNodesForFabric(FabricIndex fabricIndex)
 
     // CountForFabric() and the scan must agree, or the snapshot is not the fabric's full slice and
     // restoring it would silently drop entries.
-    VerifyOrReturnValue(mNodeSnapshotCount == count, false);
-    return true;
+    VerifyOrReturnError(mNodeSnapshotCount == count, CHIP_ERROR_INTERNAL);
+    return CHIP_NO_ERROR;
 }
 
 void PowerTopologyCluster::ReleaseNodeSnapshot()
@@ -196,17 +196,19 @@ void PowerTopologyCluster::ListAttributeWriteNotification(const ConcreteAttribut
 
     switch (opType)
     {
-    case DataModel::ListWriteOperation::kListWriteBegin:
-        mNodeSnapshotValid = SnapshotNodesForFabric(accessingFabric);
+    case DataModel::ListWriteOperation::kListWriteBegin: {
+        const CHIP_ERROR err = SnapshotNodesForFabric(accessingFabric);
+        mNodeSnapshotValid   = (err == CHIP_NO_ERROR);
         if (!mNodeSnapshotValid)
         {
             ChipLogError(Zcl,
-                         "PowerTopology: could not snapshot ElectricalCircuitNodes for fabric 0x%x; a failed write to it "
-                         "will not be rolled back",
-                         static_cast<unsigned>(accessingFabric));
+                         "PowerTopology: could not snapshot ElectricalCircuitNodes for fabric 0x%x, so a failed write to "
+                         "it will not be rolled back: %" CHIP_ERROR_FORMAT,
+                         static_cast<unsigned>(accessingFabric), err.Format());
             ReleaseNodeSnapshot();
         }
         break;
+    }
 
     case DataModel::ListWriteOperation::kListWriteFailure:
         if (mNodeSnapshotValid)

--- a/src/app/clusters/power-topology-server/PowerTopologyCluster.h
+++ b/src/app/clusters/power-topology-server/PowerTopologyCluster.h
@@ -94,9 +94,9 @@ private:
     bool DecodeCircuitNode(const Structs::CircuitNodeStruct::DecodableType & decoded, FabricIndex fabricIndex,
                            CircuitNodeStorage::Node & out) const;
 
-    // Copies the accessing fabric's entries aside for the duration of a list write. Returns false if
-    // the copy could not be taken, in which case a failed write cannot be rolled back.
-    bool SnapshotNodesForFabric(FabricIndex fabricIndex);
+    // Copies the accessing fabric's entries aside for the duration of a list write. On error the
+    // copy was not taken and a failed write cannot be rolled back.
+    CHIP_ERROR SnapshotNodesForFabric(FabricIndex fabricIndex);
     void ReleaseNodeSnapshot();
 
     // FabricTable::Delegate: purge a removed fabric's ElectricalCircuitNodes entries (fabric-scoped data).

--- a/src/app/clusters/power-topology-server/PowerTopologyCluster.h
+++ b/src/app/clusters/power-topology-server/PowerTopologyCluster.h
@@ -27,6 +27,7 @@
 #include <credentials/FabricTable.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
+#include <lib/support/ScopedMemoryBuffer.h>
 
 #include <cstddef>
 
@@ -80,12 +81,23 @@ public:
 
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
+    /// Brackets a list write so a failed one can be undone. A client writes a list as ReplaceAll
+    /// followed by one AppendItem per entry, and each of those arrives as its own WriteAttribute
+    /// call; without this the entries already applied when a later one is rejected would stay.
+    void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType,
+                                        FabricIndex accessingFabric) override;
+
 private:
     // ElectricalCircuitNodes (CIRC): fabric-scoped, writable, non-volatile list.
     DataModel::ActionReturnStatus WriteElectricalCircuitNodes(const DataModel::WriteAttributeRequest & request,
                                                               AttributeValueDecoder & decoder);
     bool DecodeCircuitNode(const Structs::CircuitNodeStruct::DecodableType & decoded, FabricIndex fabricIndex,
                            CircuitNodeStorage::Node & out) const;
+
+    // Copies the accessing fabric's entries aside for the duration of a list write. Returns false if
+    // the copy could not be taken, in which case a failed write cannot be rolled back.
+    bool SnapshotNodesForFabric(FabricIndex fabricIndex);
+    void ReleaseNodeSnapshot();
 
     // FabricTable::Delegate: purge a removed fabric's ElectricalCircuitNodes entries (fabric-scoped data).
     void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override;
@@ -95,8 +107,16 @@ private:
     FabricTable * mFabricTable;
 
     // Not owned. Non-null whenever the CIRC feature is enabled (checked at Startup). The cluster
-    // performs no allocation of its own for ElectricalCircuitNodes.
+    // holds no ElectricalCircuitNodes entries of its own; it allocates only for the duration of a
+    // single write, to stage the incoming list and to hold the rollback snapshot below.
     CircuitNodeStorage * mCircuitNodeStorage;
+
+    // The accessing fabric's entries as they were when the current list write began, restored if
+    // that write fails. Empty outside a list write. mNodeSnapshotValid distinguishes "the fabric
+    // had no entries" from "the snapshot could not be taken", since only the former may be restored.
+    Platform::ScopedMemoryBuffer<CircuitNodeStorage::Node> mNodeSnapshot;
+    size_t mNodeSnapshotCount = 0;
+    bool mNodeSnapshotValid   = false;
 };
 
 } // namespace chip::app::Clusters::PowerTopology

--- a/src/app/clusters/power-topology-server/tests/TestPowerTopologyCluster.cpp
+++ b/src/app/clusters/power-topology-server/tests/TestPowerTopologyCluster.cpp
@@ -873,7 +873,7 @@ TEST_F(TestPowerTopologyCluster, WriteElectricalCircuitNodesLabelTooLongTest)
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
-// Writing more nodes than the list maximum is rejected with ResourceExhausted.
+// Filling the storage's capacity, without exceeding the spec maximum, is ResourceExhausted.
 TEST_F(TestPowerTopologyCluster, WriteElectricalCircuitNodesResourceExhaustedTest)
 {
     chip::Testing::TestServerClusterContext context;
@@ -893,16 +893,60 @@ TEST_F(TestPowerTopologyCluster, WriteElectricalCircuitNodesResourceExhaustedTes
 
     ClusterTester tester(cluster);
 
+    // One past this storage's capacity, but still within the spec maximum, so this exercises
+    // capacity rather than the "max 50" constraint.
     std::vector<Structs::CircuitNodeStruct::Type> tooMany;
-    for (size_t i = 0; i < PowerTopologyCluster::kMaxCircuitNodes + 1; i++)
+    for (size_t i = 0; i < circuitStorage9.Capacity() + 1; i++)
     {
         tooMany.push_back(MakeCircuitNode(static_cast<NodeId>(i + 1), NullOptional, NullOptional));
     }
+    ASSERT_LE(tooMany.size(), PowerTopologyCluster::kMaxCircuitNodes);
 
     EXPECT_EQ(tester.WriteAttribute(ElectricalCircuitNodes::Id,
                                     DataModel::List<Structs::CircuitNodeStruct::Type>(tooMany.data(), tooMany.size()),
                                     ListWritingPattern::ReplaceAll),
               IMStatus::ResourceExhausted);
+
+    // The rejected write must not have mutated state.
+    ElectricalCircuitNodes::TypeInfo::DecodableType nodes;
+    EXPECT_TRUE(tester.ReadAttribute(ElectricalCircuitNodes::Id, nodes).IsSuccess());
+    auto iter = nodes.begin();
+    EXPECT_FALSE(iter.Next());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// A list longer than the spec's "max 50" is a constraint violation, not resource exhaustion, and is
+// rejected on that basis even though this storage runs out of room long before 50.
+TEST_F(TestPowerTopologyCluster, WriteElectricalCircuitNodesOverSpecMaximumIsConstraintError)
+{
+    chip::Testing::TestServerClusterContext context;
+    chip::Testing::FabricTestFixture fabricHelper{ &context.StorageDelegate() };
+    BitMask<Feature> features(Feature::kElectricalCircuit);
+    FixedCircuitNodeStorage circuitStorage9;
+    MockPowerTopologyDelegate dummyDelegate;
+
+    PowerTopologyCluster cluster(PowerTopologyCluster::Config{
+        .endpointId         = kTestEndpointId,
+        .delegate           = dummyDelegate,
+        .features           = features,
+        .fabricTable        = &fabricHelper.GetFabricTable(),
+        .circuitNodeStorage = &circuitStorage9,
+    });
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+
+    std::vector<Structs::CircuitNodeStruct::Type> overSpecMax;
+    for (size_t i = 0; i < PowerTopologyCluster::kMaxCircuitNodes + 1; i++)
+    {
+        overSpecMax.push_back(MakeCircuitNode(static_cast<NodeId>(i + 1), NullOptional, NullOptional));
+    }
+
+    EXPECT_EQ(tester.WriteAttribute(ElectricalCircuitNodes::Id,
+                                    DataModel::List<Structs::CircuitNodeStruct::Type>(overSpecMax.data(), overSpecMax.size()),
+                                    ListWritingPattern::ReplaceAll),
+              IMStatus::ConstraintError);
 
     // The rejected write must not have mutated state.
     ElectricalCircuitNodes::TypeInfo::DecodableType nodes;

--- a/src/app/clusters/power-topology-server/tests/TestPowerTopologyCluster.cpp
+++ b/src/app/clusters/power-topology-server/tests/TestPowerTopologyCluster.cpp
@@ -957,6 +957,112 @@ TEST_F(TestPowerTopologyCluster, WriteElectricalCircuitNodesOverSpecMaximumIsCon
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
+// A client writes a list as ReplaceAll([]) followed by one AppendItem per entry, and each block
+// arrives as its own WriteAttribute call. The ReplaceAll has therefore already cleared the fabric's
+// slice by the time a later entry is rejected, so without the failure notification the write would
+// leave the attribute empty rather than unchanged. WriteHandler brackets the sequence; the tester
+// does not, so this drives the notifications the way WriteHandler would.
+TEST_F(TestPowerTopologyCluster, FailedChunkedListWriteRollsBackToThePreviousNodes)
+{
+    chip::Testing::TestServerClusterContext context;
+    chip::Testing::FabricTestFixture fabricHelper{ &context.StorageDelegate() };
+    BitMask<Feature> features(Feature::kElectricalCircuit);
+    FixedCircuitNodeStorage circuitStorage10;
+    MockPowerTopologyDelegate dummyDelegate;
+
+    PowerTopologyCluster cluster(PowerTopologyCluster::Config{
+        .endpointId         = kTestEndpointId,
+        .delegate           = dummyDelegate,
+        .features           = features,
+        .fabricTable        = &fabricHelper.GetFabricTable(),
+        .circuitNodeStorage = &circuitStorage10,
+    });
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    const ConcreteAttributePath listPath(kTestEndpointId, PowerTopology::Id, ElectricalCircuitNodes::Id);
+
+    // Seed a value that the failed write must not destroy.
+    Structs::CircuitNodeStruct::Type seeded[] = {
+        MakeCircuitNode(0xA1A1, MakeOptional<EndpointId>(static_cast<EndpointId>(3)),
+                        MakeOptional(CharSpan::fromCharString("keep-me"))),
+    };
+    EXPECT_EQ(tester.WriteAttribute(ElectricalCircuitNodes::Id, DataModel::List<Structs::CircuitNodeStruct::Type>(seeded),
+                                    ListWritingPattern::ReplaceAll),
+              IMStatus::Success);
+
+    std::string tooLong(PowerTopologyCluster::kMaxNodeLabelLength + 1, 'x');
+    Structs::CircuitNodeStruct::Type rejected[] = {
+        MakeCircuitNode(0xB2B2, NullOptional, MakeOptional(CharSpan(tooLong.data(), tooLong.size()))),
+    };
+
+    cluster.ListAttributeWriteNotification(listPath, DataModel::ListWriteOperation::kListWriteBegin, kTestFabricIndex);
+    EXPECT_EQ(tester.WriteAttribute(ElectricalCircuitNodes::Id, DataModel::List<Structs::CircuitNodeStruct::Type>(rejected),
+                                    ListWritingPattern::ClearAllThenAppendItems),
+              IMStatus::ConstraintError);
+    cluster.ListAttributeWriteNotification(listPath, DataModel::ListWriteOperation::kListWriteFailure, kTestFabricIndex);
+
+    ElectricalCircuitNodes::TypeInfo::DecodableType nodes;
+    EXPECT_TRUE(tester.ReadAttribute(ElectricalCircuitNodes::Id, nodes).IsSuccess());
+    auto iter = nodes.begin();
+    ASSERT_TRUE(iter.Next());
+    EXPECT_EQ(iter.GetValue().node, static_cast<NodeId>(0xA1A1));
+    ASSERT_TRUE(iter.GetValue().endpoint.HasValue());
+    EXPECT_EQ(iter.GetValue().endpoint.Value(), static_cast<EndpointId>(3));
+    ASSERT_TRUE(iter.GetValue().label.HasValue());
+    EXPECT_TRUE(iter.GetValue().label.Value().data_equal(CharSpan::fromCharString("keep-me")));
+    EXPECT_FALSE(iter.Next());
+    EXPECT_EQ(iter.GetStatus(), CHIP_NO_ERROR);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// A chunked write that succeeds must keep what it wrote: the snapshot taken at the start of the
+// sequence is dropped, not restored, when the success notification arrives.
+TEST_F(TestPowerTopologyCluster, SuccessfulChunkedListWriteKeepsTheNewNodes)
+{
+    chip::Testing::TestServerClusterContext context;
+    chip::Testing::FabricTestFixture fabricHelper{ &context.StorageDelegate() };
+    BitMask<Feature> features(Feature::kElectricalCircuit);
+    FixedCircuitNodeStorage circuitStorage11;
+    MockPowerTopologyDelegate dummyDelegate;
+
+    PowerTopologyCluster cluster(PowerTopologyCluster::Config{
+        .endpointId         = kTestEndpointId,
+        .delegate           = dummyDelegate,
+        .features           = features,
+        .fabricTable        = &fabricHelper.GetFabricTable(),
+        .circuitNodeStorage = &circuitStorage11,
+    });
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    const ConcreteAttributePath listPath(kTestEndpointId, PowerTopology::Id, ElectricalCircuitNodes::Id);
+
+    Structs::CircuitNodeStruct::Type seeded[] = { MakeCircuitNode(0xA1A1, NullOptional, NullOptional) };
+    EXPECT_EQ(tester.WriteAttribute(ElectricalCircuitNodes::Id, DataModel::List<Structs::CircuitNodeStruct::Type>(seeded),
+                                    ListWritingPattern::ReplaceAll),
+              IMStatus::Success);
+
+    Structs::CircuitNodeStruct::Type replacement[] = { MakeCircuitNode(0xC3C3, NullOptional, NullOptional) };
+
+    cluster.ListAttributeWriteNotification(listPath, DataModel::ListWriteOperation::kListWriteBegin, kTestFabricIndex);
+    EXPECT_EQ(tester.WriteAttribute(ElectricalCircuitNodes::Id, DataModel::List<Structs::CircuitNodeStruct::Type>(replacement),
+                                    ListWritingPattern::ClearAllThenAppendItems),
+              IMStatus::Success);
+    cluster.ListAttributeWriteNotification(listPath, DataModel::ListWriteOperation::kListWriteSuccess, kTestFabricIndex);
+
+    ElectricalCircuitNodes::TypeInfo::DecodableType nodes;
+    EXPECT_TRUE(tester.ReadAttribute(ElectricalCircuitNodes::Id, nodes).IsSuccess());
+    auto iter = nodes.begin();
+    ASSERT_TRUE(iter.Next());
+    EXPECT_EQ(iter.GetValue().node, static_cast<NodeId>(0xC3C3));
+    EXPECT_FALSE(iter.Next());
+    EXPECT_EQ(iter.GetStatus(), CHIP_NO_ERROR);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
 // DefaultCircuitNodeStorage owns the persistence that used to live in the cluster, so it needs its
 // own round-trip coverage: the cluster-level tests above deliberately use a non-persisting storage.
 TEST_F(TestPowerTopologyCluster, DefaultCircuitNodeStoragePersistsAcrossInstances)


### PR DESCRIPTION
#### Summary

Two write-path defects on `ElectricalCircuitNodes`, both surfaced by running `TC_PWRTL_2_2.py` (#72280) against the example app.

##### Problem

**1. The spec maximum was conflated with storage capacity.** The write path checked the incoming list only against `CircuitNodeStorage::Capacity()`:

```cpp
VerifyOrReturnValue(otherFabricNodeCount + newCount <= mCircuitNodeStorage->Capacity(), Status::ResourceExhausted);
```

`Capacity()` is not the spec maximum. It is a storage limit a constrained platform is explicitly invited to lower, so the two conditions are distinct:

- a list longer than the spec's `max 50` is a **constraint violation**, whatever room storage has;
- running out of that room is **resource exhaustion**.

Conflating them returned `RESOURCE_EXHAUSTED` where the spec calls for `CONSTRAINT_ERROR`.

**2. A rejected list write destroyed the accessing fabric's entries.** A client writes a list as `ReplaceAll` followed by one `AppendItem` per entry, and each block arrives as a separate `WriteAttribute` call:

```
ReplaceAll([])   -> Success   accessing fabric's slice is now empty
AppendItem(a)    -> Success
AppendItem(bad)  -> ConstraintError
                    write fails, but the slice stays empty
```

Staging inside a single `ReplaceAll` does not help here, because the damage is done by an earlier block. The attribute was left **empty** rather than unchanged, which is what the merged test plan requires for both of its negative write steps.

##### Solution

- Check the spec maximum before the capacity limit, on both the `ReplaceAll` and `AppendItem` paths, so each condition reports its own status.
- Take the accessing fabric's entries aside on `kListWriteBegin` and restore them on `kListWriteFailure`, which is what that notification exists for. Only that fabric's slice is touched, and a restore reports the attribute as changed, since earlier blocks of the same write already reported intermediate values.

##### Caveats

If the snapshot cannot be allocated, the write proceeds without rollback and the reason is logged, rather than failing a write that would otherwise succeed.

#### Testing

- `TestPowerTopologyCluster.cpp`: added `WriteElectricalCircuitNodesOverSpecMaximumIsConstraintError`, `FailedChunkedListWriteRollsBackToThePreviousNodes` and `SuccessfulChunkedListWriteKeepsTheNewNodes`; updated `WriteElectricalCircuitNodesResourceExhaustedTest`, which previously wrote 51 entries into a storage of test capacity 8 and so never distinguished the two conditions. 27 tests pass.
- Ran `TC_PWRTL_2_2.py` against a locally built `chip-evse-app` carrying these changes, which is how both defects were found: step 4 returned `RESOURCE_EXHAUSTED`, and step 7 left the attribute empty after a rejected over-length `Label`.
