### PR TITLE
Introduce ::Owned tokens and CancelableOperation base class

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -168,6 +168,7 @@ static_library("core") {
     "CHIPKeyIds.cpp",
     "CHIPKeyIds.h",
     "CHIPPersistentStorageDelegate.h",
+    "CancelableOperation.h",
     "ClusterEnums.h",
     "GroupedCallbackList.h",
     "OTAImageHeader.cpp",

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -66,9 +66,11 @@
  *   that a reused callback object may have been registered with. Note that because a token takes
  *   ownership when it is constructed, any previous callee's CancelFn runs during argument
  *   evaluation, with unspecified order relative to sibling arguments. Owned tokens are only
- *   intended to live for the duration of the call they are passed to. Unless the callee is
- *   synchronously rejecting a call outright, it must Take() the Cancelable out of the token and
- *   install a CancelFn on it, as outlined in the general contract above.
+ *   intended to live for the duration of the call they are passed to. A callee that returns with
+ *   the operation still in flight must Take() the Cancelable out of the token and install a
+ *   CancelFn on it, as outlined in the general contract above; one that rejects the call outright
+ *   simply drops the token, and one that completes synchronously may bypass registration and
+ *   call Owned::Invoke().
  *
  * - Callers must be prepared for their callback to be invoked synchronously from within the
  *   function call initiating the operation. This avoids the callee having to dispatch the callback
@@ -189,9 +191,10 @@ public:
     class Owned;
 
     /**
-     * Move-only ownership of a Cancelable taken from a Callback, which may be null.
+     * Transient move-only ownership of a Cancelable taken from a Callback, which may be null.
      * Usually obtained via an implicit Callback<T>::OwnedOrNull constructor.
      * A null instance can be constructed directly from a nullptr.
+     * A token is consumed at most once, by Take() or by being moved from.
      */
     class OwnedOrNull
     {
@@ -200,57 +203,57 @@ public:
         OwnedOrNull(OwnedOrNull && other) : mCancelable(std::exchange(other.mCancelable, nullptr)) {}
 
         /**
-         * Widens an Owned, which is a non-null Cancelable, into a nullable one. By value only:
-         * an Owned must not bind to an OwnedOrNull reference, see Owned::Take() for why.
+         * Widens an Owned, which is a non-null Cancelable, into a nullable one. Goes through
+         * Owned::Take(), so the result of widening a live Owned is always non-null.
          */
         OwnedOrNull(Owned && owned);
 
         /**
-         * Whether there is a Cancelable for Take() to return. This is useful for callees that
-         * treat a missing callback as a runtime error, rather than as a hard contract violation
-         * like Owned does.
+         * Whether there is a Cancelable for Take() to return, i.e. false if no callback was
+         * supplied or the token has been consumed. This is useful for callees that treat a missing
+         * callback as a runtime error, rather than as a hard contract violation like Owned does.
          */
         [[nodiscard]] bool HasValue() const { return mCancelable != nullptr; }
 
         /**
-         * Relinquishes ownership of the Cancelable, which may be null.
+         * Transfers ownership of the Cancelable out of the token, which may be null. This is how a
+         * callee takes on the callback it was handed.
          *
-         * Null means either that no callback was supplied, or that ownership has already been
-         * taken or moved away. The two are deliberately not distinguished, which is what keeps
-         * this token pointer-sized; since a callee consumes a token exactly once, in practice null
-         * means no callback was supplied. Note that widening an Owned is checked, in that it goes
-         * through Owned::Take(): a spent Owned dies rather than quietly turning into an
-         * OwnedOrNull that looks like "no callback".
+         * Null means no callback was supplied. Taking from a consumed token is a programming error;
+         * it currently yields null, but callers must not rely on that.
          */
         [[nodiscard]] Cancelable * Take() { return std::exchange(mCancelable, nullptr); }
 
     protected:
         explicit OwnedOrNull(Cancelable * cancelable) : mCancelable(cancelable) {}
 
-    private:
-        Cancelable * mCancelable;
-    };
-
-    /**
-     * Move-only ownership of a Cancelable taken from a Callback. Never null.
-     * Usually obtained via an implicit Callback<T>::Owned constructor.
-     */
-    class Owned : private OwnedOrNull
-    {
-    public:
-        /**
-         * Relinquishes ownership of the Cancelable. Aborts if ownership has already been taken.
-         *
-         * Note this hides OwnedOrNull::Take() rather than overriding it, which is why OwnedOrNull
-         * is a private base: binding an Owned to an OwnedOrNull reference would sidestep the check.
-         * Widening by value (which goes through this method) is fine.
-         */
-        [[nodiscard]] Cancelable * Take()
+        [[nodiscard]] Cancelable * TakeNonNull()
         {
             Cancelable * cancelable = OwnedOrNull::Take();
             VerifyOrDie(cancelable != nullptr);
             return cancelable;
         }
+
+    private:
+        // Consumed and empty tokens are indistinguishable, which is what keeps this pointer-sized.
+        // Take() is documented as single-use rather than as returning null, so that consuming twice
+        // can be made fatal later (e.g. via a sentinel) without breaking callers.
+        Cancelable * mCancelable;
+    };
+
+    /**
+     * Transient move-only ownership of a Cancelable taken from a Callback. Never null.
+     * Usually obtained via an implicit Callback<T>::Owned constructor.
+     * A token is consumed at most once, by Take() or by being moved from.
+     */
+    class Owned : private OwnedOrNull // private so the checked Take() can't be bypassed
+    {
+    public:
+        /**
+         * Transfers ownership of the Cancelable out of the token. Valid only if the token has not
+         * been consumed.
+         */
+        [[nodiscard]] Cancelable * Take() { return TakeNonNull(); }
 
     protected:
         explicit Owned(Cancelable * cancelable) : OwnedOrNull(cancelable) { VerifyOrDie(cancelable != nullptr); }
@@ -347,6 +350,20 @@ public:
         Owned(Callback & callback) : Cancelable::Owned(callback.Cancel()) {}
         Owned(Callback * callback) : Cancelable::Owned((callback != nullptr) ? callback->Cancel() : nullptr) {}
         Owned(std::nullptr_t) = delete;
+
+        /**
+         * Takes the callback out of the token and invokes it, for a callee that completes an
+         * operation synchronously. Valid only if the token has not been consumed.
+         *
+         * A callee that completes asynchronously cannot use this: it must Take() the Cancelable and
+         * register it synchronously, and later unregister from its bookkeeping before recovering
+         * the Callback via FromCancelable().
+         */
+        template <typename... Args>
+        void Invoke(Args &&... args)
+        {
+            FromCancelable(Take())->Invoke(std::forward<Args>(args)...);
+        }
     };
 
     /**
@@ -359,6 +376,21 @@ public:
         OwnedOrNull(Callback * callback) : Cancelable::OwnedOrNull((callback != nullptr) ? callback->Cancel() : nullptr) {}
         OwnedOrNull(std::nullptr_t) : Cancelable::OwnedOrNull(nullptr) {}
         OwnedOrNull(Owned && owned) : Cancelable::OwnedOrNull(std::move(owned)) {}
+
+        /**
+         * Takes the callback out of the token and invokes it, for a callee that completes an
+         * operation synchronously. Valid only if the token is not null and has not been consumed,
+         * i.e. if HasValue() is true.
+         *
+         * A callee that completes asynchronously cannot use this: it must Take() the Cancelable and
+         * register it synchronously, and later unregister from its bookkeeping before recovering
+         * the Callback via FromCancelable().
+         */
+        template <typename... Args>
+        void Invoke(Args &&... args)
+        {
+            FromCancelable(TakeNonNull())->Invoke(std::forward<Args>(args)...);
+        }
     };
 };
 

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -45,6 +45,13 @@
  *
  * Refer to the documentation of Callback and Cancelable below for details.
  *
+ * Note that Callback<T>, Cancelable, and related classes are not thread-safe; they must only be
+ * used by a caller and callee that share a serial context. This is inherent to the design rather
+ * than a missing lock: neither the promise that no invocation follows Cancel() nor an accessor
+ * like IsRegistered() mean anything if the callee can concurrently be part-way through a
+ * completion. Generally the serial context will be the Matter event loop, or another thread
+ * holding the Matter stack lock.
+ *
  * While the concrete interaction patterns vary, the following are strong recommendations,
  * especially for asynchronous operations that have a single outcome:
  *

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -34,7 +34,7 @@
  * The specific contract around when or how the callee/registrar calls the callback or delivers
  * events varies between use cases, but cancellation has a very strict contract that MUST be
  * adhered to by correct implementations of this pattern: Once the caller has called Cancel() on
- * a callback that it had passed to a callee / registrar, there will be no further invocations of
+ * a callback that it had passed to a callee/registrar, there will be no further invocations of
  * the callback. This means that the callback (and possibly the caller itself) can safely be
  * deallocated at that point without creating dangling pointers / callbacks.
  *
@@ -48,17 +48,27 @@
  * While the concrete interaction patterns vary, the following are strong recommendations,
  * especially for asynchronous operations that have a single outcome:
  *
- * - Callees should accept a pointer to a single Callback<T> as the last parameter to the function,
- *   with a function signature that covers all success and failure cases. This is generally
- *   preferable to accepting e.g. separate OnSuccess and OnFailure callbacks, which would entail
- *   additional bookkeeping and memory usage for both the caller and callee, and would create
- *   separate cancellation signals. If necessary, an alternative would be to sub-class Callback<T>
- *   to hold additional function pointer(s), e.g. `void *mCallFailure(void *, CHIP_ERROR)`.
+ * - Callees should take a single Callback as the last parameter to the function, with a callback
+ *   signature that covers all success and failure cases. This is generally preferable to accepting
+ *   e.g. separate OnSuccess and OnFailure callbacks, which would entail additional bookkeeping and
+ *   memory usage for both the caller and callee, and would create separate cancellation signals.
  *
  * - If the callee has synchronously rejected the call outright (e.g. by returning a CHIP_ERROR)
  *   the callback will not be called at all. If the caller cancels the callback prior to the
  *   operation completing, the callback will not be called. Otherwise, the callback will be called
  *   exactly once.
+ *
+ * - Callback parameters should be passed by value as Callback<T>::Owned tokens (though various
+ *   existing APIs accept callbacks as plain pointers). The Owned token implicitly constructs from
+ *   a Callback<T> reference or pointer (an OwnedOrNull variant is available where a callback is
+ *   optional). This guarantees that any callbacks are always cancelled at the caller-to-callee
+ *   boundary, resulting in predictable cancellation with respect to any previous callee/registrar
+ *   that a reused callback object may have been registered with. Note that because a token takes
+ *   ownership when it is constructed, any previous callee's CancelFn runs during argument
+ *   evaluation, with unspecified order relative to sibling arguments. Owned tokens are only
+ *   intended to live for the duration of the call they are passed to. Unless the callee is
+ *   synchronously rejecting a call outright, it must Take() the Cancelable out of the token and
+ *   install a CancelFn on it, as outlined in the general contract above.
  *
  * - Callers must be prepared for their callback to be invoked synchronously from within the
  *   function call initiating the operation. This avoids the callee having to dispatch the callback
@@ -70,8 +80,9 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
 
 #include <lib/core/CHIPConfig.h>
 #include <lib/support/CodeUtils.h>
@@ -174,7 +185,79 @@ public:
     // Not copyable
     Cancelable(const Cancelable &)             = delete;
     Cancelable & operator=(const Cancelable &) = delete;
+
+    class Owned;
+
+    /**
+     * Move-only ownership of a Cancelable taken from a Callback, which may be null.
+     * Usually obtained via an implicit Callback<T>::OwnedOrNull constructor.
+     * A null instance can be constructed directly from a nullptr.
+     */
+    class OwnedOrNull
+    {
+    public:
+        OwnedOrNull(std::nullptr_t) : mCancelable(nullptr) {}
+        OwnedOrNull(OwnedOrNull && other) : mCancelable(std::exchange(other.mCancelable, nullptr)) {}
+
+        /**
+         * Widens an Owned, which is a non-null Cancelable, into a nullable one. By value only:
+         * an Owned must not bind to an OwnedOrNull reference, see Owned::Take() for why.
+         */
+        OwnedOrNull(Owned && owned);
+
+        /**
+         * Whether there is a Cancelable for Take() to return. This is useful for callees that
+         * treat a missing callback as a runtime error, rather than as a hard contract violation
+         * like Owned does.
+         */
+        [[nodiscard]] bool HasValue() const { return mCancelable != nullptr; }
+
+        /**
+         * Relinquishes ownership of the Cancelable, which may be null.
+         *
+         * Null means either that no callback was supplied, or that ownership has already been
+         * taken or moved away. The two are deliberately not distinguished, which is what keeps
+         * this token pointer-sized; since a callee consumes a token exactly once, in practice null
+         * means no callback was supplied. Note that widening an Owned is checked, in that it goes
+         * through Owned::Take(): a spent Owned dies rather than quietly turning into an
+         * OwnedOrNull that looks like "no callback".
+         */
+        [[nodiscard]] Cancelable * Take() { return std::exchange(mCancelable, nullptr); }
+
+    protected:
+        explicit OwnedOrNull(Cancelable * cancelable) : mCancelable(cancelable) {}
+
+    private:
+        Cancelable * mCancelable;
+    };
+
+    /**
+     * Move-only ownership of a Cancelable taken from a Callback. Never null.
+     * Usually obtained via an implicit Callback<T>::Owned constructor.
+     */
+    class Owned : private OwnedOrNull
+    {
+    public:
+        /**
+         * Relinquishes ownership of the Cancelable. Aborts if ownership has already been taken.
+         *
+         * Note this hides OwnedOrNull::Take() rather than overriding it, which is why OwnedOrNull
+         * is a private base: binding an Owned to an OwnedOrNull reference would sidestep the check.
+         * Widening by value (which goes through this method) is fine.
+         */
+        [[nodiscard]] Cancelable * Take()
+        {
+            Cancelable * cancelable = OwnedOrNull::Take();
+            VerifyOrDie(cancelable != nullptr);
+            return cancelable;
+        }
+
+    protected:
+        explicit Owned(Cancelable * cancelable) : OwnedOrNull(cancelable) { VerifyOrDie(cancelable != nullptr); }
+    };
 };
+
+inline Cancelable::OwnedOrNull::OwnedOrNull(Owned && owned) : mCancelable(owned.Take()) {}
 
 typedef void (*CallFn)(void *);
 
@@ -234,6 +317,49 @@ public:
      * type that the Cancelable was obtained from.
      */
     static Callback * FromCancelable(Cancelable * ca) { return static_cast<Callback *>(ca); }
+
+    /**
+     * Invokes the callback, passing mContext as the first argument.
+     */
+    template <typename... Args>
+    void Invoke(Args &&... args)
+    {
+        mCall(mContext, std::forward<Args>(args)...);
+    }
+
+    /**
+     * Implicitly accepts a Callback (or pointer to one) and takes ownership of it.
+     *
+     * A null pointer aborts, since an Owned is by definition non-null. When converting an existing
+     * pointer-based API whose callers may legitimately pass null, take an OwnedOrNull instead and
+     * reject a missing callback via HasValue(); prefer a Callback reference for new APIs, so that
+     * the case cannot arise in the first place.
+     *
+     * Note that constructing a second Owned from the same Callback while the first is still alive
+     * is not diagnosed. Only a callee accepting two callbacks of the same type can realistically
+     * run into this, and diagnosing it would require marking the Cancelable for as long as a token
+     * holds it, and make Owned no longer trivially destructible. This extra cost at every call site
+     * of an API taking an Owned callback is not warranted for such a narrow corner case.
+     */
+    class Owned : public Cancelable::Owned
+    {
+    public:
+        Owned(Callback & callback) : Cancelable::Owned(callback.Cancel()) {}
+        Owned(Callback * callback) : Cancelable::Owned((callback != nullptr) ? callback->Cancel() : nullptr) {}
+        Owned(std::nullptr_t) = delete;
+    };
+
+    /**
+     * Implicitly accepts a Callback (or pointer to one, which may be null) and takes ownership of it.
+     */
+    class OwnedOrNull : public Cancelable::OwnedOrNull
+    {
+    public:
+        OwnedOrNull(Callback & callback) : Cancelable::OwnedOrNull(callback.Cancel()) {}
+        OwnedOrNull(Callback * callback) : Cancelable::OwnedOrNull((callback != nullptr) ? callback->Cancel() : nullptr) {}
+        OwnedOrNull(std::nullptr_t) : Cancelable::OwnedOrNull(nullptr) {}
+        OwnedOrNull(Owned && owned) : Cancelable::OwnedOrNull(std::move(owned)) {}
+    };
 };
 
 /**

--- a/src/lib/core/CancelableOperation.h
+++ b/src/lib/core/CancelableOperation.h
@@ -155,7 +155,7 @@ protected:
      * Called with cancelled = true when the *caller* withdrew its Callback, in which case no
      * completion will be delivered and everything the operation holds can be released. Called with
      * cancelled = false from TakeCompletion(), i.e. just *before* the caller's callback runs, so
-     * that resources are cleaned up down before the callback can reuse or destroy the operation.
+     * that resources are cleaned up before the callback can reuse or destroy the operation.
      *
      * The distinction matters only for state the operation intends to hand to the caller: releasing
      * it here would pull it out from under the completion. Resources or underlying work like nested

--- a/src/lib/core/CancelableOperation.h
+++ b/src/lib/core/CancelableOperation.h
@@ -163,7 +163,7 @@ protected:
      *
      * A subclass that overrides this MUST call the inherited implementation.
      */
-    virtual void OnFinished(bool cancelled) {}
+    virtual void OnFinished(bool /* cancelled */) {}
 
 private:
     Cancelable * mCancelable = nullptr;

--- a/src/lib/core/CancelableOperation.h
+++ b/src/lib/core/CancelableOperation.h
@@ -158,20 +158,10 @@ protected:
      * that resources are cleaned up down before the callback can reuse or destroy the operation.
      *
      * The distinction matters only for state the operation intends to hand to the caller: releasing
-     * it here would pull it out from under the completion, so on that path leave it to the function
-     * doing the completing (see the note on payload lifetime in the class comment above).
-     * Registrations of underlying work -- nested Callbacks, timers, exchanges -- should be released
-     * unconditionally; doing so is idempotent, and leaving one live past a completion means it can
-     * fire into an idle or reused operation.
+     * it here would pull it out from under the completion. Resources or underlying work like nested
+     * Callbacks, timers, etc. should be released unconditionally.
      *
-     * A subclass that overrides this MUST call the inherited implementation, or the layers above it
-     * never hear that the operation finished. The implementation here does nothing -- there is no
-     * in-flight work at this level -- and exists to terminate that chain, so that a layer can call
-     * its base without having to know whether that base is the root of the hierarchy.
-     *
-     * A subclass with nothing in flight of its own need not override this at all, which is why it is
-     * not pure: only a layer that keeps state can know whether it has anything to release, so the
-     * obligation cannot usefully be enforced here.
+     * A subclass that overrides this MUST call the inherited implementation.
      */
     virtual void OnFinished(bool cancelled) {}
 

--- a/src/lib/core/CancelableOperation.h
+++ b/src/lib/core/CancelableOperation.h
@@ -92,9 +92,9 @@ protected:
      * operation as the callee holding it.
      *
      * An intermediate subclass that needs parameters of its own simply declares them ahead of the
-     * completion; TypedOperation reads them off this declaration and forwards to it from its
-     * type-safe Start() that takes a typed Callback<Args...>::Owned instead of an untyped
-     * Cancelable::Owned. Note that Start() must not be overloaded.
+     * completion. A TypedOperation sub-class forwards them from its type-safe Start() that takes a
+     * Callback<T>::Owned instead of the type-erased Cancelable::Owned. Note that Start() must not
+     * be overloaded for an operation class to be usable with TypedOperation.
      */
     void Start(Cancelable::Owned onCompletion)
     {
@@ -173,7 +173,7 @@ namespace detail {
 
 // Re-publishes OperationBase's protected Start(), so that a pointer to it can be formed:
 // [class.protected] does not allow naming a protected member via OperationBase itself, and
-// TypedOperation cannot name it via its own scope either, since its Start() hides the base one.
+// TypedOperationImpl cannot name it via its own scope either, since its Start() hides the base one.
 template <typename OperationBase>
 struct StartProbe : OperationBase
 {
@@ -198,7 +198,7 @@ struct MemberFunctionSignature<R (C::*)(A...)>
     using Parameters = ParameterList<A...>;
 };
 
-// The signature of OperationBase::Start(), i.e. what TypedOperation::Start() has to forward.
+// The signature of OperationBase::Start(), i.e. what TypedOperationImpl::Start() has to forward.
 template <typename OperationBase>
 using StartSignature = MemberFunctionSignature<decltype(&StartProbe<OperationBase>::Start)>;
 
@@ -235,11 +235,13 @@ using StartParameters = typename DropCompletionParameter<ParameterList<>, typena
 
 // Helper template implementing the TypedOperation alias below. It is necessary because a parameter
 // pack can only be introduced by a template parameter list: there is no way to expand
-// StartParameters<OperationBase> in place.
+// StartParameters<OperationBase> in place. It carries a distinct name so that a class deriving from
+// the alias can still name TypedOperation unqualified: the base contributes its own name as an
+// injected-class-name, which would otherwise hide the alias throughout any derived class body.
 template <typename OperationBase, typename Parameters, typename... CompletionArgs>
-class TypedOperation;
+class TypedOperationImpl;
 template <typename OperationBase, typename... StartArgs, typename... CompletionArgs>
-class TypedOperation<OperationBase, ParameterList<StartArgs...>, CompletionArgs...> : public OperationBase
+class TypedOperationImpl<OperationBase, ParameterList<StartArgs...>, CompletionArgs...> : public OperationBase
 {
     static_assert(std::is_base_of_v<CancelableOperationBase, OperationBase>);
 
@@ -304,7 +306,7 @@ protected:
  * former is a trailing pack here and the latter is read off OperationBase::Start() itself.
  */
 template <typename OperationBase, typename... CompletionArgs>
-using TypedOperation = detail::TypedOperation<OperationBase, detail::StartParameters<OperationBase>, CompletionArgs...>;
+using TypedOperation = detail::TypedOperationImpl<OperationBase, detail::StartParameters<OperationBase>, CompletionArgs...>;
 
 /**
  * Convenience type for a type-safe cancelable operation. Subclasses of this class should be

--- a/src/lib/core/CancelableOperation.h
+++ b/src/lib/core/CancelableOperation.h
@@ -1,0 +1,329 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPCallback.h>
+#include <lib/support/CodeUtils.h>
+
+#include <type_traits>
+#include <utility>
+
+namespace chip {
+namespace Callback {
+
+/**
+ * Base class for an asynchronous operation that accepts a Callback<T>, and enforces the contract
+ * that the caller hears back exactly once.
+ *
+ * This class is primarily useful for cases where cancellation has to actually do some work to stop
+ * an operation. In contrast, CallbackDeque or GroupedCallbackList are most suited to use cases
+ * where several callers wait on some shared work, and cancellation simply unlinks an individual
+ * Callback from that list.
+ *
+ * The contract a subclass has to keep is: an operation that has been started completes exactly
+ * once, unless the caller cancels it, in which case it never completes. Cancellation is the only
+ * way out without a completion, and it is the caller's to ask for, not the operation's to take.
+ *
+ * This is enforced via VerifyOrDie: it is illegal to start an operation that is already pending,
+ * to complete one that isn't, or to destruct an operation that is still pending. Note that the
+ * latter means that if an operation needs to be aborted by the callee, it must complete it with an
+ * error; the obligation to call back to the caller can't be dropped.
+ *
+ * This class is deliberately storage-agnostic: it works as a member of whatever issues the
+ * operations, or as an object in a pool, and it neither knows nor decides when it is destroyed.
+ * In particular, an operation may be reused or destroyed from within its own completion callback.
+ *
+ * Completion signatures may take rvalue reference arguments, which is useful for handing back a
+ * heavy payload without the operation having to move it first. Care must be taken with the
+ * lifetime of objects passed by reference or non-owning types like ByteSpans, especially in cases
+ * where destruction or reuse of the operation from within the callback is a possibility. The
+ * recommended recipe is to move such objects into a local in the function that completes the
+ * operation, so that its lifetime is the completion call rather than the operation's:
+ *
+ *     void Finish(CHIP_ERROR status)
+ *     {
+ *         System::PacketBufferHandle response = std::move(mResponse);
+ *         Complete(status, ByteSpan(response->Start(), response->DataLength()));
+ *     }
+ */
+class CancelableOperationBase
+{
+public:
+    /**
+     * True while an operation is in flight, i.e. from being started until it is completed or the
+     * caller cancels it.
+     */
+    bool IsPending() const { return mCancelable != nullptr; }
+
+    // Not copyable. Not movable; moving an operation would be hazardous because it could happen
+    // reentrantly during completion calls. Any subclass holding a Callback to track underlying
+    // work is also immovable by virtue of the underlying Cancelable.
+    CancelableOperationBase(const CancelableOperationBase &)             = delete;
+    CancelableOperationBase & operator=(const CancelableOperationBase &) = delete;
+    CancelableOperationBase(CancelableOperationBase &&)                  = delete;
+    CancelableOperationBase & operator=(CancelableOperationBase &&)      = delete;
+
+protected:
+    CancelableOperationBase() = default;
+
+    /**
+     * Asserts that we no longer have ownership of a caller's Callback, since a Cancel() on that
+     * callback would call back into our CancelFn, triggering a use-after-free.
+     */
+    virtual ~CancelableOperationBase() { VerifyOrDie(!IsPending()); }
+
+    /**
+     * Takes over the given Cancelable, obtained from Callback::Cancel(), and registers this
+     * operation as the callee holding it.
+     *
+     * An intermediate subclass that needs parameters of its own simply declares them ahead of the
+     * completion; TypedOperation reads them off this declaration and forwards to it from its
+     * type-safe Start() that takes a typed Callback<Args...>::Owned instead of an untyped
+     * Cancelable::Owned. Note that Start() must not be overloaded.
+     */
+    void Start(Cancelable::Owned onCompletion)
+    {
+        VerifyOrDie(!IsPending());
+        mCancelable = onCompletion.Take();
+
+        // Taking the Cancelable and installing mCancel have to happen together, here: mCancel is
+        // the only thing that makes our borrow visible to the Callback's owner, and keeping the two
+        // in one place is what guarantees that whatever is in mCancel is ours, which in turn is
+        // what makes TakeCompletion()'s unconditional clear of it sound.
+        mCancelable->mContextA = this;
+        mCancelable->mCancel   = [](Cancelable * aCancelable) {
+            auto * self = static_cast<CancelableOperationBase *>(aCancelable->mContextA);
+
+            // Cancelable::Cancel() has already cleared mCancel. Give up our reference before
+            // telling the subclass, so that IsPending() is already false during OnFinished():
+            // The subclass shouldn't attempt to call the callback in response to cancellation.
+            self->mCancelable = nullptr;
+            self->OnFinished(/* cancelled = */ true);
+        };
+    }
+
+    /**
+     * Unregisters the Cancelable from the operation and returns it in preparation for recovering
+     * the typed Callback and invoking it. (The latter is usually handled via a subclass created
+     * via the TypedOperation mixin.)
+     *
+     * Calls OnFinished(false) once the operation is no longer pending, i.e. subclasses have
+     * released whatever they had in flight by the time the caller's callback runs.
+     *
+     * The caller of this method takes on the operation's debt of invoking the callback: the
+     * operation is no longer pending, so nothing else will assert if the completion is dropped.
+     */
+    [[nodiscard]] Cancelable * TakeCompletion()
+    {
+        VerifyOrDie(IsPending());
+        Cancelable * cancelable = mCancelable;
+
+        // Unregister the cancelable, but don't call Cancel(), since that would invoke our own
+        // cancellation handler and OnFinished(true). Releasing ownership of the Cancelable
+        // *before* calling the completion is important, because the caller may well reuse its
+        // Callback and register it with another callee immediately, resulting in a call to
+        // Cancel(). Clearing mCancelable at the same time also ensures that the operation itself
+        // is no longer pending, and therefore able to be reused synchronously from the callback.
+        cancelable->mCancel = nullptr;
+        cancelable->Invalidate();
+        mCancelable = nullptr;
+
+        OnFinished(/* cancelled = */ false);
+        return cancelable;
+    }
+
+    /**
+     * Called when the operation stops being pending, to release whatever resources or operations
+     * it has in flight. When this method is called, IsPending() is already false, so an
+     * implementation must not try to complete the operation.
+     *
+     * Called with cancelled = true when the *caller* withdrew its Callback, in which case no
+     * completion will be delivered and everything the operation holds can be released. Called with
+     * cancelled = false from TakeCompletion(), i.e. just *before* the caller's callback runs, so
+     * that resources are cleaned up down before the callback can reuse or destroy the operation.
+     *
+     * The distinction matters only for state the operation intends to hand to the caller: releasing
+     * it here would pull it out from under the completion, so on that path leave it to the function
+     * doing the completing (see the note on payload lifetime in the class comment above).
+     * Registrations of underlying work -- nested Callbacks, timers, exchanges -- should be released
+     * unconditionally; doing so is idempotent, and leaving one live past a completion means it can
+     * fire into an idle or reused operation.
+     *
+     * A subclass that overrides this MUST call the inherited implementation, or the layers above it
+     * never hear that the operation finished. The implementation here does nothing -- there is no
+     * in-flight work at this level -- and exists to terminate that chain, so that a layer can call
+     * its base without having to know whether that base is the root of the hierarchy.
+     *
+     * A subclass with nothing in flight of its own need not override this at all, which is why it is
+     * not pure: only a layer that keeps state can know whether it has anything to release, so the
+     * obligation cannot usefully be enforced here.
+     */
+    virtual void OnFinished(bool cancelled) {}
+
+private:
+    Cancelable * mCancelable = nullptr;
+};
+
+namespace detail {
+
+// Re-publishes OperationBase's protected Start(), so that a pointer to it can be formed:
+// [class.protected] does not allow naming a protected member via OperationBase itself, and
+// TypedOperation cannot name it via its own scope either, since its Start() hides the base one.
+template <typename OperationBase>
+struct StartProbe : OperationBase
+{
+    using OperationBase::Start;
+};
+
+// A list of types, carrying a parameter list as a single type argument.
+template <typename... T>
+struct ParameterList
+{
+};
+
+// The return type and parameters of a pointer-to-member-function type. The class the member belongs
+// to is deliberately dropped: a layer that adds no parameters of its own does not redeclare Start(),
+// so the pointer is in terms of whichever ancestor did declare it.
+template <typename T>
+struct MemberFunctionSignature;
+template <typename C, typename R, typename... A>
+struct MemberFunctionSignature<R (C::*)(A...)>
+{
+    using Return     = R;
+    using Parameters = ParameterList<A...>;
+};
+
+// The signature of OperationBase::Start(), i.e. what TypedOperation::Start() has to forward.
+template <typename OperationBase>
+using StartSignature = MemberFunctionSignature<decltype(&StartProbe<OperationBase>::Start)>;
+
+// Drops the trailing Cancelable::Owned from a Start() parameter list, leaving the parameters the
+// layer declares for itself. Recurses so long as there is more than one parameter left.
+template <typename Kept, typename Remaining>
+struct DropCompletionParameter
+{
+    // Both specializations below match a non-empty list, so this primary template is only ever
+    // selected for a Start() that declares no parameters at all. Report the error with the same
+    // static_assert message, rather than as an undefined-template error. Type is still defined so
+    // that StartParameters below resolves, leaving just the one diagnostic. Note the condition is
+    // always false, but has to be phrased in a way that depends on a template parameter.
+    static_assert(std::is_same_v<Remaining, ParameterList<Cancelable::Owned>>,
+                  "Start() must take the completion as a Cancelable::Owned in its last parameter");
+    using Type = ParameterList<>;
+};
+template <typename... Kept, typename Last>
+struct DropCompletionParameter<ParameterList<Kept...>, ParameterList<Last>>
+{
+    static_assert(std::is_same_v<Last, Cancelable::Owned>,
+                  "Start() must take the completion as a Cancelable::Owned in its last parameter");
+    using Type = ParameterList<Kept...>;
+};
+template <typename... Kept, typename First, typename Second, typename... Rest>
+struct DropCompletionParameter<ParameterList<Kept...>, ParameterList<First, Second, Rest...>>
+    : DropCompletionParameter<ParameterList<Kept..., First>, ParameterList<Second, Rest...>>
+{
+};
+
+// The parameters OperationBase::Start() takes ahead of the completion.
+template <typename OperationBase>
+using StartParameters = typename DropCompletionParameter<ParameterList<>, typename StartSignature<OperationBase>::Parameters>::Type;
+
+// Helper template implementing the TypedOperation alias below. It is necessary because a parameter
+// pack can only be introduced by a template parameter list: there is no way to expand
+// StartParameters<OperationBase> in place.
+template <typename OperationBase, typename Parameters, typename... CompletionArgs>
+class TypedOperation;
+template <typename OperationBase, typename... StartArgs, typename... CompletionArgs>
+class TypedOperation<OperationBase, ParameterList<StartArgs...>, CompletionArgs...> : public OperationBase
+{
+    static_assert(std::is_base_of_v<CancelableOperationBase, OperationBase>);
+
+public:
+    using Completion = Callback<void (*)(void * context, CompletionArgs... args)>;
+
+protected:
+    // Forwards the base class constructors, so that operation bases taking arguments can be used.
+    // (Inherited constructors keep the access of the base constructor they name, not the access
+    // in effect here.)
+    using OperationBase::OperationBase;
+
+    /**
+     * Takes ownership of the provided callback and starts the operation, which must be completed
+     * via Complete() unless cancelled by the caller.
+     *
+     * This hides OperationBase::Start(), so the parameters OperationBase declares are the only way
+     * in: a subclass cannot start an operation without supplying them. They are forwarded, so an
+     * rvalue reference among them hands a payload to the operation without a copy, mirroring what
+     * the completion arguments do in the other direction.
+     *
+     * The return value of OperationBase::Start() is passed straight through. An OperationBase
+     * that reports a synchronous rejection via the return value MUST decide before taking
+     * ownership of the completion, i.e. before calling CancelableOperationBase::Start(): returning
+     * an error while holding the caller's callback would claim no completion is coming and then
+     * owe one anyway.
+     */
+    typename StartSignature<OperationBase>::Return Start(StartArgs... startArgs, typename Completion::Owned onCompletion)
+    {
+        return OperationBase::Start(std::forward<StartArgs>(startArgs)..., std::move(onCompletion));
+    }
+
+    /**
+     * Completes the operation (which must be pending) by releasing ownership of the caller's
+     * callback and invoking it with the provided arguments.
+     *
+     * Note that the operation is no longer pending by the time the caller's callback executes, so
+     * if operation objects can be reused (e.g. via a pool), such reuse may occur reentrantly from
+     * within the completion callback. Completion may also result in reentrant destruction of the
+     * operation.
+     */
+    void Complete(CompletionArgs... args)
+    {
+        Completion::FromCancelable(OperationBase::TakeCompletion())->Invoke(std::forward<CompletionArgs>(args)...);
+    }
+};
+
+} // namespace detail
+
+/**
+ * Adds a typed Start() and Complete() to a CancelableOperationBase subclass: Start() takes whatever
+ * parameters OperationBase::Start() declares ahead of the completion, followed by a typed completion
+ * callback, and Complete() invokes that callback. Whatever OperationBase::Start() returns is
+ * forwarded, so a layer whose Start() is fallible keeps its CHIP_ERROR.
+ *
+ * This is the only part of the CancelableOperation type hierarchy that depends on the completion
+ * signature. Separating it out in this way allows reusable operation subclasses to be compiled
+ * once rather than expanded per signature.
+ *
+ * The completion signature is a single decision made by the concrete operation, whereas Start()
+ * parameters accumulate down the hierarchy, each layer declaring the full list it takes; hence the
+ * former is a trailing pack here and the latter is read off OperationBase::Start() itself.
+ */
+template <typename OperationBase, typename... CompletionArgs>
+using TypedOperation = detail::TypedOperation<OperationBase, detail::StartParameters<OperationBase>, CompletionArgs...>;
+
+/**
+ * Convenience type for a type-safe cancelable operation. Subclasses of this class should be
+ * concrete non-template operation implementations. Reusable base classes should instead subclass
+ * CancelableOperationBase, declare a Start() taking their own parameters ahead of a
+ * Cancelable::Owned, and offer their own convenience type alias over TypedOperation.
+ */
+template <typename... CompletionArgs>
+using CancelableOperation = TypedOperation<CancelableOperationBase, CompletionArgs...>;
+
+} // namespace Callback
+} // namespace chip

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -27,6 +27,7 @@ chip_test_suite("tests") {
     "TestCHIPError.cpp",
     "TestCHIPErrorStr.cpp",
     "TestCHIPKeyIds.cpp",
+    "TestCancelableOperation.cpp",
     "TestGroupedCallbackList.cpp",
     "TestOTAImageHeader.cpp",
     "TestOptional.cpp",

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -29,6 +29,10 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
 using namespace chip::Callback;
 
 /**
@@ -63,7 +67,7 @@ public:
 
             // one-shot semantics
             cb->Cancel();
-            cb->mCall(cb->mContext);
+            cb->Invoke();
         }
     }
 };
@@ -174,9 +178,7 @@ public:
         for (Cancelable * ca = mNext; ca != this; ca = ca->mNext)
         {
             // persistent registration semantics, with data
-
-            Callback<NotifyFn> * cb = Callback<NotifyFn>::FromCancelable(ca);
-            cb->mCall(cb->mContext, v);
+            Callback<NotifyFn>::FromCancelable(ca)->Invoke(v);
         }
     }
 
@@ -275,4 +277,225 @@ TEST_F(TestCHIPCallback, PersistentCallbacksThatDeallocateThemselves)
     EXPECT_FALSE(retryHandlers.IsEmpty()); // stack callback remains
     stackCallback.Cancel();
     EXPECT_TRUE(retryHandlers.IsEmpty());
+}
+
+/*
+ * Owned / OwnedOrNull tokens
+ */
+
+// The properties the Owned tokens exist to enforce, none of which are observable at runtime.
+static_assert(!std::is_copy_constructible_v<Callback<>::Owned>, "Owned is move-only");
+static_assert(std::is_move_constructible_v<Callback<>::Owned>, "Owned is move-only");
+static_assert(!std::is_copy_constructible_v<Callback<>::OwnedOrNull>, "OwnedOrNull is move-only");
+static_assert(std::is_move_constructible_v<Callback<>::OwnedOrNull>, "OwnedOrNull is move-only");
+
+// Owned implicitly accepts a Callback by reference or by pointer, but rejects a literal nullptr.
+static_assert(std::is_convertible_v<Callback<> &, Callback<>::Owned>, "Owned accepts a reference");
+static_assert(std::is_convertible_v<Callback<> *, Callback<>::Owned>, "Owned accepts a pointer");
+static_assert(!std::is_constructible_v<Callback<>::Owned, std::nullptr_t>, "Owned rejects nullptr");
+
+// OwnedOrNull additionally accepts a literal nullptr, as well as an Owned.
+static_assert(std::is_convertible_v<std::nullptr_t, Callback<>::OwnedOrNull>, "OwnedOrNull accepts nullptr");
+static_assert(std::is_convertible_v<Callback<>::Owned, Callback<>::OwnedOrNull>, "Owned converts to OwnedOrNull");
+
+// A signature-agnostic callee's "no callback" case does not go through a typed token either, since
+// a caller with nothing to pass has no signature to name.
+static_assert(std::is_convertible_v<std::nullptr_t, Cancelable::OwnedOrNull>, "Cancelable::OwnedOrNull accepts nullptr");
+static_assert(!std::is_constructible_v<Cancelable::Owned, std::nullptr_t>, "Cancelable::Owned rejects nullptr");
+
+// Callbacks with a different signature are not interchangeable.
+static_assert(!std::is_constructible_v<Callback<>::Owned, Callback<Notifier::NotifyFn> &>, "signatures must match");
+static_assert(!std::is_constructible_v<Callback<Notifier::NotifyFn>::Owned, Callback<> &>, "signatures must match");
+
+// A callee may take a signature-agnostic Cancelable::Owned, or widen to a Cancelable::OwnedOrNull ...
+static_assert(std::is_convertible_v<Callback<>::Owned, Cancelable::Owned>, "Owned converts to Cancelable::Owned");
+static_assert(std::is_convertible_v<Cancelable::Owned, Cancelable::OwnedOrNull>, "Owned widens to OwnedOrNull");
+static_assert(std::is_convertible_v<Callback<>::Owned, Cancelable::OwnedOrNull>, "Owned widens to OwnedOrNull");
+// ... but only by value: Owned::Take() hides rather than overrides OwnedOrNull::Take(), so binding
+// an Owned to an OwnedOrNull reference would sidestep its non-null check.
+static_assert(!std::is_convertible_v<Callback<>::Owned &, Cancelable::OwnedOrNull &>, "Owned must not slice");
+static_assert(!std::is_convertible_v<Cancelable::Owned &, Cancelable::OwnedOrNull &>, "Owned must not slice");
+
+/**
+ * A registrar in the shape CHIPCallback.h recommends for new APIs: it accepts callbacks by value
+ * as Owned / OwnedOrNull tokens rather than as plain pointers.
+ */
+class Acceptor : private CallbackDeque
+{
+public:
+    void Accept(Callback<>::Owned cb) { Enqueue(cb.Take()); }
+
+    // Returns whether a callback was actually provided.
+    bool AcceptOptional(Callback<>::OwnedOrNull cb)
+    {
+        VerifyOrReturnValue(cb.HasValue(), false);
+        Enqueue(cb.Take());
+        return true;
+    }
+
+    // Models a signature-agnostic callee, e.g. a shared layer underneath several typed APIs.
+    // Returns whether a callback was actually provided.
+    bool AcceptAgnostic(Cancelable::OwnedOrNull cb)
+    {
+        VerifyOrReturnValue(cb.HasValue(), false);
+        Enqueue(cb.Take());
+        return true;
+    }
+
+    // Models a callee that rejects the call outright, dropping the token without taking it.
+    static CHIP_ERROR Reject(Callback<>::Owned) { return CHIP_ERROR_INCORRECT_STATE; }
+
+    void InvokeAll()
+    {
+        CallbackDeque ready;
+        DequeueAll(ready);
+        while (!ready.IsEmpty())
+        {
+            Callback<> * cb = Callback<>::FromCancelable(ready.First());
+            cb->Cancel();
+            cb->Invoke();
+        }
+    }
+
+    using CallbackDeque::IsEmpty;
+};
+
+TEST_F(TestCHIPCallback, OwnedTakesOwnershipAtTheCallBoundary)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor first, second;
+
+    first.Accept(cb);
+    EXPECT_TRUE(cb.IsRegistered());
+    EXPECT_FALSE(first.IsEmpty());
+
+    // Handing the same callback to a second callee withdraws it from the first.
+    second.Accept(cb);
+    EXPECT_TRUE(first.IsEmpty());
+    EXPECT_FALSE(second.IsEmpty());
+
+    first.InvokeAll();
+    EXPECT_EQ(n, 0);
+    second.InvokeAll();
+    EXPECT_EQ(n, 1);
+    EXPECT_FALSE(cb.IsRegistered());
+}
+
+TEST_F(TestCHIPCallback, OwnedAcceptsAPointer)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor acceptor;
+
+    acceptor.Accept(&cb);
+    EXPECT_TRUE(cb.IsRegistered());
+    acceptor.InvokeAll();
+    EXPECT_EQ(n, 1);
+}
+
+TEST_F(TestCHIPCallback, OwnedIsMovable)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor acceptor;
+
+    Callback<>::Owned owned(cb);
+    EXPECT_FALSE(cb.IsRegistered()); // the token holds the cancelable now, nobody is registered
+
+    acceptor.Accept(std::move(owned));
+    EXPECT_TRUE(cb.IsRegistered());
+    acceptor.InvokeAll();
+    EXPECT_EQ(n, 1);
+}
+
+// A callee that rejects the call outright still cancels the callback at the boundary: dropping the
+// token leaves the callback registered with nobody, and no invocation ever happens.
+TEST_F(TestCHIPCallback, DroppingAnOwnedTokenLeavesTheCallbackUnregistered)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor acceptor;
+
+    acceptor.Accept(cb);
+    EXPECT_TRUE(cb.IsRegistered());
+
+    EXPECT_EQ(Acceptor::Reject(cb), CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_FALSE(cb.IsRegistered());
+    EXPECT_TRUE(acceptor.IsEmpty());
+
+    acceptor.InvokeAll();
+    EXPECT_EQ(n, 0);
+}
+
+TEST_F(TestCHIPCallback, OwnedOrNullAcceptsAMissingCallback)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor acceptor;
+
+    EXPECT_FALSE(acceptor.AcceptOptional(nullptr));
+    EXPECT_TRUE(acceptor.IsEmpty());
+
+    Callback<> * missing = nullptr;
+    EXPECT_FALSE(acceptor.AcceptOptional(missing));
+    EXPECT_TRUE(acceptor.IsEmpty());
+
+    EXPECT_TRUE(acceptor.AcceptOptional(cb));
+    EXPECT_TRUE(cb.IsRegistered());
+    acceptor.InvokeAll();
+    EXPECT_EQ(n, 1);
+}
+
+// An Owned converts to an OwnedOrNull, so a callee holding a mandatory callback can forward it to
+// an API that treats it as optional.
+TEST_F(TestCHIPCallback, OwnedOrNullAcceptsAnOwned)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor acceptor;
+
+    EXPECT_TRUE(acceptor.AcceptOptional(Callback<>::Owned(cb)));
+    EXPECT_TRUE(cb.IsRegistered());
+    acceptor.InvokeAll();
+    EXPECT_EQ(n, 1);
+}
+
+// A typed Owned widens all the way to a signature-agnostic Cancelable::OwnedOrNull, so a shared
+// layer underneath several typed APIs can accept one without being templated over the signature.
+TEST_F(TestCHIPCallback, SignatureAgnosticOwnedOrNull)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor acceptor;
+
+    EXPECT_FALSE(acceptor.AcceptAgnostic(Callback<>::OwnedOrNull(nullptr)));
+    EXPECT_TRUE(acceptor.IsEmpty());
+
+    // A caller with no callback to pass need not name a signature just to say so.
+    EXPECT_FALSE(acceptor.AcceptAgnostic(nullptr));
+    EXPECT_TRUE(acceptor.IsEmpty());
+
+    EXPECT_TRUE(acceptor.AcceptAgnostic(Callback<>::Owned(cb)));
+    EXPECT_TRUE(cb.IsRegistered());
+    acceptor.InvokeAll();
+    EXPECT_EQ(n, 1);
+}
+
+// HasValue() answers what Take() would hand over, so that a callee rejecting a missing callback can
+// check it as a precondition rather than having to take first and test the pointer.
+TEST_F(TestCHIPCallback, OwnedOrNullHasValue)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+
+    EXPECT_TRUE(Callback<>::OwnedOrNull(cb).HasValue());
+    EXPECT_FALSE(Callback<>::OwnedOrNull(nullptr).HasValue());
+    EXPECT_FALSE(Cancelable::OwnedOrNull(nullptr).HasValue());
+    EXPECT_TRUE(Cancelable::OwnedOrNull(Callback<>::Owned(cb)).HasValue());
+
+    // Reports false once the token has been spent, which is why a callee gets to consume it once.
+    Callback<>::OwnedOrNull token(cb);
+    EXPECT_NE(token.Take(), nullptr);
+    EXPECT_FALSE(token.HasValue());
 }

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -345,6 +345,30 @@ public:
     // Models a callee that rejects the call outright, dropping the token without taking it.
     static CHIP_ERROR Reject(Callback<>::Owned) { return CHIP_ERROR_INCORRECT_STATE; }
 
+    // Models a callee that completes the operation synchronously, without ever registering the
+    // callback with itself.
+    static void AcceptAndComplete(Callback<>::Owned cb) { cb.Invoke(); }
+
+    // As above, but for an optional callback: Invoke() requires one, so HasValue() is a precondition.
+    // Returns whether a callback was actually provided.
+    static bool AcceptOptionalAndComplete(Callback<>::OwnedOrNull cb)
+    {
+        VerifyOrReturnValue(cb.HasValue(), false);
+        cb.Invoke();
+        return true;
+    }
+
+    // Models synchronous completion of an operation whose callback signature carries an outcome.
+    static void CompleteWith(Callback<Notifier::NotifyFn>::Owned cb, int result) { cb.Invoke(result); }
+
+    // Returns whether a callback was actually provided.
+    static bool CompleteOptionalWith(Callback<Notifier::NotifyFn>::OwnedOrNull cb, int result)
+    {
+        VerifyOrReturnValue(cb.HasValue(), false);
+        cb.Invoke(result);
+        return true;
+    }
+
     void InvokeAll()
     {
         CallbackDeque ready;
@@ -428,6 +452,24 @@ TEST_F(TestCHIPCallback, DroppingAnOwnedTokenLeavesTheCallbackUnregistered)
     EXPECT_EQ(n, 0);
 }
 
+// A callee completing synchronously never registers the callback, so it invokes it straight off the
+// token: there is no window in which the caller could cancel, and nothing to unregister.
+TEST_F(TestCHIPCallback, OwnedInvokesTheCallbackDirectly)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor acceptor;
+
+    // Whoever held the callback still gives it up at the boundary, as for any other call.
+    acceptor.Accept(cb);
+    EXPECT_TRUE(cb.IsRegistered());
+
+    Acceptor::AcceptAndComplete(cb);
+    EXPECT_EQ(n, 1);
+    EXPECT_FALSE(cb.IsRegistered());
+    EXPECT_TRUE(acceptor.IsEmpty());
+}
+
 TEST_F(TestCHIPCallback, OwnedOrNullAcceptsAMissingCallback)
 {
     int n = 0;
@@ -459,6 +501,45 @@ TEST_F(TestCHIPCallback, OwnedOrNullAcceptsAnOwned)
     EXPECT_TRUE(cb.IsRegistered());
     acceptor.InvokeAll();
     EXPECT_EQ(n, 1);
+}
+
+// The optional-callback counterpart of OwnedInvokesTheCallbackDirectly. Invoke() requires a
+// callback, so a callee that may not have been given one checks HasValue() first.
+TEST_F(TestCHIPCallback, OwnedOrNullInvokesTheCallbackDirectly)
+{
+    int n = 0;
+    Callback<> cb(reinterpret_cast<CallFn>(increment), &n);
+    Acceptor acceptor;
+
+    EXPECT_FALSE(Acceptor::AcceptOptionalAndComplete(nullptr));
+    EXPECT_EQ(n, 0);
+
+    acceptor.Accept(cb);
+    EXPECT_TRUE(cb.IsRegistered());
+
+    EXPECT_TRUE(Acceptor::AcceptOptionalAndComplete(cb));
+    EXPECT_EQ(n, 1);
+    EXPECT_FALSE(cb.IsRegistered());
+    EXPECT_TRUE(acceptor.IsEmpty());
+}
+
+// Invoke() forwards its arguments to the callback, so a callee completing synchronously reports an
+// outcome exactly as it would have from an asynchronous completion.
+TEST_F(TestCHIPCallback, InvokeForwardsArgumentsToTheCallback)
+{
+    int n = 0;
+    Callback<Notifier::NotifyFn> cb(reinterpret_cast<Notifier::NotifyFn>(increment_by), &n);
+
+    Acceptor::CompleteWith(cb, 3);
+    EXPECT_EQ(n, 3);
+    EXPECT_FALSE(cb.IsRegistered());
+
+    EXPECT_TRUE(Acceptor::CompleteOptionalWith(cb, 4));
+    EXPECT_EQ(n, 7);
+    EXPECT_FALSE(cb.IsRegistered());
+
+    EXPECT_FALSE(Acceptor::CompleteOptionalWith(nullptr, 5));
+    EXPECT_EQ(n, 7);
 }
 
 // A typed Owned widens all the way to a signature-agnostic Cancelable::OwnedOrNull, so a shared
@@ -494,7 +575,9 @@ TEST_F(TestCHIPCallback, OwnedOrNullHasValue)
     EXPECT_FALSE(Cancelable::OwnedOrNull(nullptr).HasValue());
     EXPECT_TRUE(Cancelable::OwnedOrNull(Callback<>::Owned(cb)).HasValue());
 
-    // Reports false once the token has been spent, which is why a callee gets to consume it once.
+    // Reports false once the token has been consumed. This stays true of HasValue() even though
+    // Take() does not promise a value for a consumed token, so that a callee holding one it may
+    // already have passed on can still ask.
     Callback<>::OwnedOrNull token(cb);
     EXPECT_NE(token.Take(), nullptr);
     EXPECT_FALSE(token.HasValue());

--- a/src/lib/core/tests/TestCancelableOperation.cpp
+++ b/src/lib/core/tests/TestCancelableOperation.cpp
@@ -771,6 +771,17 @@ protected:
     }
 };
 
+// TypedOperation must also be nameable unqualified from inside a subclass body, where the base
+// contributes the name of the implementation template it resolves to as an injected-class-name.
+// Compile-time only, so there is no test of its own below.
+class UnqualifiedTypedOperationSubclass : public TypedOperation<FallibleOperationBase, CHIP_ERROR>
+{
+public:
+    using Base = TypedOperation<FallibleOperationBase, CHIP_ERROR>;
+    using Base::Complete;
+    using Base::Start;
+};
+
 // The CHIP_ERROR from the layer's Start() reaches the caller through the typed Start().
 TEST(CancelableOperationTest, FallibleStartForwardsItsResult)
 {

--- a/src/lib/core/tests/TestCancelableOperation.cpp
+++ b/src/lib/core/tests/TestCancelableOperation.cpp
@@ -48,8 +48,8 @@ public:
     using TestOperationBase::Complete;
     using TestOperationBase::Start;
 
-    size_t mCancelledCount = 0;
-    size_t mFinishedCount  = 0;
+    int mCancelledCount = 0;
+    int mFinishedCount  = 0;
 
     // The `cancelled` argument of, and what IsPending() returned during, the most recent
     // OnFinished() call.
@@ -75,14 +75,14 @@ class TestCaller
 public:
     TestOperationBase::Completion mCallback{ OnCompletion, this };
 
-    size_t mCompletionCount = 0;
-    CHIP_ERROR mStatus      = CHIP_NO_ERROR;
-    int mValue              = 0;
+    int mCompletionCount = 0;
+    CHIP_ERROR mStatus   = CHIP_NO_ERROR;
+    int mValue           = 0;
 
     // Observed from within the completion handler.
     std::optional<bool> mPendingDuringCompletion;
     std::optional<bool> mRegisteredDuringCompletion;
-    std::optional<size_t> mFinishedCountDuringCompletion;
+    std::optional<int> mFinishedCountDuringCompletion;
 
     // The operation the callback was handed to, and an optional action to run reentrantly from
     // within the completion handler (cleared before it runs, so it only fires once).
@@ -133,16 +133,16 @@ TEST(CancelableOperationTest, StartAndComplete)
     operation.Start(caller.mCallback);
     EXPECT_TRUE(operation.IsPending());
     EXPECT_TRUE(caller.mCallback.IsRegistered());
-    EXPECT_EQ(caller.mCompletionCount, 0u);
+    EXPECT_EQ(caller.mCompletionCount, 0);
 
     CHIP_ERROR status = CHIP_ERROR_BUSY;
     int value         = 42;
     operation.Complete(status, value);
 
-    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 1);
     EXPECT_EQ(caller.mStatus, CHIP_ERROR_BUSY);
     EXPECT_EQ(caller.mValue, 42);
-    EXPECT_EQ(operation.mCancelledCount, 0u);
+    EXPECT_EQ(operation.mCancelledCount, 0);
     EXPECT_FALSE(operation.IsPending());
     EXPECT_FALSE(caller.mCallback.IsRegistered());
 }
@@ -175,12 +175,12 @@ TEST(CancelableOperationTest, RestartedFromWithinCompletion)
     operation.Complete(CHIP_NO_ERROR, 1);
 
     // The reentrant Start() left a second operation in flight.
-    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 1);
     EXPECT_TRUE(operation.IsPending());
     EXPECT_TRUE(caller.mCallback.IsRegistered());
 
     operation.Complete(CHIP_NO_ERROR, 2);
-    EXPECT_EQ(caller.mCompletionCount, 2u);
+    EXPECT_EQ(caller.mCompletionCount, 2);
     EXPECT_EQ(caller.mValue, 2);
     EXPECT_FALSE(operation.IsPending());
     EXPECT_FALSE(caller.mCallback.IsRegistered());
@@ -202,7 +202,7 @@ TEST(CancelableOperationTest, DestroyedFromWithinCompletion)
     operation.Start(caller.mCallback);
     operation.Complete(CHIP_NO_ERROR, 5);
 
-    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 1);
     EXPECT_EQ(caller.mValue, 5);
     EXPECT_EQ(caller.mOwnedOperation, nullptr);
     EXPECT_FALSE(caller.mCallback.IsRegistered());
@@ -217,8 +217,8 @@ TEST(CancelableOperationTest, CallerCancels)
     operation.Start(caller.mCallback);
     caller.mCallback.Cancel();
 
-    EXPECT_EQ(operation.mCancelledCount, 1u);
-    EXPECT_EQ(caller.mCompletionCount, 0u);
+    EXPECT_EQ(operation.mCancelledCount, 1);
+    EXPECT_EQ(caller.mCompletionCount, 0);
     EXPECT_FALSE(operation.IsPending());
     EXPECT_FALSE(caller.mCallback.IsRegistered());
 
@@ -241,8 +241,8 @@ TEST(CancelableOperationTest, CancellingAfterCompletionIsANoOp)
     operation.Complete(CHIP_NO_ERROR, 0);
     caller.mCallback.Cancel();
 
-    EXPECT_EQ(operation.mCancelledCount, 0u);
-    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(operation.mCancelledCount, 0);
+    EXPECT_EQ(caller.mCompletionCount, 1);
 }
 
 TEST(CancelableOperationTest, DestroyingTheCallbackCancels)
@@ -255,7 +255,7 @@ TEST(CancelableOperationTest, DestroyingTheCallbackCancels)
         EXPECT_TRUE(operation.IsPending());
     }
 
-    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_EQ(operation.mCancelledCount, 1);
     EXPECT_FALSE(operation.IsPending());
 }
 
@@ -291,7 +291,7 @@ TEST(CancelableOperationTest, DestroyedFromWithinOnFinished)
     caller.mCallback.Cancel();
     EXPECT_TRUE(destroyed);
     EXPECT_FALSE(caller.mCallback.IsRegistered());
-    EXPECT_EQ(caller.mCompletionCount, 0u);
+    EXPECT_EQ(caller.mCompletionCount, 0);
 }
 
 // Callback::Cancel() cancels interest with any previous callee, so handing an already-registered
@@ -305,15 +305,15 @@ TEST(CancelableOperationTest, StartingASecondOperationCancelsTheFirst)
     first.Start(caller.mCallback);
     second.Start(caller.mCallback);
 
-    EXPECT_EQ(first.mCancelledCount, 1u);
+    EXPECT_EQ(first.mCancelledCount, 1);
     EXPECT_FALSE(first.IsPending());
-    EXPECT_EQ(second.mCancelledCount, 0u);
+    EXPECT_EQ(second.mCancelledCount, 0);
     EXPECT_TRUE(second.IsPending());
     EXPECT_TRUE(caller.mCallback.IsRegistered());
 
     caller.mOperation = &second;
     second.Complete(CHIP_NO_ERROR, 7);
-    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 1);
     EXPECT_EQ(caller.mValue, 7);
 }
 
@@ -329,15 +329,15 @@ TEST(CancelableOperationTest, RestartingWithTheSameCallbackCancelsTheInFlightOpe
     operation.Start(caller.mCallback);
     operation.Start(caller.mCallback);
 
-    EXPECT_EQ(operation.mCancelledCount, 1u);
-    EXPECT_EQ(caller.mCompletionCount, 0u);
+    EXPECT_EQ(operation.mCancelledCount, 1);
+    EXPECT_EQ(caller.mCompletionCount, 0);
     EXPECT_TRUE(operation.IsPending());
     EXPECT_TRUE(caller.mCallback.IsRegistered());
 
     operation.Complete(CHIP_NO_ERROR, 9);
-    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 1);
     EXPECT_EQ(caller.mValue, 9);
-    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_EQ(operation.mCancelledCount, 1);
 }
 
 // A callee that rejects the call outright drops the Owned token instead of starting. The callback
@@ -353,8 +353,8 @@ TEST(CancelableOperationTest, RejectingWithoutStarting)
     operation.Start(caller.mCallback);
     EXPECT_EQ(reject(caller.mCallback), CHIP_ERROR_INCORRECT_STATE);
 
-    EXPECT_EQ(operation.mCancelledCount, 1u);
-    EXPECT_EQ(caller.mCompletionCount, 0u);
+    EXPECT_EQ(operation.mCancelledCount, 1);
+    EXPECT_EQ(caller.mCompletionCount, 0);
     EXPECT_FALSE(operation.IsPending());
     EXPECT_FALSE(caller.mCallback.IsRegistered());
 }
@@ -372,10 +372,10 @@ TEST(CancelableOperationTest, SequentialOperationsReuseTheSameInstance)
     operation.Start(caller.mCallback);
     operation.Complete(CHIP_ERROR_TIMEOUT, 3);
 
-    EXPECT_EQ(caller.mCompletionCount, 2u);
+    EXPECT_EQ(caller.mCompletionCount, 2);
     EXPECT_EQ(caller.mStatus, CHIP_ERROR_TIMEOUT);
     EXPECT_EQ(caller.mValue, 3);
-    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_EQ(operation.mCancelledCount, 1);
     EXPECT_FALSE(operation.IsPending());
     EXPECT_FALSE(caller.mCallback.IsRegistered());
 }
@@ -437,7 +437,7 @@ TEST(CancelableOperationTest, TypedCompletionOverACustomOperationBase)
 {
     struct Recorder
     {
-        size_t count      = 0;
+        int count         = 0;
         CHIP_ERROR status = CHIP_NO_ERROR;
 
         static void OnCompletion(void * context, CHIP_ERROR status)
@@ -460,7 +460,7 @@ TEST(CancelableOperationTest, TypedCompletionOverACustomOperationBase)
     EXPECT_EQ(*operation.mWork, 1);
 
     operation.Complete(CHIP_ERROR_CANCELLED);
-    EXPECT_EQ(recorder.count, 1u);
+    EXPECT_EQ(recorder.count, 1);
     EXPECT_EQ(recorder.status, CHIP_ERROR_CANCELLED);
     EXPECT_FALSE(operation.mWorkReleased);
     EXPECT_FALSE(operation.IsPending());
@@ -470,7 +470,7 @@ TEST(CancelableOperationTest, TypedCompletionOverACustomOperationBase)
     callback.Cancel();
     EXPECT_TRUE(operation.mWorkReleased);
     EXPECT_EQ(operation.mWork, nullptr); // the layer released what it was started with
-    EXPECT_EQ(recorder.count, 1u);
+    EXPECT_EQ(recorder.count, 1);
 }
 
 /**
@@ -510,7 +510,7 @@ private:
 class PayloadRecorder
 {
 public:
-    size_t mCount      = 0;
+    int mCount         = 0;
     CHIP_ERROR mStatus = CHIP_ERROR_INTERNAL;
     Payload mPayload;
 
@@ -557,7 +557,7 @@ TEST(CancelableOperationTest, MoveOnlyCompletionArgumentPassedByValue)
     EXPECT_TRUE(operation.IsPending());
 
     operation.Finish();
-    EXPECT_EQ(recorder.mCount, 1u);
+    EXPECT_EQ(recorder.mCount, 1);
     EXPECT_EQ(recorder.mStatus, CHIP_NO_ERROR);
     ASSERT_NE(recorder.mPayload, nullptr);
     EXPECT_EQ(*recorder.mPayload, 11);
@@ -575,7 +575,7 @@ TEST(CancelableOperationTest, MoveOnlyCompletionArgumentPassedByRvalueReference)
 
     operation.Begin(callback, std::make_unique<int>(22));
     operation.Finish();
-    EXPECT_EQ(recorder.mCount, 1u);
+    EXPECT_EQ(recorder.mCount, 1);
     ASSERT_NE(recorder.mPayload, nullptr);
     EXPECT_EQ(*recorder.mPayload, 22);
     EXPECT_FALSE(operation.IsPending());
@@ -599,13 +599,13 @@ TEST(CancelableOperationTest, RvalueReferencePayloadConsumedBeforeReuse)
     operation.Begin(callback, std::make_unique<int>(22));
     operation.Finish();
 
-    EXPECT_EQ(recorder.mCount, 1u);
+    EXPECT_EQ(recorder.mCount, 1);
     ASSERT_NE(recorder.mPayload, nullptr);
     EXPECT_EQ(*recorder.mPayload, 22);
     EXPECT_TRUE(operation.IsPending());
 
     operation.Finish();
-    EXPECT_EQ(recorder.mCount, 2u);
+    EXPECT_EQ(recorder.mCount, 2);
     ASSERT_NE(recorder.mPayload, nullptr);
     EXPECT_EQ(*recorder.mPayload, 44);
     EXPECT_FALSE(operation.IsPending());
@@ -624,7 +624,7 @@ TEST(CancelableOperationTest, MoveOnlyPayloadIsReleasedOnCancellation)
     operation.Begin(callback, std::make_unique<int>(33));
     callback.Cancel();
 
-    EXPECT_EQ(recorder.mCount, 0u);
+    EXPECT_EQ(recorder.mCount, 0);
     EXPECT_EQ(recorder.mPayload, nullptr);
     EXPECT_FALSE(operation.IsPending());
 }
@@ -639,16 +639,16 @@ TEST(CancelableOperationTest, FinishedBeforeCompletionCallbackRuns)
     caller.mOperation = &operation;
 
     operation.Start(caller.mCallback);
-    EXPECT_EQ(operation.mFinishedCount, 0u);
+    EXPECT_EQ(operation.mFinishedCount, 0);
 
     operation.Complete(CHIP_NO_ERROR, 3);
 
-    EXPECT_EQ(operation.mFinishedCount, 1u);
-    EXPECT_EQ(operation.mCancelledCount, 0u);
+    EXPECT_EQ(operation.mFinishedCount, 1);
+    EXPECT_EQ(operation.mCancelledCount, 0);
     EXPECT_EQ(operation.mLastFinishedCancelled, std::optional(false));
 
     // Already finished by the time the callback observed it, and no longer pending either.
-    EXPECT_EQ(caller.mFinishedCountDuringCompletion, std::optional<size_t>(1u));
+    EXPECT_EQ(caller.mFinishedCountDuringCompletion, std::optional<int>(1));
     ASSERT_TRUE(operation.mPendingDuringFinished.has_value());
     EXPECT_FALSE(*operation.mPendingDuringFinished);
 }
@@ -662,16 +662,16 @@ TEST(CancelableOperationTest, FinishedExactlyOncePerOperation)
 
     operation.Start(caller.mCallback);
     operation.Complete(CHIP_NO_ERROR, 1);
-    EXPECT_EQ(operation.mFinishedCount, 1u);
+    EXPECT_EQ(operation.mFinishedCount, 1);
 
     operation.Start(caller.mCallback);
     caller.mCallback.Cancel();
-    EXPECT_EQ(operation.mFinishedCount, 2u);
-    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_EQ(operation.mFinishedCount, 2);
+    EXPECT_EQ(operation.mCancelledCount, 1);
 
     // Cancelling again after the operation has already finished is a no-op.
     caller.mCallback.Cancel();
-    EXPECT_EQ(operation.mFinishedCount, 2u);
+    EXPECT_EQ(operation.mFinishedCount, 2);
 }
 
 // A restart from within the completion is a fresh operation, so it gets its own OnFinished().
@@ -684,12 +684,12 @@ TEST(CancelableOperationTest, FinishedAgainForAnOperationRestartedFromTheComplet
 
     operation.Start(caller.mCallback);
     operation.Complete(CHIP_NO_ERROR, 1);
-    EXPECT_EQ(operation.mFinishedCount, 1u);
+    EXPECT_EQ(operation.mFinishedCount, 1);
     EXPECT_TRUE(operation.IsPending());
 
     operation.Complete(CHIP_NO_ERROR, 2);
-    EXPECT_EQ(operation.mFinishedCount, 2u);
-    EXPECT_EQ(operation.mCancelledCount, 0u);
+    EXPECT_EQ(operation.mFinishedCount, 2);
+    EXPECT_EQ(operation.mCancelledCount, 0);
 }
 
 // An operation may free itself from the completion path of the hook as well, which is what lets a
@@ -727,7 +727,7 @@ TEST(CancelableOperationTest, DestroyedFromWithinOnFinishedWhileCompleting)
     // still delivered even though the operation is already gone.
     operation->Complete(CHIP_ERROR_TIMEOUT, 8);
     EXPECT_TRUE(destroyed);
-    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 1);
     EXPECT_EQ(caller.mStatus, CHIP_ERROR_TIMEOUT);
     EXPECT_EQ(caller.mValue, 8);
     EXPECT_FALSE(caller.mCallback.IsRegistered());
@@ -761,7 +761,7 @@ public:
     using FallibleLeafBase::Complete;
     using FallibleLeafBase::Start;
 
-    size_t mFinishedCount = 0;
+    int mFinishedCount = 0;
 
 protected:
     void OnFinished(bool cancelled) override
@@ -787,7 +787,7 @@ TEST(CancelableOperationTest, FallibleStartForwardsItsResult)
 {
     struct Recorder
     {
-        size_t count = 0;
+        int count = 0;
         static void OnCompletion(void * context, CHIP_ERROR) { static_cast<Recorder *>(context)->count++; }
     } recorder;
 
@@ -799,8 +799,8 @@ TEST(CancelableOperationTest, FallibleStartForwardsItsResult)
     EXPECT_EQ(operation.Start(false, callback), CHIP_ERROR_INVALID_ARGUMENT);
     EXPECT_FALSE(operation.IsPending());
     EXPECT_FALSE(callback.IsRegistered());
-    EXPECT_EQ(operation.mFinishedCount, 0u);
-    EXPECT_EQ(recorder.count, 0u);
+    EXPECT_EQ(operation.mFinishedCount, 0);
+    EXPECT_EQ(recorder.count, 0);
 
     // Accepted: the usual contract applies from here on.
     EXPECT_EQ(operation.Start(true, callback), CHIP_NO_ERROR);
@@ -808,8 +808,8 @@ TEST(CancelableOperationTest, FallibleStartForwardsItsResult)
     EXPECT_TRUE(callback.IsRegistered());
 
     operation.Complete(CHIP_NO_ERROR);
-    EXPECT_EQ(recorder.count, 1u);
-    EXPECT_EQ(operation.mFinishedCount, 1u);
+    EXPECT_EQ(recorder.count, 1);
+    EXPECT_EQ(operation.mFinishedCount, 1);
     EXPECT_FALSE(operation.IsPending());
 }
 
@@ -825,9 +825,9 @@ TEST(CancelableOperationTest, FallibleStartRejectionCancelsAPendingOperation)
 
     EXPECT_EQ(second.Start(false, callback), CHIP_ERROR_INVALID_ARGUMENT);
     EXPECT_FALSE(first.IsPending());
-    EXPECT_EQ(first.mFinishedCount, 1u);
+    EXPECT_EQ(first.mFinishedCount, 1);
     EXPECT_FALSE(second.IsPending());
-    EXPECT_EQ(second.mFinishedCount, 0u);
+    EXPECT_EQ(second.mFinishedCount, 0);
     EXPECT_FALSE(callback.IsRegistered());
 }
 

--- a/src/lib/core/tests/TestCancelableOperation.cpp
+++ b/src/lib/core/tests/TestCancelableOperation.cpp
@@ -1,0 +1,879 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/CancelableOperation.h>
+#include <lib/core/StringBuilderAdapters.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Callback;
+
+using TestOperationBase = CancelableOperation<CHIP_ERROR, int>;
+
+class TestCaller;
+
+/**
+ * A concrete operation, standing in for the sort of thing a real subclass would be. It performs no
+ * work of its own; the test drives the inherited Start() / Complete() directly, which are exposed
+ * publicly here.
+ */
+class TestOperation : public TestOperationBase
+{
+public:
+    using TestOperationBase::Complete;
+    using TestOperationBase::Start;
+
+    size_t mCancelledCount = 0;
+    size_t mFinishedCount  = 0;
+
+    // The `cancelled` argument of, and what IsPending() returned during, the most recent
+    // OnFinished() call.
+    std::optional<bool> mLastFinishedCancelled;
+    std::optional<bool> mPendingDuringFinished;
+
+protected:
+    void OnFinished(bool cancelled) override
+    {
+        mFinishedCount++;
+        mCancelledCount += cancelled ? 1 : 0;
+        mLastFinishedCancelled = cancelled;
+        mPendingDuringFinished = IsPending();
+        TestOperationBase::OnFinished(cancelled);
+    }
+};
+
+/**
+ * The "caller" side: owns the completion callback and records what it hears back.
+ */
+class TestCaller
+{
+public:
+    TestOperationBase::Completion mCallback{ OnCompletion, this };
+
+    size_t mCompletionCount = 0;
+    CHIP_ERROR mStatus      = CHIP_NO_ERROR;
+    int mValue              = 0;
+
+    // Observed from within the completion handler.
+    std::optional<bool> mPendingDuringCompletion;
+    std::optional<bool> mRegisteredDuringCompletion;
+    std::optional<size_t> mFinishedCountDuringCompletion;
+
+    // The operation the callback was handed to, and an optional action to run reentrantly from
+    // within the completion handler (cleared before it runs, so it only fires once).
+    TestOperation * mOperation             = nullptr;
+    void (*mReentrantAction)(TestCaller &) = nullptr;
+
+    // Optionally holds the operation, so that a reentrant action can destroy it.
+    std::unique_ptr<TestOperation> mOwnedOperation;
+
+private:
+    static void OnCompletion(void * context, CHIP_ERROR status, int value)
+    {
+        auto & self = *static_cast<TestCaller *>(context);
+        self.mCompletionCount++;
+        self.mStatus = status;
+        self.mValue  = value;
+
+        if (self.mOperation != nullptr)
+        {
+            self.mPendingDuringCompletion       = self.mOperation->IsPending();
+            self.mRegisteredDuringCompletion    = self.mCallback.IsRegistered();
+            self.mFinishedCountDuringCompletion = self.mOperation->mFinishedCount;
+        }
+
+        if (auto * action = self.mReentrantAction)
+        {
+            self.mReentrantAction = nullptr;
+            action(self);
+        }
+    }
+};
+
+TEST(CancelableOperationTest, IdleBeforeBeingStarted)
+{
+    TestOperation operation;
+    TestCaller caller;
+
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+}
+
+TEST(CancelableOperationTest, StartAndComplete)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    operation.Start(caller.mCallback);
+    EXPECT_TRUE(operation.IsPending());
+    EXPECT_TRUE(caller.mCallback.IsRegistered());
+    EXPECT_EQ(caller.mCompletionCount, 0u);
+
+    CHIP_ERROR status = CHIP_ERROR_BUSY;
+    int value         = 42;
+    operation.Complete(status, value);
+
+    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mStatus, CHIP_ERROR_BUSY);
+    EXPECT_EQ(caller.mValue, 42);
+    EXPECT_EQ(operation.mCancelledCount, 0u);
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+}
+
+// The operation must relinquish the callback *before* invoking it, so that the caller is free to
+// hand the callback straight back to another callee (or to this operation) from the completion.
+TEST(CancelableOperationTest, NeitherPendingNorRegisteredDuringCompletion)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    operation.Start(caller.mCallback);
+    operation.Complete(CHIP_NO_ERROR, 0);
+
+    ASSERT_TRUE(caller.mPendingDuringCompletion.has_value());
+    EXPECT_FALSE(*caller.mPendingDuringCompletion);
+    ASSERT_TRUE(caller.mRegisteredDuringCompletion.has_value());
+    EXPECT_FALSE(*caller.mRegisteredDuringCompletion);
+}
+
+TEST(CancelableOperationTest, RestartedFromWithinCompletion)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation       = &operation;
+    caller.mReentrantAction = [](TestCaller & self) { self.mOperation->Start(self.mCallback); };
+
+    operation.Start(caller.mCallback);
+    operation.Complete(CHIP_NO_ERROR, 1);
+
+    // The reentrant Start() left a second operation in flight.
+    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_TRUE(operation.IsPending());
+    EXPECT_TRUE(caller.mCallback.IsRegistered());
+
+    operation.Complete(CHIP_NO_ERROR, 2);
+    EXPECT_EQ(caller.mCompletionCount, 2u);
+    EXPECT_EQ(caller.mValue, 2);
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+}
+
+// Complete() touches no operation state once it has handed the callback back, so a completion
+// handler is free to destroy the operation (e.g. to return it to a pool).
+TEST(CancelableOperationTest, DestroyedFromWithinCompletion)
+{
+    TestCaller caller;
+    caller.mOwnedOperation  = std::make_unique<TestOperation>();
+    caller.mOperation       = caller.mOwnedOperation.get();
+    caller.mReentrantAction = [](TestCaller & self) {
+        self.mOperation = nullptr;
+        self.mOwnedOperation.reset();
+    };
+
+    TestOperation & operation = *caller.mOwnedOperation;
+    operation.Start(caller.mCallback);
+    operation.Complete(CHIP_NO_ERROR, 5);
+
+    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mValue, 5);
+    EXPECT_EQ(caller.mOwnedOperation, nullptr);
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+}
+
+TEST(CancelableOperationTest, CallerCancels)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    operation.Start(caller.mCallback);
+    caller.mCallback.Cancel();
+
+    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 0u);
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+
+    // The operation is told about the cancellation only once it is no longer pending, so that it
+    // cannot mistakenly try to complete in response.
+    ASSERT_TRUE(operation.mPendingDuringFinished.has_value());
+    EXPECT_FALSE(*operation.mPendingDuringFinished);
+    EXPECT_EQ(operation.mLastFinishedCancelled, std::optional(true));
+}
+
+// A completed operation must not be reachable from the callback any more: a caller that recycles
+// its callback (which starts with a Cancel()) must not be mistaken for one giving up on the work.
+TEST(CancelableOperationTest, CancellingAfterCompletionIsANoOp)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    operation.Start(caller.mCallback);
+    operation.Complete(CHIP_NO_ERROR, 0);
+    caller.mCallback.Cancel();
+
+    EXPECT_EQ(operation.mCancelledCount, 0u);
+    EXPECT_EQ(caller.mCompletionCount, 1u);
+}
+
+TEST(CancelableOperationTest, DestroyingTheCallbackCancels)
+{
+    TestOperation operation;
+    {
+        TestCaller caller;
+        caller.mOperation = &operation;
+        operation.Start(caller.mCallback);
+        EXPECT_TRUE(operation.IsPending());
+    }
+
+    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_FALSE(operation.IsPending());
+}
+
+// A pooled operation may well free itself once it is no longer pending. Cancel() only touches the
+// Cancelable (which belongs to the caller) after the CancelFn returns, so this is safe.
+TEST(CancelableOperationTest, DestroyedFromWithinOnFinished)
+{
+    bool destroyed = false;
+
+    class SelfFreeingOperation : public TestOperationBase
+    {
+    public:
+        using TestOperationBase::Start;
+
+        explicit SelfFreeingOperation(bool * destroyed) : mDestroyed(destroyed) {}
+        ~SelfFreeingOperation() override { *mDestroyed = true; }
+
+    protected:
+        void OnFinished(bool cancelled) override
+        {
+            TestOperationBase::OnFinished(cancelled);
+            delete this;
+        }
+
+    private:
+        bool * mDestroyed;
+    };
+
+    TestCaller caller;
+    (new SelfFreeingOperation(&destroyed))->Start(caller.mCallback);
+    ASSERT_FALSE(destroyed);
+
+    caller.mCallback.Cancel();
+    EXPECT_TRUE(destroyed);
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+    EXPECT_EQ(caller.mCompletionCount, 0u);
+}
+
+// Callback::Cancel() cancels interest with any previous callee, so handing an already-registered
+// callback to a second operation withdraws it from the first.
+TEST(CancelableOperationTest, StartingASecondOperationCancelsTheFirst)
+{
+    TestOperation first;
+    TestOperation second;
+    TestCaller caller;
+
+    first.Start(caller.mCallback);
+    second.Start(caller.mCallback);
+
+    EXPECT_EQ(first.mCancelledCount, 1u);
+    EXPECT_FALSE(first.IsPending());
+    EXPECT_EQ(second.mCancelledCount, 0u);
+    EXPECT_TRUE(second.IsPending());
+    EXPECT_TRUE(caller.mCallback.IsRegistered());
+
+    caller.mOperation = &second;
+    second.Complete(CHIP_NO_ERROR, 7);
+    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mValue, 7);
+}
+
+// Handing a callback back to the operation it is already registered with does not trip Start()'s
+// not-already-pending assertion: the Owned token cancels at the call boundary, so the in-flight
+// operation is cancelled before Start() ever runs.
+TEST(CancelableOperationTest, RestartingWithTheSameCallbackCancelsTheInFlightOperation)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    operation.Start(caller.mCallback);
+    operation.Start(caller.mCallback);
+
+    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 0u);
+    EXPECT_TRUE(operation.IsPending());
+    EXPECT_TRUE(caller.mCallback.IsRegistered());
+
+    operation.Complete(CHIP_NO_ERROR, 9);
+    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mValue, 9);
+    EXPECT_EQ(operation.mCancelledCount, 1u);
+}
+
+// A callee that rejects the call outright drops the Owned token instead of starting. The callback
+// has still been cancelled at the boundary, so a previously pending operation hears about it.
+TEST(CancelableOperationTest, RejectingWithoutStarting)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    auto reject = [](TestOperationBase::Completion::Owned) { return CHIP_ERROR_INCORRECT_STATE; };
+
+    operation.Start(caller.mCallback);
+    EXPECT_EQ(reject(caller.mCallback), CHIP_ERROR_INCORRECT_STATE);
+
+    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_EQ(caller.mCompletionCount, 0u);
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+}
+
+TEST(CancelableOperationTest, SequentialOperationsReuseTheSameInstance)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    operation.Start(caller.mCallback);
+    operation.Complete(CHIP_NO_ERROR, 1);
+    operation.Start(caller.mCallback);
+    caller.mCallback.Cancel();
+    operation.Start(caller.mCallback);
+    operation.Complete(CHIP_ERROR_TIMEOUT, 3);
+
+    EXPECT_EQ(caller.mCompletionCount, 2u);
+    EXPECT_EQ(caller.mStatus, CHIP_ERROR_TIMEOUT);
+    EXPECT_EQ(caller.mValue, 3);
+    EXPECT_EQ(operation.mCancelledCount, 1u);
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+}
+
+/**
+ * A move-only payload, to pin that Start() can take ownership of something and Complete() can hand
+ * ownership back to the caller. This is what makes the std::forward<>() in both load-bearing rather
+ * than a no-op: without it neither the Start() below nor either Complete() spelling compiles.
+ */
+using Payload = std::unique_ptr<int>;
+
+/**
+ * A reusable, signature-independent operation layer, in the shape that real users of the mixin are
+ * expected to take: the shared mechanics subclass CancelableOperationBase (and are compiled once),
+ * and the completion signature is applied on top per concrete operation.
+ *
+ * It takes parameters of its own in Start(); the mixin reads them off that declaration and
+ * re-declares Start() with them ahead of the typed completion.
+ */
+class UnderlyingWorkOperationBase : public CancelableOperationBase
+{
+public:
+    bool mWorkReleased  = false;
+    const char * mLabel = nullptr;
+    Payload mWork;
+
+protected:
+    void Start(const char * label, Payload work, Cancelable::Owned onCompletion)
+    {
+        CancelableOperationBase::Start(std::move(onCompletion));
+        mLabel = label;
+        mWork  = std::move(work);
+    }
+
+    void OnFinished(bool cancelled) override
+    {
+        if (cancelled)
+        {
+            mWorkReleased = true;
+            mWork.reset();
+        }
+        CancelableOperationBase::OnFinished(cancelled);
+    }
+};
+
+template <typename... Args>
+using UnderlyingWorkOperation = TypedOperation<UnderlyingWorkOperationBase, Args...>;
+
+using StatusOnlyOperationBase = UnderlyingWorkOperation<CHIP_ERROR>;
+
+class StatusOnlyOperation : public StatusOnlyOperationBase
+{
+public:
+    using StatusOnlyOperationBase::Complete;
+    using StatusOnlyOperationBase::Start;
+};
+
+TEST(CancelableOperationTest, TypedCompletionOverACustomOperationBase)
+{
+    struct Recorder
+    {
+        size_t count      = 0;
+        CHIP_ERROR status = CHIP_NO_ERROR;
+
+        static void OnCompletion(void * context, CHIP_ERROR status)
+        {
+            auto & self = *static_cast<Recorder *>(context);
+            self.count++;
+            self.status = status;
+        }
+    } recorder;
+
+    StatusOnlyOperation::Completion callback(Recorder::OnCompletion, &recorder);
+    StatusOnlyOperation operation;
+
+    // The layer's own parameters come ahead of the completion, and are forwarded to it.
+    operation.Start("first", std::make_unique<int>(1), callback);
+    EXPECT_TRUE(operation.IsPending());
+    EXPECT_FALSE(operation.mWorkReleased);
+    EXPECT_STREQ(operation.mLabel, "first");
+    ASSERT_NE(operation.mWork, nullptr);
+    EXPECT_EQ(*operation.mWork, 1);
+
+    operation.Complete(CHIP_ERROR_CANCELLED);
+    EXPECT_EQ(recorder.count, 1u);
+    EXPECT_EQ(recorder.status, CHIP_ERROR_CANCELLED);
+    EXPECT_FALSE(operation.mWorkReleased);
+    EXPECT_FALSE(operation.IsPending());
+
+    operation.Start("second", std::make_unique<int>(2), callback);
+    EXPECT_STREQ(operation.mLabel, "second");
+    callback.Cancel();
+    EXPECT_TRUE(operation.mWorkReleased);
+    EXPECT_EQ(operation.mWork, nullptr); // the layer released what it was started with
+    EXPECT_EQ(recorder.count, 1u);
+}
+
+/**
+ * An operation that takes ownership of a payload when it starts, and hands it back on completion.
+ * PayloadArg selects how the completion signature carries it: `Payload` by value, or `Payload &&`.
+ * Note the latter is baked into the class type parameter, i.e. is not a forwarding reference.
+ */
+template <typename PayloadArg>
+class PayloadOperation : public CancelableOperation<CHIP_ERROR, PayloadArg>
+{
+public:
+    using Base = CancelableOperation<CHIP_ERROR, PayloadArg>;
+    using typename Base::Completion;
+
+    void Begin(typename Completion::Owned onCompletion, Payload payload)
+    {
+        mPayload = std::move(payload);
+        Base::Start(std::move(onCompletion));
+    }
+
+    void Finish() { Base::Complete(CHIP_NO_ERROR, std::move(mPayload)); }
+
+protected:
+    void OnFinished(bool cancelled) override
+    {
+        if (cancelled)
+        {
+            mPayload.reset();
+        }
+        Base::OnFinished(cancelled);
+    }
+
+private:
+    Payload mPayload;
+};
+
+class PayloadRecorder
+{
+public:
+    size_t mCount      = 0;
+    CHIP_ERROR mStatus = CHIP_ERROR_INTERNAL;
+    Payload mPayload;
+
+    // When set, the completion handler restarts this operation with a payload holding
+    // mRestartValue, but only after having moved away the payload it was called with.
+    PayloadOperation<Payload &&> * mRestartOperation            = nullptr;
+    PayloadOperation<Payload &&>::Completion * mRestartCallback = nullptr;
+    int mRestartValue                                           = 0;
+
+    static void OnCompletionByValue(void * context, CHIP_ERROR status, Payload payload)
+    {
+        static_cast<PayloadRecorder *>(context)->Record(status, std::move(payload));
+    }
+
+    static void OnCompletionByRvalueRef(void * context, CHIP_ERROR status, Payload && payload)
+    {
+        static_cast<PayloadRecorder *>(context)->Record(status, std::move(payload));
+    }
+
+private:
+    void Record(CHIP_ERROR status, Payload payload)
+    {
+        mCount++;
+        mStatus  = status;
+        mPayload = std::move(payload);
+
+        if (auto * operation = mRestartOperation)
+        {
+            mRestartOperation = nullptr;
+            operation->Begin(*mRestartCallback, std::make_unique<int>(mRestartValue));
+        }
+    }
+};
+
+TEST(CancelableOperationTest, MoveOnlyCompletionArgumentPassedByValue)
+{
+    using Operation = PayloadOperation<Payload>;
+
+    PayloadRecorder recorder;
+    Operation::Completion callback(PayloadRecorder::OnCompletionByValue, &recorder);
+    Operation operation;
+
+    operation.Begin(callback, std::make_unique<int>(11));
+    EXPECT_TRUE(operation.IsPending());
+
+    operation.Finish();
+    EXPECT_EQ(recorder.mCount, 1u);
+    EXPECT_EQ(recorder.mStatus, CHIP_NO_ERROR);
+    ASSERT_NE(recorder.mPayload, nullptr);
+    EXPECT_EQ(*recorder.mPayload, 11);
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(callback.IsRegistered());
+}
+
+TEST(CancelableOperationTest, MoveOnlyCompletionArgumentPassedByRvalueReference)
+{
+    using Operation = PayloadOperation<Payload &&>;
+
+    PayloadRecorder recorder;
+    Operation::Completion callback(PayloadRecorder::OnCompletionByRvalueRef, &recorder);
+    Operation operation;
+
+    operation.Begin(callback, std::make_unique<int>(22));
+    operation.Finish();
+    EXPECT_EQ(recorder.mCount, 1u);
+    ASSERT_NE(recorder.mPayload, nullptr);
+    EXPECT_EQ(*recorder.mPayload, 22);
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(callback.IsRegistered());
+}
+
+// The operation hands back a reference to storage it owns, so a caller accepting an rvalue
+// reference has to move the payload away before reusing the operation. Done in that order, both
+// the payload it was given and the restarted operation come out intact.
+TEST(CancelableOperationTest, RvalueReferencePayloadConsumedBeforeReuse)
+{
+    using Operation = PayloadOperation<Payload &&>;
+
+    PayloadRecorder recorder;
+    Operation::Completion callback(PayloadRecorder::OnCompletionByRvalueRef, &recorder);
+    Operation operation;
+    recorder.mRestartOperation = &operation;
+    recorder.mRestartCallback  = &callback;
+    recorder.mRestartValue     = 44;
+
+    operation.Begin(callback, std::make_unique<int>(22));
+    operation.Finish();
+
+    EXPECT_EQ(recorder.mCount, 1u);
+    ASSERT_NE(recorder.mPayload, nullptr);
+    EXPECT_EQ(*recorder.mPayload, 22);
+    EXPECT_TRUE(operation.IsPending());
+
+    operation.Finish();
+    EXPECT_EQ(recorder.mCount, 2u);
+    ASSERT_NE(recorder.mPayload, nullptr);
+    EXPECT_EQ(*recorder.mPayload, 44);
+    EXPECT_FALSE(operation.IsPending());
+}
+
+// The payload an operation is holding is released when the caller withdraws its callback, rather
+// than being handed back through a completion that must not happen.
+TEST(CancelableOperationTest, MoveOnlyPayloadIsReleasedOnCancellation)
+{
+    using Operation = PayloadOperation<Payload>;
+
+    PayloadRecorder recorder;
+    Operation::Completion callback(PayloadRecorder::OnCompletionByValue, &recorder);
+    Operation operation;
+
+    operation.Begin(callback, std::make_unique<int>(33));
+    callback.Cancel();
+
+    EXPECT_EQ(recorder.mCount, 0u);
+    EXPECT_EQ(recorder.mPayload, nullptr);
+    EXPECT_FALSE(operation.IsPending());
+}
+
+// The hook fires on the completion path too, with cancelled = false, and it does so *before* the
+// caller's callback runs: an intermediate layer's in-flight work is torn down by the time the
+// callback can reuse or destroy the operation.
+TEST(CancelableOperationTest, FinishedBeforeCompletionCallbackRuns)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    operation.Start(caller.mCallback);
+    EXPECT_EQ(operation.mFinishedCount, 0u);
+
+    operation.Complete(CHIP_NO_ERROR, 3);
+
+    EXPECT_EQ(operation.mFinishedCount, 1u);
+    EXPECT_EQ(operation.mCancelledCount, 0u);
+    EXPECT_EQ(operation.mLastFinishedCancelled, std::optional(false));
+
+    // Already finished by the time the callback observed it, and no longer pending either.
+    EXPECT_EQ(caller.mFinishedCountDuringCompletion, std::optional<size_t>(1u));
+    ASSERT_TRUE(operation.mPendingDuringFinished.has_value());
+    EXPECT_FALSE(*operation.mPendingDuringFinished);
+}
+
+// Exactly one OnFinished() per started operation, whichever way it ends.
+TEST(CancelableOperationTest, FinishedExactlyOncePerOperation)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation = &operation;
+
+    operation.Start(caller.mCallback);
+    operation.Complete(CHIP_NO_ERROR, 1);
+    EXPECT_EQ(operation.mFinishedCount, 1u);
+
+    operation.Start(caller.mCallback);
+    caller.mCallback.Cancel();
+    EXPECT_EQ(operation.mFinishedCount, 2u);
+    EXPECT_EQ(operation.mCancelledCount, 1u);
+
+    // Cancelling again after the operation has already finished is a no-op.
+    caller.mCallback.Cancel();
+    EXPECT_EQ(operation.mFinishedCount, 2u);
+}
+
+// A restart from within the completion is a fresh operation, so it gets its own OnFinished().
+TEST(CancelableOperationTest, FinishedAgainForAnOperationRestartedFromTheCompletion)
+{
+    TestOperation operation;
+    TestCaller caller;
+    caller.mOperation       = &operation;
+    caller.mReentrantAction = [](TestCaller & self) { self.mOperation->Start(self.mCallback); };
+
+    operation.Start(caller.mCallback);
+    operation.Complete(CHIP_NO_ERROR, 1);
+    EXPECT_EQ(operation.mFinishedCount, 1u);
+    EXPECT_TRUE(operation.IsPending());
+
+    operation.Complete(CHIP_NO_ERROR, 2);
+    EXPECT_EQ(operation.mFinishedCount, 2u);
+    EXPECT_EQ(operation.mCancelledCount, 0u);
+}
+
+// An operation may free itself from the completion path of the hook as well, which is what lets a
+// pooled operation return itself to the pool without the leaf having to arrange it.
+TEST(CancelableOperationTest, DestroyedFromWithinOnFinishedWhileCompleting)
+{
+    bool destroyed = false;
+
+    class SelfFreeingOnCompletion : public TestOperationBase
+    {
+    public:
+        using TestOperationBase::Complete;
+        using TestOperationBase::Start;
+
+        explicit SelfFreeingOnCompletion(bool * destroyed) : mDestroyed(destroyed) {}
+        ~SelfFreeingOnCompletion() override { *mDestroyed = true; }
+
+    protected:
+        void OnFinished(bool cancelled) override
+        {
+            TestOperationBase::OnFinished(cancelled);
+            delete this;
+        }
+
+    private:
+        bool * mDestroyed;
+    };
+
+    TestCaller caller;
+    auto * operation = new SelfFreeingOnCompletion(&destroyed);
+    operation->Start(caller.mCallback);
+    ASSERT_FALSE(destroyed);
+
+    // Complete() must not touch the operation after TakeCompletion() returns, so the callback is
+    // still delivered even though the operation is already gone.
+    operation->Complete(CHIP_ERROR_TIMEOUT, 8);
+    EXPECT_TRUE(destroyed);
+    EXPECT_EQ(caller.mCompletionCount, 1u);
+    EXPECT_EQ(caller.mStatus, CHIP_ERROR_TIMEOUT);
+    EXPECT_EQ(caller.mValue, 8);
+    EXPECT_FALSE(caller.mCallback.IsRegistered());
+}
+
+/**
+ * A layer whose Start() is fallible, to pin that TypedOperation forwards the result. It decides
+ * before taking ownership of the completion, so a rejection leaves nothing pending and owes no
+ * callback -- the Owned token is simply dropped, having already cancelled at the call boundary.
+ */
+class FallibleOperationBase : public CancelableOperationBase
+{
+public:
+    CHIP_ERROR mAcceptedWith = CHIP_ERROR_INTERNAL;
+
+protected:
+    CHIP_ERROR Start(bool accept, Cancelable::Owned onCompletion)
+    {
+        VerifyOrReturnError(accept, CHIP_ERROR_INVALID_ARGUMENT);
+        CancelableOperationBase::Start(std::move(onCompletion));
+        mAcceptedWith = CHIP_NO_ERROR;
+        return CHIP_NO_ERROR;
+    }
+};
+
+using FallibleLeafBase = TypedOperation<FallibleOperationBase, CHIP_ERROR>;
+
+class FallibleOperation : public FallibleLeafBase
+{
+public:
+    using FallibleLeafBase::Complete;
+    using FallibleLeafBase::Start;
+
+    size_t mFinishedCount = 0;
+
+protected:
+    void OnFinished(bool cancelled) override
+    {
+        mFinishedCount++;
+        FallibleOperationBase::OnFinished(cancelled);
+    }
+};
+
+// The CHIP_ERROR from the layer's Start() reaches the caller through the typed Start().
+TEST(CancelableOperationTest, FallibleStartForwardsItsResult)
+{
+    struct Recorder
+    {
+        size_t count = 0;
+        static void OnCompletion(void * context, CHIP_ERROR) { static_cast<Recorder *>(context)->count++; }
+    } recorder;
+
+    FallibleOperation::Completion callback(Recorder::OnCompletion, &recorder);
+    FallibleOperation operation;
+
+    // Rejected: no completion is owed, nothing is pending, and the callback was still cancelled at
+    // the call boundary, so it is left registered with nobody.
+    EXPECT_EQ(operation.Start(false, callback), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_FALSE(operation.IsPending());
+    EXPECT_FALSE(callback.IsRegistered());
+    EXPECT_EQ(operation.mFinishedCount, 0u);
+    EXPECT_EQ(recorder.count, 0u);
+
+    // Accepted: the usual contract applies from here on.
+    EXPECT_EQ(operation.Start(true, callback), CHIP_NO_ERROR);
+    EXPECT_TRUE(operation.IsPending());
+    EXPECT_TRUE(callback.IsRegistered());
+
+    operation.Complete(CHIP_NO_ERROR);
+    EXPECT_EQ(recorder.count, 1u);
+    EXPECT_EQ(operation.mFinishedCount, 1u);
+    EXPECT_FALSE(operation.IsPending());
+}
+
+// A rejection must not disturb an operation that is already in flight elsewhere -- except via the
+// Owned token's boundary Cancel(), which withdraws the callback from whoever held it.
+TEST(CancelableOperationTest, FallibleStartRejectionCancelsAPendingOperation)
+{
+    FallibleOperation::Completion callback([](void *, CHIP_ERROR) {}, nullptr);
+    FallibleOperation first, second;
+
+    EXPECT_EQ(first.Start(true, callback), CHIP_NO_ERROR);
+    EXPECT_TRUE(first.IsPending());
+
+    EXPECT_EQ(second.Start(false, callback), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_FALSE(first.IsPending());
+    EXPECT_EQ(first.mFinishedCount, 1u);
+    EXPECT_FALSE(second.IsPending());
+    EXPECT_EQ(second.mFinishedCount, 0u);
+    EXPECT_FALSE(callback.IsRegistered());
+}
+
+// void Start() still works: the forwarding `return` of a void expression is well-formed.
+static_assert(
+    std::is_same_v<decltype(std::declval<TestOperation &>().Start(std::declval<TestOperationBase::Completion &>())), void>,
+    "a void Start() forwards as void");
+static_assert(
+    std::is_same_v<decltype(std::declval<FallibleOperation &>().Start(true, std::declval<FallibleOperation::Completion &>())),
+                   CHIP_ERROR>,
+    "a fallible Start() forwards its CHIP_ERROR");
+
+/**
+ * A layer between the root and the leaf, to pin that OnFinished() chains all the way up. Records
+ * into a trace so that the order of the layers is observable, not just the fact that both ran.
+ */
+std::vector<std::string> gFinishedTrace;
+
+class ChainMiddleBase : public CancelableOperationBase
+{
+protected:
+    void OnFinished(bool cancelled) override
+    {
+        gFinishedTrace.push_back(cancelled ? "middle:cancelled" : "middle:completed");
+        CancelableOperationBase::OnFinished(cancelled);
+    }
+};
+
+using ChainLeafBase = TypedOperation<ChainMiddleBase, CHIP_ERROR>;
+
+class ChainLeafOperation : public ChainLeafBase
+{
+public:
+    using ChainLeafBase::Complete;
+    using ChainLeafBase::Start;
+
+protected:
+    void OnFinished(bool cancelled) override
+    {
+        gFinishedTrace.push_back(cancelled ? "leaf:cancelled" : "leaf:completed");
+        ChainMiddleBase::OnFinished(cancelled);
+    }
+};
+
+TEST(CancelableOperationTest, HookChainsThroughIntermediateLayers)
+{
+    gFinishedTrace.clear();
+
+    ChainLeafOperation::Completion callback([](void *, CHIP_ERROR) {}, nullptr);
+    ChainLeafOperation operation;
+
+    operation.Start(callback);
+    operation.Complete(CHIP_NO_ERROR);
+    operation.Start(callback);
+    callback.Cancel();
+
+    EXPECT_EQ(gFinishedTrace,
+              (std::vector<std::string>{ "leaf:completed", "middle:completed", "leaf:cancelled", "middle:cancelled" }));
+}
+
+} // namespace

--- a/src/lib/core/tests/TestCancelableOperation.cpp
+++ b/src/lib/core/tests/TestCancelableOperation.cpp
@@ -19,6 +19,7 @@
 
 #include <lib/core/CancelableOperation.h>
 #include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/tests/ExtraPwTestMacros.h>
 
 #include <memory>
 #include <optional>


### PR DESCRIPTION
### Summary

Cancelable::Owned / Callback<T>::Owned are implicitly constructible wrappers around a Cancelable pointer that ensure reliable taking of ownership at a caller-to-callee boundary.

CancelableOperation is a base class that provides the mechanics of implementing an operation that accepts a Callback<T>, and enforces the contract that the caller hears back exactly once. It's useful for cases where cancellation has to actually do some work to stop an operation. (In contrast, CallbackDeque or GroupedCallbackList are most suited to use cases where several callers wait on some shared work, and cancellation simply unlinks an individual Callback from that list.)

A TypedOperation template is provided so that reusable intermediate operation base classes (e.g. an operation that establishes a CASE session with a device and then does something with it) can be plain classes, rather than templates over the completion arguments of the ultimate leaf class.

Also add an Invoke() helper on Callback<T> that prepends mContext. Remove the suggestion to sub-class Callback with extra function pointers for now, since that would involve extra work to integrate nicely with ::Owned tokens.

#### A sketch of an intermediate operation base class

```
class ControllerOperationBase : public Callback::CancelableOperationBase
{
protected:
    void Start(DeviceController & controller, NodeId nodeId, Callback::Cancelable::Owned onCompletion)
    {
        Callback::CancelableOperationBase::Start(std::move(onCompletion));
        CHIP_ERROR err = controller.GetConnectedDevice(nodeId, &mDeviceConnected, &mDeviceConnectionFailure);
        if (err != CHIP_NO_ERROR)
        {
            OnConnectionFailure(err);
        }
    }

    void OnFinished(bool cancelled) override
    {
        mDeviceConnected.Cancel();
        mDeviceConnectionFailure.Cancel();
        Callback::CancelableOperationBase::OnFinished(cancelled);
    }

    virtual void OnConnected(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle) = 0;
    virtual void OnConnectionFailure(CHIP_ERROR error)                                                      = 0;

    Callback::Callback<OnDeviceConnected> mDeviceConnected = ...;
    Callback::Callback<OnDeviceConnectionFailure> mDeviceConnectionFailure = ...;
};

template <typename... Args>
using ControllerOperation = Callback::TypedOperation<ControllerOperationBase, Args...>;
```

### Testing

New unit tests.