### PR TITLE
Replace custom enum for Set in OptionalCommands

### DIFF
--- a/examples/evse-app/evse-common/include/EnergyEvseManager.h
+++ b/examples/evse-app/evse-common/include/EnergyEvseManager.h
@@ -32,7 +32,7 @@ class EnergyEvseManager : public Instance
 {
 public:
     EnergyEvseManager(EndpointId aEndpointId, EnergyEvseDelegate & aDelegate, Feature aFeature, OptionalAttributes aOptionalAttrs,
-                      OptionalCommands aOptionalCmds) :
+                      EnergyEvseCluster::OptionalCommandSet aOptionalCmds) :
         EnergyEvse::Instance(aEndpointId, aDelegate, aFeature, aOptionalAttrs, aOptionalCmds)
     {
         mDelegate = &aDelegate;

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -109,7 +109,7 @@ CHIP_ERROR EnergyEvseInit(chip::EndpointId endpointId)
         BitMask<EnergyEvse::OptionalAttributes, uint32_t>(EnergyEvse::OptionalAttributes::kSupportsUserMaximumChargingCurrent,
                                                           EnergyEvse::OptionalAttributes::kSupportsRandomizationWindow,
                                                           EnergyEvse::OptionalAttributes::kSupportsApproximateEvEfficiency),
-        BitMask<EnergyEvse::OptionalCommands, uint32_t>(EnergyEvse::OptionalCommands::kSupportsStartDiagnostics));
+        EnergyEvseCluster::OptionalCommandSet().Set<EnergyEvse::Commands::StartDiagnostics::Id>());
 
     if (!gEvseInstance)
     {

--- a/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
+++ b/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
@@ -27,7 +27,7 @@ namespace Clusters {
 namespace EnergyEvse {
 
 Instance::Instance(EndpointId aEndpointId, Delegate & aDelegate, Feature aFeature, OptionalAttributes aOptionalAttrs,
-                   OptionalCommands aOptionalCmds) :
+                   EnergyEvseCluster::OptionalCommandSet aOptionalCmds) :
     mCluster(EnergyEvseCluster::Config(aEndpointId, aDelegate, aFeature, aOptionalAttrs, aOptionalCmds))
 {}
 
@@ -64,9 +64,9 @@ bool Instance::SupportsOptAttr(OptionalAttributes aOptionalAttrs) const
     return mCluster.Cluster().OptionalAttrs().Has(aOptionalAttrs);
 }
 
-bool Instance::SupportsOptCmd(OptionalCommands aOptionalCmds) const
+bool Instance::SupportsStartDiagnostics() const
 {
-    return mCluster.Cluster().OptionalCmds().Has(aOptionalCmds);
+    return mCluster.Cluster().SupportsStartDiagnostics();
 }
 
 StateEnum Instance::GetState() const

--- a/src/app/clusters/energy-evse-server/CodegenIntegration.h
+++ b/src/app/clusters/energy-evse-server/CodegenIntegration.h
@@ -31,14 +31,14 @@ class Instance
 {
 public:
     Instance(EndpointId aEndpointId, Delegate & aDelegate, Feature aFeature, OptionalAttributes aOptionalAttrs,
-             OptionalCommands aOptionalCmds);
+             EnergyEvseCluster::OptionalCommandSet aOptionalCmds);
 
     CHIP_ERROR Init();
     void Shutdown();
 
     bool HasFeature(Feature aFeature) const;
     bool SupportsOptAttr(OptionalAttributes aOptionalAttrs) const;
-    bool SupportsOptCmd(OptionalCommands aOptionalCmds) const;
+    bool SupportsStartDiagnostics() const;
 
     // Attribute accessors - pass through to cluster
     StateEnum GetState() const;

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
@@ -440,7 +440,7 @@ CHIP_ERROR EnergyEvseCluster::AcceptedCommands(const ConcreteClusterPath & path,
     {
         ReturnErrorOnFailure(builder.AppendElements({ EnableDischarging::kMetadataEntry }));
     }
-    if (mOptionalCmds.Has(OptionalCommands::kSupportsStartDiagnostics))
+    if (SupportsStartDiagnostics())
     {
         ReturnErrorOnFailure(builder.AppendElements({ StartDiagnostics::kMetadataEntry }));
     }

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -44,25 +44,23 @@ enum class OptionalAttributes : uint32_t
     kSupportsApproximateEvEfficiency    = 0x4
 };
 
-enum class OptionalCommands : uint32_t
-{
-    kSupportsStartDiagnostics = 0x1
-};
-
 class EnergyEvseCluster : public DefaultServerCluster
 {
 
 public:
+    /// Commands that this cluster supports only if the application opts into them.
+    using OptionalCommandSet = app::OptionalAttributeSet<Commands::StartDiagnostics::Id>;
+
     struct Config
     {
         EndpointId endpointId;
         EnergyEvse::Delegate & delegate;
         BitMask<EnergyEvse::Feature> feature;
-        BitMask<EnergyEvse::OptionalCommands> optionalCmds;
+        OptionalCommandSet optionalCmds;
         BitMask<EnergyEvse::OptionalAttributes> optionalAttrs;
 
         Config(EndpointId aEndpointId, EnergyEvse::Delegate & aDelegate, BitMask<EnergyEvse::Feature> aFeature,
-               BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, BitMask<EnergyEvse::OptionalCommands> aOptionalCmds) :
+               BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, OptionalCommandSet aOptionalCmds) :
             endpointId(aEndpointId),
             delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds), optionalAttrs(aOptionalAttrs)
         {}
@@ -84,7 +82,9 @@ public:
 
     const BitFlags<EnergyEvse::Feature> & Features() const { return mFeatureFlags; }
     const BitFlags<EnergyEvse::OptionalAttributes> & OptionalAttrs() const { return mOptionalAttrs; }
-    const BitFlags<EnergyEvse::OptionalCommands> & OptionalCmds() const { return mOptionalCmds; }
+
+    /// StartDiagnostics is optionally conformant and only accepted when the application opts into it.
+    bool SupportsStartDiagnostics() const { return mOptionalCmds.IsSet(Commands::StartDiagnostics::Id); }
 
     // Attribute getters and setters - cluster owns the data
     StateEnum GetState() const { return mState; }
@@ -192,7 +192,7 @@ private:
     EnergyEvse::Delegate & mDelegate;
     const BitFlags<EnergyEvse::Feature> mFeatureFlags;
     const BitFlags<EnergyEvse::OptionalAttributes> mOptionalAttrs;
-    const BitFlags<EnergyEvse::OptionalCommands> mOptionalCmds;
+    const OptionalCommandSet mOptionalCmds;
 
     // Attribute storage
     StateEnum mState                                       = StateEnum::kNotPluggedIn;

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
@@ -66,7 +66,7 @@ TEST_F(TestEnergyEvseCluster, TestFeatures)
         // ChargingPreferences feature is mandatory
         BitMask<Feature> minimumFeatures(Feature::kChargingPreferences);
         BitMask<OptionalAttributes> optionalAttributes;
-        BitMask<OptionalCommands> optionalCommands;
+        EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, minimumFeatures, optionalAttributes, optionalCommands));
@@ -116,7 +116,7 @@ TEST_F(TestEnergyEvseCluster, TestFeatures)
     {
         BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
         BitMask<OptionalAttributes> optionalAttributes;
-        BitMask<OptionalCommands> optionalCommands;
+        EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
@@ -178,7 +178,8 @@ TEST_F(TestEnergyEvseCluster, TestFeatures)
         BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
                                                        OptionalAttributes::kSupportsRandomizationWindow,
                                                        OptionalAttributes::kSupportsApproximateEvEfficiency);
-        BitMask<OptionalCommands> optionalCommands(OptionalCommands::kSupportsStartDiagnostics);
+        EnergyEvseCluster::OptionalCommandSet optionalCommands =
+            EnergyEvseCluster::OptionalCommandSet().Set<Commands::StartDiagnostics::Id>();
 
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
@@ -250,7 +251,7 @@ TEST_F(TestEnergyEvseCluster, TestStartupFailsWithMismatchedEndpointId)
     MockEvseDelegate mockDelegate;
     BitMask<Feature> noFeatures;
     BitMask<OptionalAttributes> optionalAttributes;
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     constexpr EndpointId kClusterEndpointId  = 1;
     constexpr EndpointId kDelegateEndpointId = 2;
@@ -273,7 +274,7 @@ TEST_F(TestEnergyEvseCluster, TestStartupSucceedsWithMatchingEndpointId)
     MockEvseDelegate mockDelegate;
     BitMask<Feature> noFeatures;
     BitMask<OptionalAttributes> optionalAttributes;
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
     constexpr EndpointId kEndpointId = 1;
 
     // Create cluster with endpoint ID
@@ -301,7 +302,7 @@ TEST_F(TestEnergyEvseCluster, TestAttributesMinimalConfig)
     MockEvseDelegate mockDelegate;
     BitMask<Feature> noFeatures;
     BitMask<OptionalAttributes> optionalAttributes;
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
@@ -378,7 +379,7 @@ TEST_F(TestEnergyEvseCluster, TestAttributesFullConfig)
     BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
                                                    OptionalAttributes::kSupportsRandomizationWindow,
                                                    OptionalAttributes::kSupportsApproximateEvEfficiency);
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
@@ -499,7 +500,7 @@ TEST_F(TestEnergyEvseCluster, TestWriteAttributes)
     BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
                                                    OptionalAttributes::kSupportsRandomizationWindow,
                                                    OptionalAttributes::kSupportsApproximateEvEfficiency);
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
@@ -559,7 +560,7 @@ TEST_F(TestEnergyEvseCluster, TestWriteAttributesNotifiesChange)
     BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
                                                    OptionalAttributes::kSupportsRandomizationWindow,
                                                    OptionalAttributes::kSupportsApproximateEvEfficiency);
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
@@ -607,7 +608,7 @@ TEST_F(TestEnergyEvseCluster, TestWriteReadOnlyAttributesFails)
     BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
                                                    OptionalAttributes::kSupportsRandomizationWindow,
                                                    OptionalAttributes::kSupportsApproximateEvEfficiency);
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
@@ -672,7 +673,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
     BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
                                                    OptionalAttributes::kSupportsRandomizationWindow,
                                                    OptionalAttributes::kSupportsApproximateEvEfficiency);
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
@@ -775,7 +776,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetNoOpWhenSameValue)
     MockEvseDelegate mockDelegate;
     BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
     BitMask<OptionalAttributes> optionalAttributes;
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
@@ -844,7 +845,7 @@ TEST_F(TestEnergyEvseCluster, TestDisable)
     MockEvseDelegate mockDelegate;
     BitMask<Feature> noFeatures;
     BitMask<OptionalAttributes> optionalAttributes;
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
@@ -872,7 +873,7 @@ TEST_F(TestEnergyEvseCluster, TestEnableCharging)
     MockEvseDelegate mockDelegate;
     BitMask<Feature> noFeatures;
     BitMask<OptionalAttributes> optionalAttributes;
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
@@ -973,7 +974,7 @@ TEST_F(TestEnergyEvseCluster, TestEnableDischarging)
     MockEvseDelegate mockDelegate;
     BitMask<Feature> features(Feature::kV2x); // V2x feature enables discharging
     BitMask<OptionalAttributes> optionalAttributes;
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, features, optionalAttributes, optionalCommands));
@@ -1059,7 +1060,8 @@ TEST_F(TestEnergyEvseCluster, TestStartDiagnostics)
     BitMask<OptionalAttributes> optionalAttributes;
     // Test with command supported
     {
-        BitMask<OptionalCommands> optionalCommands(OptionalCommands::kSupportsStartDiagnostics);
+        EnergyEvseCluster::OptionalCommandSet optionalCommands =
+            EnergyEvseCluster::OptionalCommandSet().Set<Commands::StartDiagnostics::Id>();
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
         mockDelegate.SetCluster(cluster);
@@ -1082,7 +1084,7 @@ TEST_F(TestEnergyEvseCluster, TestStartDiagnostics)
     }
     // Test with command not supported
     {
-        BitMask<OptionalCommands> optionalCommands;
+        EnergyEvseCluster::OptionalCommandSet optionalCommands;
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
         mockDelegate.SetCluster(cluster);
@@ -1111,7 +1113,7 @@ TEST_F(TestEnergyEvseCluster, TestTargetsCommands)
     // SoCReporting feature requires TargetSoC to be present
     BitMask<Feature> features(Feature::kChargingPreferences, Feature::kSoCReporting);
     BitMask<OptionalAttributes> optionalAttributes;
-    BitMask<OptionalCommands> optionalCommands;
+    EnergyEvseCluster::OptionalCommandSet optionalCommands;
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, features, optionalAttributes, optionalCommands));

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseClusterBackwardsCompatibility.cpp
@@ -49,7 +49,7 @@ TEST_F(TestEvseClusterBackwardsCompatibility, TestInstanceLifecycle)
         BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kSoCReporting, Feature::kPlugAndCharge, Feature::kRfid,
                                      Feature::kV2x);
         BitMask<OptionalAttributes> optionalAttrs;
-        BitMask<OptionalCommands> optionalCmds;
+        EnergyEvseCluster::OptionalCommandSet optionalCmds;
 
         Instance instance(kTestEndpointId, mockDelegate, allFeatures, optionalAttrs, optionalCmds);
 
@@ -82,7 +82,7 @@ TEST_F(TestEvseClusterBackwardsCompatibility, TestInstanceLifecycle)
         MockEvseDelegate mockDelegate;
         BitMask<Feature> noFeatures;
         BitMask<OptionalAttributes> optionalAttrs;
-        BitMask<OptionalCommands> optionalCmds;
+        EnergyEvseCluster::OptionalCommandSet optionalCmds;
 
         Instance instance(kTestEndpointId, mockDelegate, noFeatures, optionalAttrs, optionalCmds);
 

--- a/src/app/clusters/icd-management-server/CodegenIntegration.cpp
+++ b/src/app/clusters/icd-management-server/CodegenIntegration.cpp
@@ -38,12 +38,12 @@ LazyRegisteredServerCluster<ICDManagementClusterWithCIP> gServer;
 LazyRegisteredServerCluster<ICDManagementCluster> gServer;
 #endif
 
-constexpr chip::BitMask<OptionalCommands> kEnabledCommands()
+constexpr ICDManagementCluster::OptionalCommandSet kEnabledCommands()
 {
 #if defined(ICD_MANAGEMENT_STAY_ACTIVE_REQUEST_COMMAND)
-    return chip::BitMask<OptionalCommands>(kStayActive);
+    return ICDManagementCluster::OptionalCommandSet().Set<Commands::StayActiveRequest::Id>();
 #else
-    return chip::BitMask<OptionalCommands>();
+    return ICDManagementCluster::OptionalCommandSet();
 #endif
 }
 
@@ -54,7 +54,7 @@ public:
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
         ICDManagementCluster::OptionalAttributeSet optionalAttributeSet(optionalAttributeBits);
-        constexpr BitMask<OptionalCommands> enabledCommands = kEnabledCommands();
+        constexpr ICDManagementCluster::OptionalCommandSet enabledCommands = kEnabledCommands();
 
         // Get UserActiveModeTriggerHint
         BitMask<IcdManagement::UserActiveModeTriggerBitmap> userActiveModeTriggerHint(0);

--- a/src/app/clusters/icd-management-server/ICDManagementCluster.cpp
+++ b/src/app/clusters/icd-management-server/ICDManagementCluster.cpp
@@ -90,8 +90,7 @@ void ICDManagementFabricDelegate::OnFabricRemoved(const FabricTable & fabricTabl
 
 ICDManagementCluster::ICDManagementCluster(EndpointId endpointId, Crypto::SymmetricKeystore & symmetricKeystore,
                                            FabricTable & fabricTable, ICDConfigurationData & icdConfigurationData,
-                                           OptionalAttributeSet optionalAttributeSet,
-                                           BitMask<IcdManagement::OptionalCommands> enabledCommands,
+                                           OptionalAttributeSet optionalAttributeSet, OptionalCommandSet enabledCommands,
                                            BitMask<IcdManagement::UserActiveModeTriggerBitmap> userActiveModeTriggerBitmap,
                                            CharSpan userActiveModeTriggerInstruction) :
     DefaultServerCluster({ endpointId, IcdManagement::Id }),
@@ -217,7 +216,7 @@ CHIP_ERROR ICDManagementCluster::AcceptedCommands(const ConcreteClusterPath & pa
                                                   ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
 {
     if (mICDConfigurationData.GetFeatureMap().Has(Feature::kLongIdleTimeSupport) ||
-        mEnabledCommands.Has(OptionalCommands::kStayActive))
+        mEnabledCommands.IsSet(Commands::StayActiveRequest::Id))
     {
         static constexpr DataModel::AcceptedCommandEntry kStayActiveCommand[] = {
             Commands::StayActiveRequest::kMetadataEntry,
@@ -230,7 +229,7 @@ CHIP_ERROR ICDManagementCluster::AcceptedCommands(const ConcreteClusterPath & pa
 CHIP_ERROR ICDManagementCluster::GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder)
 {
     if (mICDConfigurationData.GetFeatureMap().Has(Feature::kLongIdleTimeSupport) ||
-        mEnabledCommands.Has(OptionalCommands::kStayActive))
+        mEnabledCommands.IsSet(Commands::StayActiveRequest::Id))
     {
         static constexpr CommandId kStayActiveResponse[] = {
             Commands::StayActiveResponse::Id,
@@ -258,8 +257,7 @@ CHIP_ERROR ICDManagementCluster::ReadOperatingMode(AttributeValueEncoder & encod
 #if CHIP_CONFIG_ENABLE_ICD_CIP
 ICDManagementClusterWithCIP::ICDManagementClusterWithCIP(
     EndpointId endpointId, Crypto::SymmetricKeystore & symmetricKeystore, FabricTable & fabricTable,
-    ICDConfigurationData & icdConfigurationData, OptionalAttributeSet optionalAttributeSet,
-    BitMask<IcdManagement::OptionalCommands> enabledCommands,
+    ICDConfigurationData & icdConfigurationData, OptionalAttributeSet optionalAttributeSet, OptionalCommandSet enabledCommands,
     BitMask<IcdManagement::UserActiveModeTriggerBitmap> userActiveModeTriggerBitmap, CharSpan userActiveModeTriggerInstruction) :
     ICDManagementCluster(endpointId, symmetricKeystore, fabricTable, icdConfigurationData, optionalAttributeSet, enabledCommands,
                          userActiveModeTriggerBitmap, userActiveModeTriggerInstruction)

--- a/src/app/clusters/icd-management-server/ICDManagementCluster.h
+++ b/src/app/clusters/icd-management-server/ICDManagementCluster.h
@@ -46,11 +46,6 @@ namespace app {
 namespace Clusters {
 
 namespace IcdManagement {
-enum class OptionalCommands : uint8_t
-{
-    kStayActive = 0x01,
-};
-
 constexpr size_t kUserActiveModeTriggerInstructionMaxLength = 128;
 } // namespace IcdManagement
 
@@ -65,9 +60,12 @@ class ICDManagementCluster : public DefaultServerCluster, public chip::app::ICDS
 public:
     using OptionalAttributeSet = app::OptionalAttributeSet<IcdManagement::Attributes::UserActiveModeTriggerInstruction::Id>;
 
+    /// Commands that this cluster supports only if the application opts into them.
+    using OptionalCommandSet = app::OptionalAttributeSet<IcdManagement::Commands::StayActiveRequest::Id>;
+
     // TODO: The interaction between enabledCommands and feature flags (particularly LITS) needs clarification.
     // According to spec, LITS implies StayActiveRequest support. Options:
-    // 1. Document that kStayActive bit in enabledCommands is ignored when LITS feature is set
+    // 1. Document that the StayActiveRequest bit in enabledCommands is ignored when LITS feature is set
     // 2. Add Startup() validation to fail if enabledCommands and feature flags are inconsistent,
     //    and simplify AcceptedCommands/GeneratedCommands to only check mEnabledCommands
 
@@ -81,7 +79,7 @@ public:
      */
     ICDManagementCluster(EndpointId endpointId, Crypto::SymmetricKeystore & symmetricKeystore, FabricTable & fabricTable,
                          ICDConfigurationData & icdConfigurationData, OptionalAttributeSet optionalAttributeSet,
-                         BitMask<IcdManagement::OptionalCommands> enabledCommands,
+                         OptionalCommandSet enabledCommands,
                          BitMask<IcdManagement::UserActiveModeTriggerBitmap> userActiveModeTriggerBitmap,
                          CharSpan userActiveModeTriggerInstruction);
 
@@ -116,7 +114,7 @@ protected:
     ICDConfigurationData & mICDConfigurationData;
     const OptionalAttributeSet mOptionalAttributeSet;
     const BitMask<IcdManagement::UserActiveModeTriggerBitmap> mUserActiveModeTriggerBitmap;
-    const BitMask<IcdManagement::OptionalCommands> mEnabledCommands;
+    const OptionalCommandSet mEnabledCommands;
     uint8_t mUserActiveModeTriggerInstructionLength;
     char mUserActiveModeTriggerInstruction[IcdManagement::kUserActiveModeTriggerInstructionMaxLength];
 };
@@ -156,7 +154,7 @@ class ICDManagementClusterWithCIP : public ICDManagementCluster
 public:
     ICDManagementClusterWithCIP(EndpointId endpointId, Crypto::SymmetricKeystore & symmetricKeystore, FabricTable & fabricTable,
                                 ICDConfigurationData & icdConfigurationData, OptionalAttributeSet optionalAttributeSet,
-                                BitMask<IcdManagement::OptionalCommands> enabledCommands,
+                                OptionalCommandSet enabledCommands,
                                 BitMask<IcdManagement::UserActiveModeTriggerBitmap> userActiveModeTriggerBitmap,
                                 CharSpan userActiveModeTriggerInstruction);
 

--- a/src/app/clusters/icd-management-server/tests/TestICDManagementCluster.cpp
+++ b/src/app/clusters/icd-management-server/tests/TestICDManagementCluster.cpp
@@ -60,8 +60,8 @@ TEST_F(TestIcdManagementCluster, TestAttributes)
     FabricTable fabricTable;
     ICDConfigurationData & icdConfig = ICDConfigurationData::GetInstance();
 
-    BitMask<IcdManagement::OptionalCommands> optionalCommands =
-        BitMask<IcdManagement::OptionalCommands>(IcdManagement::OptionalCommands::kStayActive);
+    ICDManagementCluster::OptionalCommandSet optionalCommands =
+        ICDManagementCluster::OptionalCommandSet().Set<IcdManagement::Commands::StayActiveRequest::Id>();
     BitMask<IcdManagement::UserActiveModeTriggerBitmap> userActiveModeTriggerHint(0);
 
     // Since ICDManagementClusterWithCIP is under the #if CHIP_CONFIG_ENABLE_ICD_CIP, we need to test both cases.
@@ -115,7 +115,7 @@ TEST_F(TestIcdManagementCluster, TestAttributes)
     ASSERT_TRUE(IsAttributesListEqualTo(cluster, expectedAttributes));
 
     // Test accepted commands list
-    bool hasStayActive = optionalCommands.Has(IcdManagement::OptionalCommands::kStayActive);
+    bool hasStayActive = optionalCommands.IsSet(IcdManagement::Commands::StayActiveRequest::Id);
 
     // Build expected accepted commands list dynamically
     if (hasCIP && (hasLIT || hasStayActive))


### PR DESCRIPTION
### Summary

This change replaces custom enum definitions for `OptionalAttributeSet` for optional commands so we can keep a better alignment of command IDs. As a follow up it may be good to create a "generic" set that can be used for Attributes and Commands (just to keep consistent naming).

Also, the method `SupportsOptCmd` from EnergyEVSE was replaced with `SupportsStartDiagnostics` since there is only one optional command in this cluster (StartDiagnostics).

### Related issues

NA

### Testing

No functionality should change, behavior should remain the same in unit test and integration tests in the CI.
