### PR TITLE
Add range constraint to CHIP_DEVICE_DISCRIMINATOR Kconfig

### DIFF
--- a/config/common/cmake/Kconfig
+++ b/config/common/cmake/Kconfig
@@ -200,6 +200,7 @@ config CHIP_DEVICE_TYPE
 
 config CHIP_DEVICE_DISCRIMINATOR
 	hex "Device pairing discriminator"
+	range 0x0 0xFFF
 	default 0xF00
 	help
 	  Provides a 12-bit identifier that is used to discover the device during


### PR DESCRIPTION
Fixes #73860

#### Problem

`CHIP_DEVICE_DISCRIMINATOR` is a `hex` Kconfig symbol representing the
12-bit Matter pairing discriminator. It had no range constraint, so an
out-of-range value (e.g. `0x2454`) was accepted verbatim and propagated
to runtime, triggering an `abort()` inside
`SetupDiscriminator::SetLongValue()` during commissioning.

#### Change overview

Add `range 0x0 0xFFF` to `CHIP_DEVICE_DISCRIMINATOR` in
`config/common/cmake/Kconfig`. Kconfig now rejects illegal (>0xFFF)
values and falls back to the default (`0xF00`) with a warning, preventing
the runtime abort.

#### Testing

A clean reconfigure with `-DCONFIG_CHIP_DEVICE_DISCRIMINATOR=0x2454`
emits a Kconfig warning ("outside the active range ([0x0, 0xfff]) --
falling back on defaults") and uses `0xF00`; the build completes and no
runtime abort occurs.