### PR TITLE
[NXP][Zephyr] Use upstream Zephyr for CI build

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -31,6 +31,7 @@ concurrency:
 
 env:
     CHIP_LOG_TIMESTAMPS: false
+    NXP_ZEPHYR_REVISION: b9df9f46ae4618a97c138b2c3cc11685264f967c
 
 jobs:
     FreeRTOS:
@@ -148,7 +149,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:203
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:211
             volumes:
                 - "/:/runner-root-volume"
 
@@ -172,6 +173,17 @@ jobs:
                       pigweed:
                         - 'src/pw_backends/**'
                         - 'third_party/pigweed/**'
+            - name: Setup Zephyr Workspace
+              if:
+                  github.event_name == 'push' ||
+                  steps.changed_paths.outputs.nxp == 'true' ||
+                  steps.changed_paths.outputs.pigweed == 'true'
+              run: |
+                  rm -rf /opt/nxp-zephyr/zephyrproject
+                  west init /opt/nxp-zephyr/zephyrproject -m https://github.com/zephyrproject-rtos/zephyr.git --mr ${{ env.NXP_ZEPHYR_REVISION }}
+                  cd /opt/nxp-zephyr/zephyrproject
+                  west update -o=--depth=1 -n
+                  west zephyr-export
             - name: Build NXP Zephyr all-clusters example
               if:
                   github.event_name == 'push' || steps.changed_paths.outputs.nxp

--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -191,7 +191,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target nxp-rw61x-zephyr-all-clusters \
+                      --target nxp-rw61x-zephyr-all-clusters-build-only-no-blobs \
                       build \
                   "
 
@@ -205,7 +205,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target nxp-rw61x-zephyr-thermostat-ota \
+                      --target nxp-rw61x-zephyr-thermostat-ota-build-only-no-blobs \
                       build \
                   "
 
@@ -219,7 +219,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target nxp-rw61x-zephyr-thermostat-thread \
+                      --target nxp-rw61x-zephyr-thermostat-thread-build-only-no-blobs \
                       build \
                   "
 
@@ -233,7 +233,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target nxp-rw61x-zephyr-laundry-washer-factory \
+                      --target nxp-rw61x-zephyr-laundry-washer-factory-build-only-no-blobs \
                       build \
                   "
 
@@ -247,7 +247,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target nxp-rw61x-zephyr-unit-test \
+                      --target nxp-rw61x-zephyr-unit-test-build-only-no-blobs \
                       build \
                   "
             - name: Notify Slack on Failure

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -634,6 +634,7 @@ def BuildNxpTarget():
     target.AppendModifier(name="log-none", log_level=NxpLogLevel.NONE).ExceptIfRe("-log-(progress|error|all)")
     target.AppendModifier(name="mtd", enable_mtd=True).OnlyIfRe("thread").OnlyIfRe("mcxw72")
     target.AppendModifier(name="no-ble", disable_ble=True)
+    target.AppendModifier(name="build-only-no-blobs", build_only_no_blobs=True).OnlyIfRe('zephyr')
     target.AppendModifier(name="se05x", se05x_enable=True).OnlyIfRe('cmake').OnlyIfRe('rw61x')
     target.AppendModifier(name="iw610", iw610_transceiver=True).OnlyIfRe('rt1060').OnlyIfRe('evkc').OnlyIfRe('cmake')
 

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -179,6 +179,7 @@ class NxpBuilder(GnBuilder):
                  enable_factory_data_build: bool = False,
                  enable_mtd: bool = False,
                  disable_pairing_autostart: bool = False,
+                 build_only_no_blobs: bool = False,
                  iw416_transceiver: bool = False,
                  w8801_transceiver: bool = False,
                  iwx12_transceiver: bool = False,
@@ -214,6 +215,7 @@ class NxpBuilder(GnBuilder):
         self.enable_factory_data_build = enable_factory_data_build
         self.enable_mtd = enable_mtd
         self.disable_pairing_autostart = disable_pairing_autostart
+        self.build_only_no_blobs = build_only_no_blobs
         self.board_variant = board_variant
         self.iw416_transceiver = iw416_transceiver
         self.w8801_transceiver = w8801_transceiver
@@ -340,6 +342,9 @@ class NxpBuilder(GnBuilder):
 
         if self.enable_thread and self.os_env == NxpOsUsed.ZEPHYR:
             flags.append('-DEXTRA_CONF_FILE="prj_thread_ftd.conf"')
+
+        if self.build_only_no_blobs and self.os_env == NxpOsUsed.ZEPHYR:
+            flags.append("-DCONFIG_BUILD_ONLY_NO_BLOBS=y")
 
         if self.has_sw_version_2:
             flags.append("-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION=2")


### PR DESCRIPTION
### Summary
Setup NXP Zephyr CI to build against upstream zephyrproject-rtos/zephyr main branch at runtime instead of using the pre-installed NXP ZSDK in the docker image.

### Changes
- Add NXP_ZEPHYR_REVISION env variable for easy Zephyr SHA updates
- Add Setup Zephyr Workspace step to initialize workspace at CI runtime
- Update docker image tag to 209 (lighter image without pre-installed ZSDK)
- Add -DCONFIG_BUILD_ONLY_NO_BLOBS=y for Zephyr CI builds (no firmware blobs needed for compilation-only CI)

### Dependencies
Depends on #73736 (Dockerfile changes and version bump)

### Testing
CI build only, no on-board testing.