### PR TITLE
Small fixes to `LaundryWasherControls` cluster that were missed in #72665

### DIFF
--- a/src/app/clusters/laundry-washer-controls-server/CodegenIntegration.cpp
+++ b/src/app/clusters/laundry-washer-controls-server/CodegenIntegration.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "CodegenIntegration.h"
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/static-cluster-config/LaundryWasherControls.h>
 #include <data-model-providers/codegen/ClusterIntegration.h>
 

--- a/src/app/clusters/laundry-washer-controls-server/LaundryWasherControlsCluster.h
+++ b/src/app/clusters/laundry-washer-controls-server/LaundryWasherControlsCluster.h
@@ -31,7 +31,6 @@ class LaundryWasherControlsCluster : public DefaultServerCluster
     constexpr static uint8_t kMaxSupportedRinsesLength = 4;
 
 public:
-
     struct Config
     {
         Config(BitFlags<LaundryWasherControls::Feature> features, LaundryWasherControls::Delegate & delegate) :

--- a/src/app/clusters/laundry-washer-controls-server/LaundryWasherControlsCluster.h
+++ b/src/app/clusters/laundry-washer-controls-server/LaundryWasherControlsCluster.h
@@ -31,8 +31,6 @@ class LaundryWasherControlsCluster : public DefaultServerCluster
     constexpr static uint8_t kMaxSupportedRinsesLength = 4;
 
 public:
-    // Spec mandates that at least one of the features declared in LaundryWasherControls::Feature must be supported.
-    // This encourages correct construction of the cluster when writing the code
 
     struct Config
     {
@@ -76,8 +74,14 @@ public:
         mDelegate = &delegate;
 
         // delegate change implies change in these attributes.
-        NotifySpinSpeedsAttributeChanged();
-        NotifySupportedRinsesAttributeChanged();
+        if (mFeatures.Has(LaundryWasherControls::Feature::kSpin))
+        {
+            NotifySpinSpeedsAttributeChanged();
+        }
+        if (mFeatures.Has(LaundryWasherControls::Feature::kRinse))
+        {
+            NotifySupportedRinsesAttributeChanged();
+        }
     }
     CHIP_ERROR SetSpinSpeedCurrent(DataModel::Nullable<uint8_t> spinSpeedCurrent);
     CHIP_ERROR SetNumberOfRinses(LaundryWasherControls::NumberOfRinsesEnum numberOfRinses);


### PR DESCRIPTION
### Summary

Minimal changes to the `LaundryWasherControls` that I missed to do in the codegen->codedriven convertion PR for the cluster (#72665).

### Related issues

#72576

### Testing

Passing CI