### PR TITLE
[all-devices-app] Document Out-of-Band Control Architecture

### DIFF
--- a/docs/examples/all_devices.md
+++ b/docs/examples/all_devices.md
@@ -7,4 +7,5 @@
 all-devices-app/README
 all-devices-app/**/README
 all-devices-app/docs/*
+all-devices-app/docs/design/*
 ```

--- a/examples/all-devices-app/docs/architecture.md
+++ b/examples/all-devices-app/docs/architecture.md
@@ -156,3 +156,15 @@ following guidelines:
 4. **Concrete Naming**: Avoid ambiguous umbrella folders or generic utility
    names. Use specific operational titles (e.g., `DeviceTypeParser.h`,
    `NetworkInfrastructureManager.h`).
+
+---
+
+## 5. Subsystem Design Documents
+
+Detailed architecture specifications for application subsystems:
+
+-   **[Out-of-Band Control Architecture](design/out_of_band_control.md)**:
+    Unified architecture for external control interfaces (Named Pipes, Pigweed
+    RPC, test runners), separating transport translators from cluster execution
+    backends (`OOBAccessor`).
+

--- a/examples/all-devices-app/docs/architecture.md
+++ b/examples/all-devices-app/docs/architecture.md
@@ -167,4 +167,3 @@ Detailed architecture specifications for application subsystems:
     Unified architecture for external control interfaces (Named Pipes, Pigweed
     RPC, test runners), separating transport translators from cluster execution
     backends (`OOBAccessor`).
-

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -343,8 +343,10 @@ sequenceDiagram
     -   Decodes TLV fields.
     -   Calls `mCluster.SetOnOff(true)` on target cluster instance.
 
-> [!NOTE] > **Thread Safety & Stack Synchronization**: The POSIX named pipe
-> listener runs on a background worker thread. When a command is received,
+> [!NOTE]
+>
+> **Thread Safety & Stack Synchronization**: The POSIX named pipe listener runs
+> on a background worker thread. When a command is received,
 > `PosixNamedPipeDispatcher` synchronizes execution onto the Matter event loop
 > via `chip::DeviceLayer::PlatformMgr().ScheduleWork(...)` or acquires
 > `chip::DeviceLayer::PlatformMgr().LockChipStack()` before invoking

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -1,8 +1,11 @@
 # Out-of-Band Control Architecture
 
-This document describes the Out-of-Band (OOB) control architecture in `all-devices-app`.
+This document describes the Out-of-Band (OOB) control architecture in
+`all-devices-app`.
 
-OOB control allows external interfaces (POSIX Named Pipes, Pigweed RPC, test runners, platform buttons) to mutate cluster state, simulate sensor triggers, and execute device actions independently of the Matter Interaction Model.
+OOB control allows external interfaces (POSIX Named Pipes, Pigweed RPC, test
+runners, platform buttons) to mutate cluster state, simulate sensor triggers,
+and execute device actions independently of the Matter Interaction Model.
 
 ---
 
@@ -39,13 +42,26 @@ flowchart LR
 
 ### How OOB Control Works
 
-- **Single Control Surface**: `OOBAccessor` is the only mechanism to control simulated devices and clusters outside of the Matter protocol.
-- **Generic Action Dispatch**: An `OOBAccessor` receives a semantic action name and a TLV data buffer. The application maintains a registry of accessors and queries them in order until one handles the action.
-- **Transport Translation**: External protocols and transports (Named Pipe JSON, Pigweed RPC, Test Event Triggers) parse incoming requests, convert them into an action name and TLV payload, and forward them to `OOBAccessorRegistry`.
-- **Code Organization**:
-  - **Shared Cluster Accessors**: Accessors for common Matter clusters (e.g., `OnOff`, `OccupancySensing`) live in `all-devices-common/oob-accessors/clusters/` so any device containing that cluster reuses the same implementation.
-  - **Device-Specific Accessors**: Accessors tied to a specific device live directly alongside the device implementation in `devices/types/<device-name>/`.
-  - **Platform Transport Code**: Transport translators and listener dispatchers (e.g., POSIX Named Pipes) live in platform directories under `posix/named_pipe/`.
+-   **Single Control Surface**: `OOBAccessor` is the only mechanism to control
+    simulated devices and clusters outside of the Matter protocol.
+-   **Generic Action Dispatch**: An `OOBAccessor` receives a semantic action
+    name and a TLV data buffer. The application maintains a registry of
+    accessors and queries them in order until one handles the action.
+-   **Transport Translation**: External protocols and transports (Named Pipe
+    JSON, Pigweed RPC, Test Event Triggers) parse incoming requests, convert
+    them into an action name and TLV payload, and forward them to
+    `OOBAccessorRegistry`.
+-   **Code Organization**:
+    -   **Shared Cluster Accessors**: Accessors for common Matter clusters
+        (e.g., `OnOff`, `OccupancySensing`) live in
+        `all-devices-common/oob-accessors/clusters/` so any device containing
+        that cluster reuses the same implementation.
+    -   **Device-Specific Accessors**: Accessors tied to a specific device live
+        directly alongside the device implementation in
+        `devices/types/<device-name>/`.
+    -   **Platform Transport Code**: Transport translators and listener
+        dispatchers (e.g., POSIX Named Pipes) live in platform directories under
+        `posix/named_pipe/`.
 
 ---
 
@@ -208,24 +224,28 @@ sequenceDiagram
     Accessor->>Cluster: SetOnOff(true)
 ```
 
-1. **Ingress**: External process writes JSON string to named pipe (e.g. `/tmp/chip_all_devices_fifo`):
-   ```json
-   {
-       "action": "SetOnOff",
-       "endpoint": 1,
-       "value": true
-   }
-   ```
-2. **Dispatch**: `PosixNamedPipeDispatcher` reads pipe, parses JSON, and extracts `"action"`.
-3. **Translation**: Dispatcher invokes `OnOffTranslator::TranslateAndExecute(json)`:
-   - Extracts `endpoint = 1` and `value = true`.
-   - Encodes flat TLV payload:
-     - Tag 1: `EndpointId` (`uint16_t`)
-     - Tag 2: `Value` (`bool`)
-   - Calls `mOobRegistry.HandleAction("SetOnOff", tlvBuffer)`.
-4. **Execution**: `OOBAccessorRegistry` routes to `OnOffOobAccessor` registered for Endpoint 1:
-   - Decodes TLV fields.
-   - Calls `mCluster.SetOnOff(true)` on target cluster instance.
+1. **Ingress**: External process writes JSON string to named pipe (e.g.
+   `/tmp/chip_all_devices_fifo`):
+    ```json
+    {
+        "action": "SetOnOff",
+        "endpoint": 1,
+        "value": true
+    }
+    ```
+2. **Dispatch**: `PosixNamedPipeDispatcher` reads pipe, parses JSON, and
+   extracts `"action"`.
+3. **Translation**: Dispatcher invokes
+   `OnOffTranslator::TranslateAndExecute(json)`:
+    - Extracts `endpoint = 1` and `value = true`.
+    - Encodes flat TLV payload:
+        - Tag 1: `EndpointId` (`uint16_t`)
+        - Tag 2: `Value` (`bool`)
+    - Calls `mOobRegistry.HandleAction("SetOnOff", tlvBuffer)`.
+4. **Execution**: `OOBAccessorRegistry` routes to `OnOffOobAccessor` registered
+   for Endpoint 1:
+    - Decodes TLV fields.
+    - Calls `mCluster.SetOnOff(true)` on target cluster instance.
 
 ---
 
@@ -234,6 +254,7 @@ sequenceDiagram
 ### Step 1: Register Cluster OOB Accessors
 
 In `all-devices-common/device/types/<device-name>/OOBAccessors.h`:
+
 ```cpp
 #pragma once
 #include <oob-accessors/OOBAccessorRegistry.h>
@@ -244,6 +265,7 @@ void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry);
 ```
 
 In `all-devices-common/device/types/<device-name>/OOBAccessors.cpp`:
+
 ```cpp
 #include "OOBAccessors.h"
 #include "MyDevice.h"
@@ -258,6 +280,7 @@ void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry)
 ### Step 2: Register Named Pipe Translators
 
 In `all-devices-common/device/types/<device-name>/NamedPipes.h`:
+
 ```cpp
 #pragma once
 #include <posix/named_pipe/NamedPipeDispatcher.h>
@@ -268,6 +291,7 @@ void RegisterNamedPipes(MyDevice & device, NamedPipeDispatcher & dispatcher);
 ```
 
 In `all-devices-common/device/types/<device-name>/NamedPipes.cpp`:
+
 ```cpp
 #include "NamedPipes.h"
 #include "MyDevice.h"
@@ -281,7 +305,8 @@ void RegisterNamedPipes(MyDevice & device, NamedPipeDispatcher & dispatcher)
 
 ### Step 3: Factory Attachment
 
-In `DeviceFactory.h`, creator lambdas attach registered accessors and translators uniformly:
+In `DeviceFactory.h`, creator lambdas attach registered accessors and
+translators uniformly:
 
 ```cpp
 mContext->oobRegistry.AttachAccessors(*device);
@@ -292,17 +317,22 @@ mContext->namedPipesRegistry.AttachDevice(*device);
 
 ## 6. Build Configuration & Conditional Compilation
 
-Configuration defines are generated into `<app_config/all_devices_config.h>` for both GN and CMake, mirroring the `enabled_devices` build system:
+Configuration defines are generated into `<app_config/all_devices_config.h>` for
+both GN and CMake, mirroring the `enabled_devices` build system:
 
-- **GN Build** (`oob-accessors/all_devices_config.gni`): Uses `buildconfig_header` to emit `app_config/all_devices_config.h`.
-- **CMake Build** (`oob-accessors/all_devices_config.cmake`): Uses `configure_file` with `all_devices_config.h.in` to emit `${CMAKE_CURRENT_BINARY_DIR}/app_config/all_devices_config.h`.
+-   **GN Build** (`oob-accessors/all_devices_config.gni`): Uses
+    `buildconfig_header` to emit `app_config/all_devices_config.h`.
+-   **CMake Build** (`oob-accessors/all_devices_config.cmake`): Uses
+    `configure_file` with `all_devices_config.h.in` to emit
+    `${CMAKE_CURRENT_BINARY_DIR}/app_config/all_devices_config.h`.
 
-| Build Target / Flag | `ALL_DEVICES_APP_ENABLE_NAMED_PIPES` | `ALL_DEVICES_APP_ENABLE_PWRPC` | `ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS` |
-| :--- | :--- | :--- | :--- |
-| POSIX Linux (`all-devices-app`) | 1 | 0 (or 1 if `chip_enable_pw_rpc`) | 1 |
-| Embedded Targets (ESP32, SiLabs, Telink) | 0 | 0 | 0 |
+| Build Target / Flag                      | `ALL_DEVICES_APP_ENABLE_NAMED_PIPES` | `ALL_DEVICES_APP_ENABLE_PWRPC`   | `ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS` |
+| :--------------------------------------- | :----------------------------------- | :------------------------------- | :------------------------------------- |
+| POSIX Linux (`all-devices-app`)          | 1                                    | 0 (or 1 if `chip_enable_pw_rpc`) | 1                                      |
+| Embedded Targets (ESP32, SiLabs, Telink) | 0                                    | 0                                | 0                                      |
 
 Header aliasing in `all-devices-common/oob-accessors/OOBAccessorRegistry.h`:
+
 ```cpp
 #pragma once
 #include <app_config/all_devices_config.h>
@@ -317,6 +347,7 @@ using OOBAccessorRegistry = chip::app::NoopOOBAccessorRegistry;
 ```
 
 Header aliasing in `posix/named_pipe/NamedPipeDispatcher.h`:
+
 ```cpp
 #pragma once
 #include <app_config/all_devices_config.h>
@@ -334,55 +365,69 @@ using NamedPipeDispatcher = chip::app::NoopNamedPipeDispatcher;
 
 ## 7. TODO / Implementation Checklist
 
-> [!NOTE]
-> The unified Out-of-Band Control architecture is specified above and tracked for implementation via the following phased checklist.
+> [!NOTE] The unified Out-of-Band Control architecture is specified above and
+> tracked for implementation via the following phased checklist.
 
 ### Phase 1: Core OOB Registry & Cluster Accessors
-- [ ] Create `all-devices-common/oob-accessors/all_devices_config.gni`, `all_devices_config.cmake`, and `all_devices_config.h.in`.
-- [ ] Create `all-devices-common/oob-accessors/OOBAccessor.h`.
-- [ ] Create `all-devices-common/oob-accessors/InMemoryOOBAccessorRegistry.h` and `.cpp`.
-- [ ] Create `all-devices-common/oob-accessors/NoopOOBAccessorRegistry.h`.
-- [ ] Create `all-devices-common/oob-accessors/OOBAccessorRegistry.h` (aliasing header).
-- [ ] Implement shared cluster accessors in `all-devices-common/oob-accessors/clusters/`:
-  - [ ] `OnOffOobAccessor.h/.cpp`
-  - [ ] `OccupancyOobAccessor.h/.cpp`
-  - [ ] `BooleanStateOobAccessor.h/.cpp`
-  - [ ] `AmbientContextOobAccessor.h/.cpp`
-  - [ ] `BasicInformationOobAccessor.h/.cpp`
-- [ ] Update `all-devices-common/BUILD.gn` with new OOB source targets.
+
+-   [ ] Create `all-devices-common/oob-accessors/all_devices_config.gni`,
+        `all_devices_config.cmake`, and `all_devices_config.h.in`.
+-   [ ] Create `all-devices-common/oob-accessors/OOBAccessor.h`.
+-   [ ] Create `all-devices-common/oob-accessors/InMemoryOOBAccessorRegistry.h`
+        and `.cpp`.
+-   [ ] Create `all-devices-common/oob-accessors/NoopOOBAccessorRegistry.h`.
+-   [ ] Create `all-devices-common/oob-accessors/OOBAccessorRegistry.h`
+        (aliasing header).
+-   [ ] Implement shared cluster accessors in
+        `all-devices-common/oob-accessors/clusters/`:
+    -   [ ] `OnOffOobAccessor.h/.cpp`
+    -   [ ] `OccupancyOobAccessor.h/.cpp`
+    -   [ ] `BooleanStateOobAccessor.h/.cpp`
+    -   [ ] `AmbientContextOobAccessor.h/.cpp`
+    -   [ ] `BasicInformationOobAccessor.h/.cpp`
+-   [ ] Update `all-devices-common/BUILD.gn` with new OOB source targets.
 
 ### Phase 2: Device-Type OOB Accessor Registration
-- [ ] Add `OOBAccessors.h` and `OOBAccessors.cpp` for all existing device types:
-  - [ ] `all-devices-common/device/types/on-off-light/`
-  - [ ] `all-devices-common/device/types/dimmable-light/`
-  - [ ] `all-devices-common/device/types/occupancy-sensor/`
-  - [ ] `all-devices-common/device/types/contact-sensor/`
-  - [ ] `all-devices-common/device/types/light-sensor/`
-  - [ ] `all-devices-common/device/types/air-quality-sensor/`
-  - [ ] `all-devices-common/device/types/speaker/`
-  - [ ] `all-devices-common/device/types/smart-plug/`
-- [ ] Hook `oobRegistry.AttachAccessors(*device)` into `DeviceFactory.h`.
+
+-   [ ] Add `OOBAccessors.h` and `OOBAccessors.cpp` for all existing device
+        types:
+    -   [ ] `all-devices-common/device/types/on-off-light/`
+    -   [ ] `all-devices-common/device/types/dimmable-light/`
+    -   [ ] `all-devices-common/device/types/occupancy-sensor/`
+    -   [ ] `all-devices-common/device/types/contact-sensor/`
+    -   [ ] `all-devices-common/device/types/light-sensor/`
+    -   [ ] `all-devices-common/device/types/air-quality-sensor/`
+    -   [ ] `all-devices-common/device/types/speaker/`
+    -   [ ] `all-devices-common/device/types/smart-plug/`
+-   [ ] Hook `oobRegistry.AttachAccessors(*device)` into `DeviceFactory.h`.
 
 ### Phase 3: POSIX Named Pipe Dispatcher & Translators
-- [ ] Create `posix/named_pipe/NamedPipeCommandTranslator.h`.
-- [ ] Create `posix/named_pipe/PosixNamedPipeDispatcher.h` and `.cpp`.
-- [ ] Create `posix/named_pipe/NoopNamedPipeDispatcher.h`.
-- [ ] Create `posix/named_pipe/NamedPipeDispatcher.h` (aliasing header).
-- [ ] Implement granular translators in `posix/named_pipe/translators/`:
-  - [ ] `OnOffTranslator.h/.cpp`
-  - [ ] `OccupancyTranslator.h/.cpp`
-  - [ ] `BooleanStateTranslator.h/.cpp`
-  - [ ] `AmbientContextTranslator.h/.cpp`
-  - [ ] `BasicInformationTranslator.h/.cpp`
+
+-   [ ] Create `posix/named_pipe/NamedPipeCommandTranslator.h`.
+-   [ ] Create `posix/named_pipe/PosixNamedPipeDispatcher.h` and `.cpp`.
+-   [ ] Create `posix/named_pipe/NoopNamedPipeDispatcher.h`.
+-   [ ] Create `posix/named_pipe/NamedPipeDispatcher.h` (aliasing header).
+-   [ ] Implement granular translators in `posix/named_pipe/translators/`:
+    -   [ ] `OnOffTranslator.h/.cpp`
+    -   [ ] `OccupancyTranslator.h/.cpp`
+    -   [ ] `BooleanStateTranslator.h/.cpp`
+    -   [ ] `AmbientContextTranslator.h/.cpp`
+    -   [ ] `BasicInformationTranslator.h/.cpp`
 
 ### Phase 4: Device-Type Named Pipe Registration & Integration
-- [ ] Add `NamedPipes.h` and `NamedPipes.cpp` under `all-devices-common/device/types/<device-name>/` for each supported device.
-- [ ] Inject `NamedPipeDispatcher` and `OOBAccessorRegistry` into `DeviceFactory::Context`.
-- [ ] Wire initialization in `posix/main.cpp`.
+
+-   [ ] Add `NamedPipes.h` and `NamedPipes.cpp` under
+        `all-devices-common/device/types/<device-name>/` for each supported
+        device.
+-   [ ] Inject `NamedPipeDispatcher` and `OOBAccessorRegistry` into
+        `DeviceFactory::Context`.
+-   [ ] Wire initialization in `posix/main.cpp`.
 
 ### Phase 5: Legacy Cleanup & Build Verification
-- [ ] Remove legacy `AppCommandDelegate.h/.cpp`.
-- [ ] Remove legacy `ClusterTypeMappings.h/.cpp`.
-- [ ] Remove legacy `AllDevicesAppClusterImplementationRegistry.h`.
-- [ ] Update build files (`posix/BUILD.gn`, `all-devices-common/BUILD.gn`).
-- [ ] Build target `linux-x64-all-devices-clang` and verify with sample named pipe commands.
+
+-   [ ] Remove legacy `AppCommandDelegate.h/.cpp`.
+-   [ ] Remove legacy `ClusterTypeMappings.h/.cpp`.
+-   [ ] Remove legacy `AllDevicesAppClusterImplementationRegistry.h`.
+-   [ ] Update build files (`posix/BUILD.gn`, `all-devices-common/BUILD.gn`).
+-   [ ] Build target `linux-x64-all-devices-clang` and verify with sample named
+        pipe commands.

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -194,7 +194,7 @@ namespace chip::app {
 class PosixNamedPipeDispatcher
 {
 public:
-    explicit PosixNamedPipeDispatcher(InMemoryOOBAccessorRegistry & oobRegistry) :
+    explicit PosixNamedPipeDispatcher(OOBAccessorRegistry & oobRegistry) :
         mOobRegistry(oobRegistry) {}
 
     /**
@@ -225,7 +225,7 @@ public:
     CHIP_ERROR DispatchJson(const Json::Value & json);
 
 private:
-    InMemoryOOBAccessorRegistry & mOobRegistry;
+    OOBAccessorRegistry & mOobRegistry;
     std::unordered_map<std::string, std::unique_ptr<NamedPipeCommandTranslator>> mTranslators;
 };
 
@@ -413,10 +413,10 @@ both GN and CMake:
     `configure_file` with `all_devices_config.h.in` to emit
     `${CMAKE_CURRENT_BINARY_DIR}/app_config/all_devices_config.h`.
 
-| Build Target / Flag                      | `ALL_DEVICES_APP_ENABLE_NAMED_PIPES` | `ALL_DEVICES_APP_ENABLE_PWRPC`   | `ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS` |
-| :--------------------------------------- | :----------------------------------- | :------------------------------- | :------------------------------------- |
-| POSIX Linux (`all-devices-app`)          | 1                                    | 0 (or 1 if `chip_enable_pw_rpc`) | 1                                      |
-| Embedded Targets (ESP32, SiLabs, Telink) | 0                                    | 0                                | 0                                      |
+| Build Target / Flag                      | `ALL_DEVICES_APP_ENABLE_NAMED_PIPES` | `PW_RPC_ENABLED` (via `chip_enable_pw_rpc`) | `ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS` |
+| :--------------------------------------- | :----------------------------------- | :------------------------------------------ | :------------------------------------- |
+| POSIX Linux (`all-devices-app`)          | 1                                    | 0 (or 1 if `chip_enable_pw_rpc`)            | 1                                      |
+| Embedded Targets (ESP32, SiLabs, Telink) | 0                                    | 0                                           | 0                                      |
 
 Header aliasing in `all-devices-common/oob-accessors/OOBAccessorRegistry.h`:
 

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -80,7 +80,7 @@ flowchart LR
 
 ## 2. Directory Layout
 
-```
+```text
 examples/all-devices-app/
 ├── all-devices-common/
 │   ├── device/
@@ -404,7 +404,7 @@ embedded builds:
     `${DEVICE_DIR}/OOBAccessors.cpp`. `NamedPipes.cpp` is excluded from CMake
     source lists.
 
-Configuration defines are generated into `<app_config/all_devices_config.h>` for
+Configuration defines are generated into `app_config/all_devices_config.h` for
 both GN and CMake:
 
 -   **GN Build** (`oob-accessors/all_devices_config.gni`): Uses

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -145,7 +145,7 @@ public:
      * @brief Registers an OOB accessor instance.
      * @param accessor The accessor instance to register.
      */
-    CHIP_ERROR Register(std::unique_ptr<chip::app::Clusters::OOBAccessor> accessor);
+    CHIP_ERROR Register(std::unique_ptr<OOBAccessor> accessor);
 
     /**
      * @brief Dispatches an action to registered accessors in order.

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -163,8 +163,29 @@ public:
      */
     CHIP_ERROR HandleAction(CharSpan action, ByteSpan tlvData);
 
+    /**
+     * @brief Clears all registered accessors during device teardown.
+     */
+    void Clear() { mAccessors.clear(); }
+
 private:
     std::vector<std::unique_ptr<OOBAccessor>> mAccessors;
+};
+
+} // namespace chip::app
+```
+
+### `NoopOOBAccessorRegistry` Class
+
+```cpp
+namespace chip::app {
+
+class NoopOOBAccessorRegistry
+{
+public:
+    CHIP_ERROR Register(std::unique_ptr<OOBAccessor> /* accessor */) { return CHIP_NO_ERROR; }
+    CHIP_ERROR HandleAction(CharSpan /* action */, ByteSpan /* tlvData */) { return CHIP_ERROR_NOT_FOUND; }
+    void Clear() {}
 };
 
 } // namespace chip::app
@@ -300,6 +321,13 @@ sequenceDiagram
     -   Decodes TLV fields.
     -   Calls `mCluster.SetOnOff(true)` on target cluster instance.
 
+> [!NOTE] > **Thread Safety & Stack Synchronization**: The POSIX named pipe
+> listener runs on a background worker thread. When a command is received,
+> `PosixNamedPipeDispatcher` synchronizes execution onto the Matter event loop
+> via `chip::DeviceLayer::PlatformMgr().ScheduleWork(...)` or acquires
+> `chip::DeviceLayer::PlatformMgr().LockChipStack()` before invoking
+> `HandleAction` on `OOBAccessorRegistry`.
+
 ---
 
 ## 5. Adding OOB Support for a Device
@@ -314,9 +342,9 @@ In `all-devices-common/device/types/<device-name>/OOBAccessors.h`:
 
 namespace chip::app {
 
-class MyDevice;
+class OnOffLight;
 
-void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry);
+void RegisterOOBAccessors(OnOffLight & device, OOBAccessorRegistry & registry);
 
 } // namespace chip::app
 ```
@@ -325,7 +353,7 @@ In `all-devices-common/device/types/<device-name>/OOBAccessors.cpp`:
 
 ```cpp
 #include "OOBAccessors.h"
-#include "MyDevice.h"
+#include "OnOffLight.h"
 
 #if ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS
 #include <oob-accessors/clusters/OnOffOOBAccessor.h>
@@ -333,10 +361,10 @@ In `all-devices-common/device/types/<device-name>/OOBAccessors.cpp`:
 
 namespace chip::app {
 
-void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry)
+void RegisterOOBAccessors(OnOffLight & device, OOBAccessorRegistry & registry)
 {
 #if ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS
-    registry.Register(std::make_unique<OnOffOOBAccessor>(device.GetOnOffCluster(), device.GetEndpointId()));
+    registry.Register(std::make_unique<OnOffOOBAccessor>(device.OnOffCluster(), device.GetEndpointId()));
 #endif
 }
 
@@ -353,9 +381,9 @@ In `all-devices-common/device/types/<device-name>/NamedPipes.h`:
 
 namespace chip::app {
 
-class MyDevice;
+class OnOffLight;
 
-void RegisterNamedPipes(MyDevice & device, PosixNamedPipeDispatcher & dispatcher);
+void RegisterNamedPipes(OnOffLight & device, PosixNamedPipeDispatcher & dispatcher);
 
 } // namespace chip::app
 ```
@@ -364,12 +392,12 @@ In `all-devices-common/device/types/<device-name>/NamedPipes.cpp`:
 
 ```cpp
 #include "NamedPipes.h"
-#include "MyDevice.h"
+#include "OnOffLight.h"
 #include <posix/named_pipe/translators/OnOffTranslator.h>
 
 namespace chip::app {
 
-void RegisterNamedPipes(MyDevice & device, PosixNamedPipeDispatcher & dispatcher)
+void RegisterNamedPipes(OnOffLight & device, PosixNamedPipeDispatcher & dispatcher)
 {
     dispatcher.EnsureTranslatorRegistered<OnOffTranslator>();
 }
@@ -412,23 +440,22 @@ source_set("posix") {
 }
 ```
 
-### Step 4: Factory & Application Attachment
+### Step 4: Application Lifecycle & Registration
 
-In `DeviceFactory.h` (concrete creator registrations):
-
-```cpp
-RegisterCreator("on-off-light", [this]() {
-    VerifyOrDie(mContext.has_value());
-    auto device = std::make_unique<LoggingOnOffLight>(...);
-    RegisterOOBAccessors(*device, mOobRegistry);
-    return device;
-});
-```
-
-In POSIX application initialization (`posix/main.cpp`):
+In application initialization (`posix/main.cpp` and embedded setup):
 
 ```cpp
-mNamedPipeDispatcher.Start(kDefaultFifoPath);
+// 1. Device creation via factory
+auto device = DeviceFactory::GetInstance().Create(deviceTypeName);
+
+// 2. Register endpoint with data model provider (allocates valid endpoint ID)
+ReturnErrorOnFailure(device->Register(endpointIdAllocator, dataModelProvider));
+
+// 3. Register OOB accessors once endpoint ID is assigned
+RegisterOOBAccessors(*device, oobRegistry);
+
+// 4. Start named pipe listener in POSIX main
+namedPipeDispatcher.Start(kDefaultFifoPath);
 ```
 
 ---
@@ -475,13 +502,17 @@ Header aliasing in `all-devices-common/oob-accessors/OOBAccessorRegistry.h`:
 #pragma once
 #include <app_config/all_devices_config.h>
 
+#if ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS
+#include <oob-accessors/InMemoryOOBAccessorRegistry.h>
+#else
+#include <oob-accessors/NoopOOBAccessorRegistry.h>
+#endif
+
 namespace chip::app {
 
 #if ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS
-#include <oob-accessors/InMemoryOOBAccessorRegistry.h>
 using OOBAccessorRegistry = InMemoryOOBAccessorRegistry;
 #else
-#include <oob-accessors/NoopOOBAccessorRegistry.h>
 using OOBAccessorRegistry = NoopOOBAccessorRegistry;
 #endif
 
@@ -528,8 +559,8 @@ using OOBAccessorRegistry = NoopOOBAccessorRegistry;
     -   [ ] `all-devices-common/device/types/speaker/`
     -   [ ] `all-devices-common/device/types/on-off-plug-in-unit/`
     -   [ ] `all-devices-common/device/types/dimmable-plug-in-unit/`
--   [ ] Hook `RegisterOOBAccessors(*device, mOobRegistry)` into
-        `DeviceFactory.h`.
+-   [ ] Hook `RegisterOOBAccessors(*device, oobRegistry)` after endpoint
+        registration in `main.cpp`.
 
 ### Phase 3: POSIX Named Pipe Dispatcher & Translators
 

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -70,8 +70,7 @@ flowchart LR
         `all-devices-common/device/types/<device-name>/`:
         -   Core logic and `OOBAccessors.h/.cpp` belong to the platform-neutral
             `:<device-name>` target.
-        -   `NamedPipes.h/.cpp` belongs to the POSIX-only `:<device-name>:posix`
-            sub-target.
+        -   `NamedPipes.h/.cpp` belongs to the POSIX-only `:posix` sub-target.
     -   **Platform Transport Infrastructure**: Dispatchers and base interfaces
         (e.g., POSIX Named Pipes) live in platform directories under
         `posix/named_pipe/`.
@@ -83,6 +82,9 @@ flowchart LR
 ```text
 examples/all-devices-app/
 ├── all-devices-common/
+│   ├── device-factory/
+│   │   ├── DeviceFactory.h
+│   │   └── BUILD.gn
 │   ├── device/
 │   │   └── types/
 │   │       └── <device-name>/
@@ -91,15 +93,20 @@ examples/all-devices-app/
 │   │           ├── NamedPipes.h/.cpp                   # Device Named Pipe registration (POSIX-only)
 │   │           └── BUILD.gn                            # GN targets: :<device-name>, :posix, :logging
 │   └── oob-accessors/
+│       ├── all_devices_config.gni                      # GN build configuration header generator
+│       ├── all_devices_config.cmake                    # CMake build configuration header generator
+│       ├── all_devices_config.h.in                     # CMake configuration template
+│       ├── BUILD.gn                                    # GN rules for oob-accessors
 │       ├── OOBAccessor.h                               # Base interface: HandleAction(action, tlvData)
 │       ├── OOBAccessorRegistry.h                       # Active alias (InMemory vs Noop)
-│       ├── InMemoryOOBAccessorRegistry.h/.cpp           # Intrusive list of registered OOBAccessors
+│       ├── InMemoryOOBAccessorRegistry.h/.cpp           # Container of registered OOBAccessors
 │       ├── NoopOOBAccessorRegistry.h                   # Zero-cost inline stub for disabled targets
 │       └── clusters/
-│           └── <Cluster>OobAccessor.h/.cpp             # Cluster accessors (e.g. OnOffOobAccessor, OccupancyOobAccessor)
+│           └── <Cluster>OOBAccessor.h/.cpp             # Cluster accessors (e.g. OnOffOOBAccessor, OccupancyOOBAccessor)
 └── posix/
     └── named_pipe/
-        ├── NamedPipeCommandTranslator.h                # Base interface: TranslateAndExecute(json)
+        ├── BUILD.gn                                    # GN rules for POSIX dispatcher & translators
+        ├── NamedPipeCommandTranslator.h                # Base interface: TranslateAndExecute(json, registry)
         ├── PosixNamedPipeDispatcher.h/.cpp             # POSIX pipe listener & JSON command router
         └── translators/
             └── <Command>Translator.h/.cpp              # Command translators (e.g. OnOffTranslator, OccupancyTranslator)
@@ -114,7 +121,7 @@ examples/all-devices-app/
 ```cpp
 namespace chip::app {
 
-class OOBAccessor : public chip::IntrusiveListNodeBase<chip::IntrusiveMode::AutoUnlink>
+class OOBAccessor
 {
 public:
     virtual ~OOBAccessor() = default;
@@ -126,6 +133,9 @@ public:
      * @return std::nullopt if action is not supported (registry continues dispatch).
      * @return CHIP_NO_ERROR if action was recognized and executed successfully.
      * @return Other CHIP_ERROR on execution failure (registry stops dispatch).
+     *
+     * @note Asynchronous Safety: The tlvData parameter is a non-owning temporary view valid
+     *       only during synchronous execution of this call.
      */
     virtual std::optional<CHIP_ERROR> HandleAction(CharSpan action, ByteSpan tlvData) = 0;
 };
@@ -153,14 +163,8 @@ public:
      */
     CHIP_ERROR HandleAction(CharSpan action, ByteSpan tlvData);
 
-    /**
-     * @brief Helper to attach all accessors declared by a device instance.
-     */
-    template <typename ConcreteDevice>
-    void AttachAccessors(ConcreteDevice & device)
-    {
-        RegisterOOBAccessors(device, *this);
-    }
+private:
+    std::vector<std::unique_ptr<OOBAccessor>> mAccessors;
 };
 
 } // namespace chip::app
@@ -171,6 +175,8 @@ public:
 ```cpp
 namespace chip::app {
 
+class OOBAccessorRegistry;
+
 class NamedPipeCommandTranslator
 {
 public:
@@ -179,8 +185,9 @@ public:
     /**
      * @brief Translates a JSON payload into TLV and executes the action via OOBAccessorRegistry.
      * @param json Parsed JSON payload from named pipe.
+     * @param registry Target registry to dispatch the translated action.
      */
-    virtual CHIP_ERROR TranslateAndExecute(const Json::Value & json) = 0;
+    virtual CHIP_ERROR TranslateAndExecute(const Json::Value & json, OOBAccessorRegistry & registry) = 0;
 };
 
 } // namespace chip::app
@@ -196,6 +203,28 @@ class PosixNamedPipeDispatcher
 public:
     explicit PosixNamedPipeDispatcher(OOBAccessorRegistry & oobRegistry) :
         mOobRegistry(oobRegistry) {}
+    ~PosixNamedPipeDispatcher();
+
+    /**
+     * @brief Starts listening on the named pipe FIFO.
+     * @param fifoPath Path to the named pipe file (e.g. "/tmp/chip_all_devices_fifo").
+     */
+    CHIP_ERROR Start(const char * fifoPath);
+
+    /**
+     * @brief Stops listening on the named pipe and cleans up the FIFO file.
+     */
+    CHIP_ERROR Stop();
+
+    /**
+     * @brief Checks if a translator is registered for the specified action name.
+     */
+    bool HasTranslator(const std::string & actionName) const;
+
+    /**
+     * @brief Registers a command translator instance under the specified action name.
+     */
+    CHIP_ERROR RegisterTranslator(const std::string & actionName, std::unique_ptr<NamedPipeCommandTranslator> translator);
 
     /**
      * @brief Registers a translator if not already present, deduping by TranslatorType::kName.
@@ -209,19 +238,13 @@ public:
         }
         return RegisterTranslator(
             TranslatorType::kName,
-            std::make_unique<TranslatorType>(mOobRegistry, std::forward<Args>(args)...)
+            std::make_unique<TranslatorType>(std::forward<Args>(args)...)
         );
     }
 
     /**
-     * @brief Helper to attach all named pipe translators required by a device instance.
+     * @brief Parses and dispatches a JSON command to the registered translator.
      */
-    template <typename ConcreteDevice>
-    void AttachDevice(ConcreteDevice & device)
-    {
-        RegisterNamedPipes(device, *this);
-    }
-
     CHIP_ERROR DispatchJson(const Json::Value & json);
 
 private:
@@ -241,12 +264,14 @@ private:
 ```mermaid
 sequenceDiagram
     participant Pipe as Named Pipe
+    participant Disp as Posix Named Pipe Dispatcher
     participant Trans as Command Translator
     participant Reg as OOB Accessor Registry
     participant Accessor as Cluster OOB Accessor
     participant Cluster as OnOff Cluster
 
-    Pipe->>Trans: {"action": "SetOnOff", "endpoint": 1, "value": true}
+    Pipe->>Disp: Raw JSON string: {"action": "SetOnOff", "endpoint": 1, "value": true}
+    Disp->>Trans: TranslateAndExecute(json, Reg)
     Trans->>Reg: HandleAction("SetOnOff", TLV[endpoint: 1, value: true])
     Reg->>Accessor: HandleAction("SetOnOff", TLV)
     Accessor->>Cluster: SetOnOff(true)
@@ -264,13 +289,13 @@ sequenceDiagram
 2.  **Dispatch**: `PosixNamedPipeDispatcher` reads pipe, parses JSON, and
     extracts `"action"`.
 3.  **Translation**: Dispatcher invokes
-    `OnOffTranslator::TranslateAndExecute(json)`:
+    `OnOffTranslator::TranslateAndExecute(json, mOobRegistry)`:
     -   Extracts `endpoint = 1` and `value = true`.
     -   Encodes flat TLV payload:
         -   Tag 1: `EndpointId` (`uint16_t`)
         -   Tag 2: `Value` (`bool`)
-    -   Calls `mOobRegistry.HandleAction("SetOnOff", tlvBuffer)`.
-4.  **Execution**: `OOBAccessorRegistry` routes to `OnOffOobAccessor` registered
+    -   Calls `registry.HandleAction("SetOnOff", tlvBuffer)`.
+4.  **Execution**: `OOBAccessorRegistry` routes to `OnOffOOBAccessor` registered
     for Endpoint 1:
     -   Decodes TLV fields.
     -   Calls `mCluster.SetOnOff(true)` on target cluster instance.
@@ -287,9 +312,13 @@ In `all-devices-common/device/types/<device-name>/OOBAccessors.h`:
 #pragma once
 #include <oob-accessors/OOBAccessorRegistry.h>
 
+namespace chip::app {
+
 class MyDevice;
 
 void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry);
+
+} // namespace chip::app
 ```
 
 In `all-devices-common/device/types/<device-name>/OOBAccessors.cpp`:
@@ -297,12 +326,21 @@ In `all-devices-common/device/types/<device-name>/OOBAccessors.cpp`:
 ```cpp
 #include "OOBAccessors.h"
 #include "MyDevice.h"
-#include <oob-accessors/clusters/OnOffOobAccessor.h>
+
+#if ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS
+#include <oob-accessors/clusters/OnOffOOBAccessor.h>
+#endif
+
+namespace chip::app {
 
 void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry)
 {
-    registry.Register(std::make_unique<OnOffOobAccessor>(device.GetOnOffCluster(), device.GetEndpointId()));
+#if ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS
+    registry.Register(std::make_unique<OnOffOOBAccessor>(device.GetOnOffCluster(), device.GetEndpointId()));
+#endif
 }
+
+} // namespace chip::app
 ```
 
 ### Step 2: Register Named Pipe Translators (POSIX-Only)
@@ -313,9 +351,13 @@ In `all-devices-common/device/types/<device-name>/NamedPipes.h`:
 #pragma once
 #include <posix/named_pipe/PosixNamedPipeDispatcher.h>
 
+namespace chip::app {
+
 class MyDevice;
 
 void RegisterNamedPipes(MyDevice & device, PosixNamedPipeDispatcher & dispatcher);
+
+} // namespace chip::app
 ```
 
 In `all-devices-common/device/types/<device-name>/NamedPipes.cpp`:
@@ -325,10 +367,14 @@ In `all-devices-common/device/types/<device-name>/NamedPipes.cpp`:
 #include "MyDevice.h"
 #include <posix/named_pipe/translators/OnOffTranslator.h>
 
+namespace chip::app {
+
 void RegisterNamedPipes(MyDevice & device, PosixNamedPipeDispatcher & dispatcher)
 {
     dispatcher.EnsureTranslatorRegistered<OnOffTranslator>();
 }
+
+} // namespace chip::app
 ```
 
 ### Step 3: Define Granular GN Sub-Targets
@@ -361,23 +407,28 @@ source_set("posix") {
 
   public_deps = [
     ":<device-name>",
-    "${chip_root}/examples/all-devices-app/posix/named_pipe:dispatcher",
+    "${chip_root}/examples/all-devices-app/posix/named_pipe",
   ]
 }
 ```
 
 ### Step 4: Factory & Application Attachment
 
-In `DeviceFactory.h` (common across all platforms):
+In `DeviceFactory.h` (concrete creator registrations):
 
 ```cpp
-mContext->oobRegistry.AttachAccessors(*device);
+RegisterCreator("on-off-light", [this]() {
+    VerifyOrDie(mContext.has_value());
+    auto device = std::make_unique<LoggingOnOffLight>(...);
+    RegisterOOBAccessors(*device, mOobRegistry);
+    return device;
+});
 ```
 
 In POSIX application initialization (`posix/main.cpp`):
 
 ```cpp
-mNamedPipeDispatcher.AttachDevice(*device);
+mNamedPipeDispatcher.Start(kDefaultFifoPath);
 ```
 
 ---
@@ -424,13 +475,17 @@ Header aliasing in `all-devices-common/oob-accessors/OOBAccessorRegistry.h`:
 #pragma once
 #include <app_config/all_devices_config.h>
 
+namespace chip::app {
+
 #if ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS
 #include <oob-accessors/InMemoryOOBAccessorRegistry.h>
-using OOBAccessorRegistry = chip::app::InMemoryOOBAccessorRegistry;
+using OOBAccessorRegistry = InMemoryOOBAccessorRegistry;
 #else
 #include <oob-accessors/NoopOOBAccessorRegistry.h>
-using OOBAccessorRegistry = chip::app::NoopOOBAccessorRegistry;
+using OOBAccessorRegistry = NoopOOBAccessorRegistry;
 #endif
+
+} // namespace chip::app
 ```
 
 ---
@@ -452,12 +507,13 @@ using OOBAccessorRegistry = chip::app::NoopOOBAccessorRegistry;
         (aliasing header).
 -   [ ] Implement shared cluster accessors in
         `all-devices-common/oob-accessors/clusters/`:
-    -   [ ] `OnOffOobAccessor.h/.cpp`
-    -   [ ] `OccupancyOobAccessor.h/.cpp`
-    -   [ ] `BooleanStateOobAccessor.h/.cpp`
-    -   [ ] `AmbientContextOobAccessor.h/.cpp`
-    -   [ ] `BasicInformationOobAccessor.h/.cpp`
--   [ ] Update `all-devices-common/BUILD.gn` with new OOB source targets.
+    -   [ ] `OnOffOOBAccessor.h/.cpp`
+    -   [ ] `OccupancyOOBAccessor.h/.cpp`
+    -   [ ] `BooleanStateOOBAccessor.h/.cpp`
+    -   [ ] `AmbientContextOOBAccessor.h/.cpp`
+    -   [ ] `BasicInformationOOBAccessor.h/.cpp`
+-   [ ] Update `all-devices-common/oob-accessors/BUILD.gn` with new OOB source
+        targets.
 
 ### Phase 2: Device-Type OOB Accessor Registration
 
@@ -470,8 +526,10 @@ using OOBAccessorRegistry = chip::app::NoopOOBAccessorRegistry;
     -   [ ] `all-devices-common/device/types/light-sensor/`
     -   [ ] `all-devices-common/device/types/air-quality-sensor/`
     -   [ ] `all-devices-common/device/types/speaker/`
-    -   [ ] `all-devices-common/device/types/smart-plug/`
--   [ ] Hook `oobRegistry.AttachAccessors(*device)` into `DeviceFactory.h`.
+    -   [ ] `all-devices-common/device/types/on-off-plug-in-unit/`
+    -   [ ] `all-devices-common/device/types/dimmable-plug-in-unit/`
+-   [ ] Hook `RegisterOOBAccessors(*device, mOobRegistry)` into
+        `DeviceFactory.h`.
 
 ### Phase 3: POSIX Named Pipe Dispatcher & Translators
 
@@ -490,13 +548,15 @@ using OOBAccessorRegistry = chip::app::NoopOOBAccessorRegistry;
         `all-devices-common/device/types/<device-name>/` for each supported
         device.
 -   [ ] Add `source_set("posix")` to each device's `BUILD.gn`.
--   [ ] Wire `mNamedPipeDispatcher.AttachDevice(*device)` in `posix/main.cpp`.
+-   [ ] Wire `mNamedPipeDispatcher.Start(path)` in `posix/main.cpp`.
 
 ### Phase 5: Legacy Cleanup & Build Verification
 
 -   [ ] Remove legacy `AppCommandDelegate.h/.cpp`.
 -   [ ] Remove legacy `ClusterTypeMappings.h/.cpp`.
 -   [ ] Remove legacy `AllDevicesAppClusterImplementationRegistry.h`.
--   [ ] Update build files (`posix/BUILD.gn`, `all-devices-common/BUILD.gn`).
+-   [ ] Update build files (`posix/BUILD.gn`,
+        `all-devices-common/oob-accessors/BUILD.gn`,
+        `posix/named_pipe/BUILD.gn`).
 -   [ ] Build target `linux-x64-all-devices-clang` and verify with sample named
         pipe commands.

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -1,0 +1,388 @@
+# Out-of-Band Control Architecture
+
+This document describes the Out-of-Band (OOB) control architecture in `all-devices-app`.
+
+OOB control allows external interfaces (POSIX Named Pipes, Pigweed RPC, test runners, platform buttons) to mutate cluster state, simulate sensor triggers, and execute device actions independently of the Matter Interaction Model.
+
+---
+
+## 1. Core Architecture
+
+The architecture separates **Transport Translation** from **Action Execution**:
+
+```mermaid
+flowchart LR
+    subgraph External["External Inputs"]
+        NP["Named Pipes (JSON)"]
+        RPC["Pigweed RPC (Proto)"]
+        TET["Test Event Triggers"]
+    end
+
+    subgraph Translators["Translators"]
+        TR["Command Translators"]
+    end
+
+    subgraph Backend["OOB Execution Backend"]
+        REG["OOBAccessorRegistry"]
+        OOB["OOBAccessors"]
+    end
+
+    subgraph Device["Device Data Model"]
+        CLUSTER["Cluster Instances"]
+    end
+
+    External --> TR
+    TR -->|Action Name + TLV Payload| REG
+    REG --> OOB
+    OOB -->|Direct C++ Method Calls| CLUSTER
+```
+
+### How OOB Control Works
+
+- **Single Control Surface**: `OOBAccessor` is the only mechanism to control simulated devices and clusters outside of the Matter protocol.
+- **Generic Action Dispatch**: An `OOBAccessor` receives a semantic action name and a TLV data buffer. The application maintains a registry of accessors and queries them in order until one handles the action.
+- **Transport Translation**: External protocols and transports (Named Pipe JSON, Pigweed RPC, Test Event Triggers) parse incoming requests, convert them into an action name and TLV payload, and forward them to `OOBAccessorRegistry`.
+- **Code Organization**:
+  - **Shared Cluster Accessors**: Accessors for common Matter clusters (e.g., `OnOff`, `OccupancySensing`) live in `all-devices-common/oob-accessors/clusters/` so any device containing that cluster reuses the same implementation.
+  - **Device-Specific Accessors**: Accessors tied to a specific device live directly alongside the device implementation in `devices/types/<device-name>/`.
+  - **Platform Transport Code**: Transport translators and listener dispatchers (e.g., POSIX Named Pipes) live in platform directories under `posix/named_pipe/`.
+
+---
+
+## 2. Directory Layout
+
+```
+examples/all-devices-app/
+├── all-devices-common/
+│   ├── device/
+│   │   └── types/
+│   │       └── <device-name>/
+│   │           ├── <DeviceName>.h/.cpp                 # Core device implementation
+│   │           ├── OOBAccessors.h/.cpp                 # Device-level OOB accessor registration
+│   │           └── NamedPipes.h/.cpp                   # Device-level Named Pipe translator registration
+│   └── oob-accessors/
+│       ├── OOBAccessor.h                               # Base interface: HandleAction(action, tlvData)
+│       ├── OOBAccessorRegistry.h                       # Active alias (InMemory vs Noop)
+│       ├── InMemoryOOBAccessorRegistry.h/.cpp           # Intrusive list of registered OOBAccessors
+│       ├── NoopOOBAccessorRegistry.h                   # Zero-cost inline stub for disabled targets
+│       └── clusters/
+│           └── <Cluster>OobAccessor.h/.cpp             # Cluster accessors (e.g. OnOffOobAccessor, OccupancyOobAccessor)
+└── posix/
+    └── named_pipe/
+        ├── NamedPipeCommandTranslator.h                # Base interface: TranslateAndExecute(json)
+        ├── NamedPipeDispatcher.h                       # Active alias (Posix vs Noop)
+        ├── PosixNamedPipeDispatcher.h/.cpp             # POSIX pipe listener & JSON command router
+        ├── NoopNamedPipeDispatcher.h                   # Zero-cost inline stub for disabled targets
+        └── translators/
+            └── <Command>Translator.h/.cpp              # Command translators (e.g. OnOffTranslator, OccupancyTranslator)
+```
+
+---
+
+## 3. Interfaces & Core Types
+
+### OOBAccessor Interface
+
+```cpp
+namespace chip::app::Clusters {
+
+class OOBAccessor
+{
+public:
+    virtual ~OOBAccessor() = default;
+
+    /**
+     * @brief Executes an out-of-band action on a target endpoint.
+     * @param action Semantic action string (e.g. "SetOnOff", "SetOccupancy").
+     * @param tlvData Encoded TLV payload containing endpoint ID and action parameters.
+     */
+    virtual CHIP_ERROR HandleAction(CharSpan action, ByteSpan tlvData) = 0;
+};
+
+} // namespace chip::app::Clusters
+```
+
+### OOBAccessorRegistry Interface
+
+```cpp
+class InMemoryOOBAccessorRegistry
+{
+public:
+    /**
+     * @brief Registers an OOB accessor instance.
+     * @param accessor The accessor instance to register.
+     */
+    CHIP_ERROR Register(std::unique_ptr<chip::app::Clusters::OOBAccessor> accessor);
+
+    /**
+     * @brief Dispatches an action to registered accessors.
+     */
+    CHIP_ERROR HandleAction(CharSpan action, ByteSpan tlvData);
+
+    /**
+     * @brief Helper to attach all accessors declared by a device instance.
+     */
+    template <typename ConcreteDevice>
+    void AttachAccessors(ConcreteDevice & device)
+    {
+        RegisterOOBAccessors(device, *this);
+    }
+};
+```
+
+### NamedPipeCommandTranslator Interface
+
+```cpp
+class NamedPipeCommandTranslator
+{
+public:
+    virtual ~NamedPipeCommandTranslator() = default;
+
+    /**
+     * @brief Translates a JSON payload into TLV and executes the action via OOBAccessorRegistry.
+     * @param json Parsed JSON payload from named pipe.
+     */
+    virtual CHIP_ERROR TranslateAndExecute(const Json::Value & json) = 0;
+};
+```
+
+### PosixNamedPipeDispatcher Interface
+
+```cpp
+class PosixNamedPipeDispatcher
+{
+public:
+    explicit PosixNamedPipeDispatcher(InMemoryOOBAccessorRegistry & oobRegistry) :
+        mOobRegistry(oobRegistry) {}
+
+    /**
+     * @brief Registers a translator if not already present, deduping by TranslatorType::kName.
+     */
+    template <typename TranslatorType, typename... Args>
+    CHIP_ERROR EnsureTranslatorRegistered(Args &&... args)
+    {
+        if (HasTranslator(TranslatorType::kName))
+        {
+            return CHIP_NO_ERROR;
+        }
+        return RegisterTranslator(
+            TranslatorType::kName,
+            std::make_unique<TranslatorType>(mOobRegistry, std::forward<Args>(args)...)
+        );
+    }
+
+    /**
+     * @brief Helper to attach all named pipe translators required by a device instance.
+     */
+    template <typename ConcreteDevice>
+    void AttachDevice(ConcreteDevice & device)
+    {
+        RegisterNamedPipes(device, *this);
+    }
+
+    CHIP_ERROR DispatchJson(const Json::Value & json);
+
+private:
+    InMemoryOOBAccessorRegistry & mOobRegistry;
+    std::unordered_map<std::string, std::unique_ptr<NamedPipeCommandTranslator>> mTranslators;
+};
+```
+
+---
+
+## 4. Execution Flow
+
+### Named Pipe Command Flow
+
+```mermaid
+sequenceDiagram
+    participant Pipe as Named Pipe
+    participant Trans as OnOffTranslator
+    participant Reg as OOBAccessorRegistry
+    participant Accessor as OnOffOobAccessor
+    participant Cluster as OnOffCluster
+
+    Pipe->>Trans: {"action": "SetOnOff", "endpoint": 1, "value": true}
+    Trans->>Reg: HandleAction("SetOnOff", TLV[endpoint: 1, value: true])
+    Reg->>Accessor: HandleAction("SetOnOff", TLV)
+    Accessor->>Cluster: SetOnOff(true)
+```
+
+1. **Ingress**: External process writes JSON string to named pipe (e.g. `/tmp/chip_all_devices_fifo`):
+   ```json
+   {
+       "action": "SetOnOff",
+       "endpoint": 1,
+       "value": true
+   }
+   ```
+2. **Dispatch**: `PosixNamedPipeDispatcher` reads pipe, parses JSON, and extracts `"action"`.
+3. **Translation**: Dispatcher invokes `OnOffTranslator::TranslateAndExecute(json)`:
+   - Extracts `endpoint = 1` and `value = true`.
+   - Encodes flat TLV payload:
+     - Tag 1: `EndpointId` (`uint16_t`)
+     - Tag 2: `Value` (`bool`)
+   - Calls `mOobRegistry.HandleAction("SetOnOff", tlvBuffer)`.
+4. **Execution**: `OOBAccessorRegistry` routes to `OnOffOobAccessor` registered for Endpoint 1:
+   - Decodes TLV fields.
+   - Calls `mCluster.SetOnOff(true)` on target cluster instance.
+
+---
+
+## 5. Adding OOB Support for a Device
+
+### Step 1: Register Cluster OOB Accessors
+
+In `all-devices-common/device/types/<device-name>/OOBAccessors.h`:
+```cpp
+#pragma once
+#include <oob-accessors/OOBAccessorRegistry.h>
+
+class MyDevice;
+
+void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry);
+```
+
+In `all-devices-common/device/types/<device-name>/OOBAccessors.cpp`:
+```cpp
+#include "OOBAccessors.h"
+#include "MyDevice.h"
+#include <oob-accessors/clusters/OnOffOobAccessor.h>
+
+void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry)
+{
+    registry.Register(std::make_unique<OnOffOobAccessor>(device.GetOnOffCluster(), device.GetEndpointId()));
+}
+```
+
+### Step 2: Register Named Pipe Translators
+
+In `all-devices-common/device/types/<device-name>/NamedPipes.h`:
+```cpp
+#pragma once
+#include <posix/named_pipe/NamedPipeDispatcher.h>
+
+class MyDevice;
+
+void RegisterNamedPipes(MyDevice & device, NamedPipeDispatcher & dispatcher);
+```
+
+In `all-devices-common/device/types/<device-name>/NamedPipes.cpp`:
+```cpp
+#include "NamedPipes.h"
+#include "MyDevice.h"
+#include <posix/named_pipe/translators/OnOffTranslator.h>
+
+void RegisterNamedPipes(MyDevice & device, NamedPipeDispatcher & dispatcher)
+{
+    dispatcher.EnsureTranslatorRegistered<OnOffTranslator>();
+}
+```
+
+### Step 3: Factory Attachment
+
+In `DeviceFactory.h`, creator lambdas attach registered accessors and translators uniformly:
+
+```cpp
+mContext->oobRegistry.AttachAccessors(*device);
+mContext->namedPipesRegistry.AttachDevice(*device);
+```
+
+---
+
+## 6. Build Configuration & Conditional Compilation
+
+Configuration defines are generated into `<app_config/all_devices_config.h>` for both GN and CMake, mirroring the `enabled_devices` build system:
+
+- **GN Build** (`oob-accessors/all_devices_config.gni`): Uses `buildconfig_header` to emit `app_config/all_devices_config.h`.
+- **CMake Build** (`oob-accessors/all_devices_config.cmake`): Uses `configure_file` with `all_devices_config.h.in` to emit `${CMAKE_CURRENT_BINARY_DIR}/app_config/all_devices_config.h`.
+
+| Build Target / Flag | `ALL_DEVICES_APP_ENABLE_NAMED_PIPES` | `ALL_DEVICES_APP_ENABLE_PWRPC` | `ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS` |
+| :--- | :--- | :--- | :--- |
+| POSIX Linux (`all-devices-app`) | 1 | 0 (or 1 if `chip_enable_pw_rpc`) | 1 |
+| Embedded Targets (ESP32, SiLabs, Telink) | 0 | 0 | 0 |
+
+Header aliasing in `all-devices-common/oob-accessors/OOBAccessorRegistry.h`:
+```cpp
+#pragma once
+#include <app_config/all_devices_config.h>
+
+#if ALL_DEVICES_APP_ENABLE_OOB_ACCESSORS
+#include <oob-accessors/InMemoryOOBAccessorRegistry.h>
+using OOBAccessorRegistry = chip::app::InMemoryOOBAccessorRegistry;
+#else
+#include <oob-accessors/NoopOOBAccessorRegistry.h>
+using OOBAccessorRegistry = chip::app::NoopOOBAccessorRegistry;
+#endif
+```
+
+Header aliasing in `posix/named_pipe/NamedPipeDispatcher.h`:
+```cpp
+#pragma once
+#include <app_config/all_devices_config.h>
+
+#if ALL_DEVICES_APP_ENABLE_NAMED_PIPES
+#include <posix/named_pipe/PosixNamedPipeDispatcher.h>
+using NamedPipeDispatcher = chip::app::PosixNamedPipeDispatcher;
+#else
+#include <posix/named_pipe/NoopNamedPipeDispatcher.h>
+using NamedPipeDispatcher = chip::app::NoopNamedPipeDispatcher;
+#endif
+```
+
+---
+
+## 7. TODO / Implementation Checklist
+
+> [!NOTE]
+> The unified Out-of-Band Control architecture is specified above and tracked for implementation via the following phased checklist.
+
+### Phase 1: Core OOB Registry & Cluster Accessors
+- [ ] Create `all-devices-common/oob-accessors/all_devices_config.gni`, `all_devices_config.cmake`, and `all_devices_config.h.in`.
+- [ ] Create `all-devices-common/oob-accessors/OOBAccessor.h`.
+- [ ] Create `all-devices-common/oob-accessors/InMemoryOOBAccessorRegistry.h` and `.cpp`.
+- [ ] Create `all-devices-common/oob-accessors/NoopOOBAccessorRegistry.h`.
+- [ ] Create `all-devices-common/oob-accessors/OOBAccessorRegistry.h` (aliasing header).
+- [ ] Implement shared cluster accessors in `all-devices-common/oob-accessors/clusters/`:
+  - [ ] `OnOffOobAccessor.h/.cpp`
+  - [ ] `OccupancyOobAccessor.h/.cpp`
+  - [ ] `BooleanStateOobAccessor.h/.cpp`
+  - [ ] `AmbientContextOobAccessor.h/.cpp`
+  - [ ] `BasicInformationOobAccessor.h/.cpp`
+- [ ] Update `all-devices-common/BUILD.gn` with new OOB source targets.
+
+### Phase 2: Device-Type OOB Accessor Registration
+- [ ] Add `OOBAccessors.h` and `OOBAccessors.cpp` for all existing device types:
+  - [ ] `all-devices-common/device/types/on-off-light/`
+  - [ ] `all-devices-common/device/types/dimmable-light/`
+  - [ ] `all-devices-common/device/types/occupancy-sensor/`
+  - [ ] `all-devices-common/device/types/contact-sensor/`
+  - [ ] `all-devices-common/device/types/light-sensor/`
+  - [ ] `all-devices-common/device/types/air-quality-sensor/`
+  - [ ] `all-devices-common/device/types/speaker/`
+  - [ ] `all-devices-common/device/types/smart-plug/`
+- [ ] Hook `oobRegistry.AttachAccessors(*device)` into `DeviceFactory.h`.
+
+### Phase 3: POSIX Named Pipe Dispatcher & Translators
+- [ ] Create `posix/named_pipe/NamedPipeCommandTranslator.h`.
+- [ ] Create `posix/named_pipe/PosixNamedPipeDispatcher.h` and `.cpp`.
+- [ ] Create `posix/named_pipe/NoopNamedPipeDispatcher.h`.
+- [ ] Create `posix/named_pipe/NamedPipeDispatcher.h` (aliasing header).
+- [ ] Implement granular translators in `posix/named_pipe/translators/`:
+  - [ ] `OnOffTranslator.h/.cpp`
+  - [ ] `OccupancyTranslator.h/.cpp`
+  - [ ] `BooleanStateTranslator.h/.cpp`
+  - [ ] `AmbientContextTranslator.h/.cpp`
+  - [ ] `BasicInformationTranslator.h/.cpp`
+
+### Phase 4: Device-Type Named Pipe Registration & Integration
+- [ ] Add `NamedPipes.h` and `NamedPipes.cpp` under `all-devices-common/device/types/<device-name>/` for each supported device.
+- [ ] Inject `NamedPipeDispatcher` and `OOBAccessorRegistry` into `DeviceFactory::Context`.
+- [ ] Wire initialization in `posix/main.cpp`.
+
+### Phase 5: Legacy Cleanup & Build Verification
+- [ ] Remove legacy `AppCommandDelegate.h/.cpp`.
+- [ ] Remove legacy `ClusterTypeMappings.h/.cpp`.
+- [ ] Remove legacy `AllDevicesAppClusterImplementationRegistry.h`.
+- [ ] Update build files (`posix/BUILD.gn`, `all-devices-common/BUILD.gn`).
+- [ ] Build target `linux-x64-all-devices-clang` and verify with sample named pipe commands.

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -46,7 +46,16 @@ flowchart LR
     simulated devices and clusters outside of the Matter protocol.
 -   **Generic Action Dispatch**: An `OOBAccessor` receives a semantic action
     name and a TLV data buffer. The application maintains a registry of
-    accessors and queries them in order until one handles the action.
+    accessors and queries them in order:
+    -   `CHIP_NO_ERROR`: The action was recognized and executed successfully.
+        Dispatch terminates.
+    -   `CHIP_ERROR_NOT_FOUND`: The action is not supported by this accessor.
+        Registry continues querying the next accessor.
+    -   Other `CHIP_ERROR`: The action was recognized by this accessor, but
+        execution failed. Dispatch terminates immediately and propagates the
+        error.
+    -   If no registered accessor handles the action, `HandleAction` returns
+        `CHIP_ERROR_NOT_FOUND`.
 -   **Transport Translation**: External protocols and transports (Named Pipe
     JSON, Pigweed RPC, Test Event Triggers) parse incoming requests, convert
     them into an action name and TLV payload, and forward them to
@@ -111,6 +120,9 @@ public:
      * @brief Executes an out-of-band action on a target endpoint.
      * @param action Semantic action string (e.g. "SetOnOff", "SetOccupancy").
      * @param tlvData Encoded TLV payload containing endpoint ID and action parameters.
+     * @return CHIP_NO_ERROR if action was recognized and executed successfully.
+     * @return CHIP_ERROR_NOT_FOUND if action is not supported (registry continues dispatch).
+     * @return Other CHIP_ERROR on execution failure (registry stops dispatch).
      */
     virtual CHIP_ERROR HandleAction(CharSpan action, ByteSpan tlvData) = 0;
 };
@@ -118,7 +130,7 @@ public:
 } // namespace chip::app::Clusters
 ```
 
-### `OOBAccessorRegistry` Interface
+### `InMemoryOOBAccessorRegistry` Class
 
 ```cpp
 namespace chip::app {
@@ -133,7 +145,8 @@ public:
     CHIP_ERROR Register(std::unique_ptr<chip::app::Clusters::OOBAccessor> accessor);
 
     /**
-     * @brief Dispatches an action to registered accessors.
+     * @brief Dispatches an action to registered accessors in order.
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_NOT_FOUND if unhandled, or specific error on execution failure.
      */
     CHIP_ERROR HandleAction(CharSpan action, ByteSpan tlvData);
 

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -65,11 +65,15 @@ flowchart LR
         (e.g., `OnOff`, `OccupancySensing`) live in
         `all-devices-common/oob-accessors/clusters/` so any device containing
         that cluster reuses the same implementation.
-    -   **Device-Specific Accessors**: Accessors tied to a specific device live
-        directly alongside the device implementation in
-        `all-devices-common/device/types/<device-name>/`.
-    -   **Platform Transport Code**: Transport translators and listener
-        dispatchers (e.g., POSIX Named Pipes) live in platform directories under
+    -   **Device-Specific Accessors & Integrations**: Device implementations and
+        their associated OOB hooks live together in
+        `all-devices-common/device/types/<device-name>/`:
+        -   Core logic and `OOBAccessors.h/.cpp` belong to the platform-neutral
+            `:<device-name>` target.
+        -   `NamedPipes.h/.cpp` belongs to the POSIX-only `:<device-name>:posix`
+            sub-target.
+    -   **Platform Transport Infrastructure**: Dispatchers and base interfaces
+        (e.g., POSIX Named Pipes) live in platform directories under
         `posix/named_pipe/`.
 
 ---
@@ -82,9 +86,10 @@ examples/all-devices-app/
 │   ├── device/
 │   │   └── types/
 │   │       └── <device-name>/
-│   │           ├── <DeviceName>.h/.cpp                 # Core device implementation
-│   │           ├── OOBAccessors.h/.cpp                 # Device-level OOB accessor registration
-│   │           └── NamedPipes.h/.cpp                   # Device-level Named Pipe translator registration
+│   │           ├── <DeviceName>.h/.cpp                 # Core device implementation (platform-neutral)
+│   │           ├── OOBAccessors.h/.cpp                 # Device OOB accessor registration (platform-neutral)
+│   │           ├── NamedPipes.h/.cpp                   # Device Named Pipe registration (POSIX-only)
+│   │           └── BUILD.gn                            # GN targets: :<device-name>, :posix, :logging
 │   └── oob-accessors/
 │       ├── OOBAccessor.h                               # Base interface: HandleAction(action, tlvData)
 │       ├── OOBAccessorRegistry.h                       # Active alias (InMemory vs Noop)
@@ -95,9 +100,7 @@ examples/all-devices-app/
 └── posix/
     └── named_pipe/
         ├── NamedPipeCommandTranslator.h                # Base interface: TranslateAndExecute(json)
-        ├── NamedPipeDispatcher.h                       # Active alias (Posix vs Noop)
         ├── PosixNamedPipeDispatcher.h/.cpp             # POSIX pipe listener & JSON command router
-        ├── NoopNamedPipeDispatcher.h                   # Zero-cost inline stub for disabled targets
         └── translators/
             └── <Command>Translator.h/.cpp              # Command translators (e.g. OnOffTranslator, OccupancyTranslator)
 ```
@@ -276,7 +279,7 @@ sequenceDiagram
 
 ## 5. Adding OOB Support for a Device
 
-### Step 1: Register Cluster OOB Accessors
+### Step 1: Register Cluster OOB Accessors (Platform-Neutral)
 
 In `all-devices-common/device/types/<device-name>/OOBAccessors.h`:
 
@@ -302,17 +305,17 @@ void RegisterOOBAccessors(MyDevice & device, OOBAccessorRegistry & registry)
 }
 ```
 
-### Step 2: Register Named Pipe Translators
+### Step 2: Register Named Pipe Translators (POSIX-Only)
 
 In `all-devices-common/device/types/<device-name>/NamedPipes.h`:
 
 ```cpp
 #pragma once
-#include <posix/named_pipe/NamedPipeDispatcher.h>
+#include <posix/named_pipe/PosixNamedPipeDispatcher.h>
 
 class MyDevice;
 
-void RegisterNamedPipes(MyDevice & device, NamedPipeDispatcher & dispatcher);
+void RegisterNamedPipes(MyDevice & device, PosixNamedPipeDispatcher & dispatcher);
 ```
 
 In `all-devices-common/device/types/<device-name>/NamedPipes.cpp`:
@@ -322,28 +325,87 @@ In `all-devices-common/device/types/<device-name>/NamedPipes.cpp`:
 #include "MyDevice.h"
 #include <posix/named_pipe/translators/OnOffTranslator.h>
 
-void RegisterNamedPipes(MyDevice & device, NamedPipeDispatcher & dispatcher)
+void RegisterNamedPipes(MyDevice & device, PosixNamedPipeDispatcher & dispatcher)
 {
     dispatcher.EnsureTranslatorRegistered<OnOffTranslator>();
 }
 ```
 
-### Step 3: Factory Attachment
+### Step 3: Define Granular GN Sub-Targets
 
-In `DeviceFactory.h`, creator lambdas attach registered accessors and
-translators uniformly:
+In `all-devices-common/device/types/<device-name>/BUILD.gn`:
+
+```gn
+import("//build_overrides/chip.gni")
+
+# Platform-neutral device target (used by all platforms)
+source_set("<device-name>") {
+  sources = [
+    "<DeviceName>.cpp",
+    "<DeviceName>.h",
+    "OOBAccessors.cpp",
+    "OOBAccessors.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/oob-accessors",
+  ]
+}
+
+# POSIX-only named pipe integration (pulled exclusively by POSIX builds)
+source_set("posix") {
+  sources = [
+    "NamedPipes.cpp",
+    "NamedPipes.h",
+  ]
+
+  public_deps = [
+    ":<device-name>",
+    "${chip_root}/examples/all-devices-app/posix/named_pipe:dispatcher",
+  ]
+}
+```
+
+### Step 4: Factory & Application Attachment
+
+In `DeviceFactory.h` (common across all platforms):
 
 ```cpp
 mContext->oobRegistry.AttachAccessors(*device);
-mContext->namedPipesRegistry.AttachDevice(*device);
+```
+
+In POSIX application initialization (`posix/main.cpp`):
+
+```cpp
+mNamedPipeDispatcher.AttachDevice(*device);
 ```
 
 ---
 
-## 6. Build Configuration & Conditional Compilation
+## 6. Build Configuration & Target Isolation
+
+Target separation prevents platform-specific dependencies from leaking into
+embedded builds:
+
+-   **POSIX GN Target (`posix/BUILD.gn`)**: Pulls both the base device target
+    and the `:posix` sub-target:
+    ```gn
+    deps = [
+      "${chip_root}/examples/all-devices-app/all-devices-common/device/types/on-off-light",
+      "${chip_root}/examples/all-devices-app/all-devices-common/device/types/on-off-light:posix",
+    ]
+    ```
+-   **Embedded GN Targets (`silabs/BUILD.gn`)**: Pulls only the platform-neutral
+    base target `device/types/<name>` (and any `:silabs` / `:logging`
+    sub-targets). The `:posix` target is never referenced, eliminating
+    transitive POSIX headers.
+-   **Embedded CMake Targets (`esp32`, `telink`)**: `enabled_devices.cmake`
+    collects `${DEVICE_DIR}/<DeviceName>.cpp` and
+    `${DEVICE_DIR}/OOBAccessors.cpp`. `NamedPipes.cpp` is excluded from CMake
+    source lists.
 
 Configuration defines are generated into `<app_config/all_devices_config.h>` for
-both GN and CMake, mirroring the `enabled_devices` build system:
+both GN and CMake:
 
 -   **GN Build** (`oob-accessors/all_devices_config.gni`): Uses
     `buildconfig_header` to emit `app_config/all_devices_config.h`.
@@ -368,21 +430,6 @@ using OOBAccessorRegistry = chip::app::InMemoryOOBAccessorRegistry;
 #else
 #include <oob-accessors/NoopOOBAccessorRegistry.h>
 using OOBAccessorRegistry = chip::app::NoopOOBAccessorRegistry;
-#endif
-```
-
-Header aliasing in `posix/named_pipe/NamedPipeDispatcher.h`:
-
-```cpp
-#pragma once
-#include <app_config/all_devices_config.h>
-
-#if ALL_DEVICES_APP_ENABLE_NAMED_PIPES
-#include <posix/named_pipe/PosixNamedPipeDispatcher.h>
-using NamedPipeDispatcher = chip::app::PosixNamedPipeDispatcher;
-#else
-#include <posix/named_pipe/NoopNamedPipeDispatcher.h>
-using NamedPipeDispatcher = chip::app::NoopNamedPipeDispatcher;
 #endif
 ```
 
@@ -430,8 +477,6 @@ using NamedPipeDispatcher = chip::app::NoopNamedPipeDispatcher;
 
 -   [ ] Create `posix/named_pipe/NamedPipeCommandTranslator.h`.
 -   [ ] Create `posix/named_pipe/PosixNamedPipeDispatcher.h` and `.cpp`.
--   [ ] Create `posix/named_pipe/NoopNamedPipeDispatcher.h`.
--   [ ] Create `posix/named_pipe/NamedPipeDispatcher.h` (aliasing header).
 -   [ ] Implement granular translators in `posix/named_pipe/translators/`:
     -   [ ] `OnOffTranslator.h/.cpp`
     -   [ ] `OccupancyTranslator.h/.cpp`
@@ -439,14 +484,13 @@ using NamedPipeDispatcher = chip::app::NoopNamedPipeDispatcher;
     -   [ ] `AmbientContextTranslator.h/.cpp`
     -   [ ] `BasicInformationTranslator.h/.cpp`
 
-### Phase 4: Device-Type Named Pipe Registration & Integration
+### Phase 4: Device-Type Named Pipe Registration & Sub-Targets
 
 -   [ ] Add `NamedPipes.h` and `NamedPipes.cpp` under
         `all-devices-common/device/types/<device-name>/` for each supported
         device.
--   [ ] Inject `NamedPipeDispatcher` and `OOBAccessorRegistry` into
-        `DeviceFactory::Context`.
--   [ ] Wire initialization in `posix/main.cpp`.
+-   [ ] Add `source_set("posix")` to each device's `BUILD.gn`.
+-   [ ] Wire `mNamedPipeDispatcher.AttachDevice(*device)` in `posix/main.cpp`.
 
 ### Phase 5: Legacy Cleanup & Build Verification
 

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -116,6 +116,28 @@ examples/all-devices-app/
 
 ## 3. Interfaces & Core Types
 
+### `CreatedDevice` Struct
+
+```cpp
+namespace chip::app {
+
+struct CreatedDevice
+{
+    std::unique_ptr<DeviceInterface> device;
+
+    /**
+     * @brief Optional callback to execute actions after endpoint registration.
+     *
+     * This callback MUST be invoked after `device->Register(...)` completes so that
+     * any actions requiring a valid allocated EndpointId (such as registering OOB
+     * cluster accessors) have access to `device->GetEndpointId()`.
+     */
+    std::function<void(OOBAccessorRegistry & registry)> postRegistrationCallback;
+};
+
+} // namespace chip::app
+```
+
 ### `OOBAccessor` Interface
 
 ```cpp
@@ -440,22 +462,49 @@ source_set("posix") {
 }
 ```
 
-### Step 4: Application Lifecycle & Registration
+### Step 4: Factory Creation & Application Lifecycle
+
+In `DeviceFactory.h` (creator registration):
+
+```cpp
+RegisterCreator("on-off-light", [this](const std::string & label) -> CreatedDevice {
+    VerifyOrDie(mContext.has_value());
+    auto device = std::make_unique<LoggingOnOffLight>(mContext->timerDelegate);
+    auto * rawDevice = device.get();
+
+    return CreatedDevice{
+        .device = std::move(device),
+        .postRegistrationCallback = [rawDevice](OOBAccessorRegistry & registry) {
+            RegisterOOBAccessors(*rawDevice, registry);
+        },
+    };
+});
+```
 
 In application initialization (`posix/main.cpp` and embedded setup):
 
 ```cpp
-// 1. Device creation via factory
-auto device = DeviceFactory::GetInstance().Create(deviceTypeName);
+for (const auto & entry : AppOptions::GetDeviceTypeEntries())
+{
+    // 1. Create device + post-registration callback via factory
+    auto created = DeviceFactory::GetInstance().Create(entry.type, entry.label);
+    VerifyOrReturnError(created.device != nullptr, CHIP_ERROR_NO_MEMORY);
 
-// 2. Register endpoint with data model provider (allocates valid endpoint ID)
-ReturnErrorOnFailure(device->Register(endpointIdAllocator, dataModelProvider));
+    // 2. Register endpoint with data model provider (allocates valid endpoint ID)
+    ReturnErrorOnFailure(
+        created.device->Register(endpointIdAllocator, mDataModelProvider, EndpointComposition::WithParent(entry.parentId)));
 
-// 3. Register OOB accessors once endpoint ID is assigned
-RegisterOOBAccessors(*device, oobRegistry);
+    // 3. Invoke post-registration callback once EndpointId is assigned
+    if (created.postRegistrationCallback)
+    {
+        created.postRegistrationCallback(mOobRegistry);
+    }
+
+    mConstructedDevices.push_back(std::move(created.device));
+}
 
 // 4. Start named pipe listener in POSIX main
-namedPipeDispatcher.Start(kDefaultFifoPath);
+mNamedPipeDispatcher.Start(kDefaultFifoPath);
 ```
 
 ---
@@ -559,7 +608,7 @@ using OOBAccessorRegistry = NoopOOBAccessorRegistry;
     -   [ ] `all-devices-common/device/types/speaker/`
     -   [ ] `all-devices-common/device/types/on-off-plug-in-unit/`
     -   [ ] `all-devices-common/device/types/dimmable-plug-in-unit/`
--   [ ] Hook `RegisterOOBAccessors(*device, oobRegistry)` after endpoint
+-   [ ] Hook `created.postRegistrationCallback(mOobRegistry)` after endpoint
         registration in `main.cpp`.
 
 ### Phase 3: POSIX Named Pipe Dispatcher & Translators

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -47,15 +47,15 @@ flowchart LR
 -   **Generic Action Dispatch**: An `OOBAccessor` receives a semantic action
     name and a TLV data buffer. The application maintains a registry of
     accessors and queries them in order:
+    -   `std::nullopt`: The action is not supported by this accessor. Registry
+        continues querying the next accessor.
     -   `CHIP_NO_ERROR`: The action was recognized and executed successfully.
         Dispatch terminates.
-    -   `CHIP_ERROR_NOT_FOUND`: The action is not supported by this accessor.
-        Registry continues querying the next accessor.
     -   Other `CHIP_ERROR`: The action was recognized by this accessor, but
         execution failed. Dispatch terminates immediately and propagates the
         error.
-    -   If no registered accessor handles the action, `HandleAction` returns
-        `CHIP_ERROR_NOT_FOUND`.
+    -   If no registered accessor handles the action (all return
+        `std::nullopt`), `HandleAction` returns `CHIP_ERROR_NOT_FOUND`.
 -   **Transport Translation**: External protocols and transports (Named Pipe
     JSON, Pigweed RPC, Test Event Triggers) parse incoming requests, convert
     them into an action name and TLV payload, and forward them to
@@ -112,9 +112,9 @@ examples/all-devices-app/
 ### `OOBAccessor` Interface
 
 ```cpp
-namespace chip::app::Clusters {
+namespace chip::app {
 
-class OOBAccessor
+class OOBAccessor : public chip::IntrusiveListNodeBase<chip::IntrusiveMode::AutoUnlink>
 {
 public:
     virtual ~OOBAccessor() = default;
@@ -123,14 +123,14 @@ public:
      * @brief Executes an out-of-band action on a target endpoint.
      * @param action Semantic action string (e.g. "SetOnOff", "SetOccupancy").
      * @param tlvData Encoded TLV payload containing endpoint ID and action parameters.
+     * @return std::nullopt if action is not supported (registry continues dispatch).
      * @return CHIP_NO_ERROR if action was recognized and executed successfully.
-     * @return CHIP_ERROR_NOT_FOUND if action is not supported (registry continues dispatch).
      * @return Other CHIP_ERROR on execution failure (registry stops dispatch).
      */
-    virtual CHIP_ERROR HandleAction(CharSpan action, ByteSpan tlvData) = 0;
+    virtual std::optional<CHIP_ERROR> HandleAction(CharSpan action, ByteSpan tlvData) = 0;
 };
 
-} // namespace chip::app::Clusters
+} // namespace chip::app
 ```
 
 ### `InMemoryOOBAccessorRegistry` Class
@@ -335,7 +335,7 @@ void RegisterNamedPipes(MyDevice & device, PosixNamedPipeDispatcher & dispatcher
 
 In `all-devices-common/device/types/<device-name>/BUILD.gn`:
 
-```gn
+```text
 import("//build_overrides/chip.gni")
 
 # Platform-neutral device target (used by all platforms)
@@ -389,7 +389,7 @@ embedded builds:
 
 -   **POSIX GN Target (`posix/BUILD.gn`)**: Pulls both the base device target
     and the `:posix` sub-target:
-    ```gn
+    ```text
     deps = [
       "${chip_root}/examples/all-devices-app/all-devices-common/device/types/on-off-light",
       "${chip_root}/examples/all-devices-app/all-devices-common/device/types/on-off-light:posix",

--- a/examples/all-devices-app/docs/design/out_of_band_control.md
+++ b/examples/all-devices-app/docs/design/out_of_band_control.md
@@ -26,8 +26,8 @@ flowchart LR
     end
 
     subgraph Backend["OOB Execution Backend"]
-        REG["OOBAccessorRegistry"]
-        OOB["OOBAccessors"]
+        REG["OOB Accessor Registry"]
+        OOB["OOB Accessors"]
     end
 
     subgraph Device["Device Data Model"]
@@ -58,7 +58,7 @@ flowchart LR
         that cluster reuses the same implementation.
     -   **Device-Specific Accessors**: Accessors tied to a specific device live
         directly alongside the device implementation in
-        `devices/types/<device-name>/`.
+        `all-devices-common/device/types/<device-name>/`.
     -   **Platform Transport Code**: Transport translators and listener
         dispatchers (e.g., POSIX Named Pipes) live in platform directories under
         `posix/named_pipe/`.
@@ -97,7 +97,7 @@ examples/all-devices-app/
 
 ## 3. Interfaces & Core Types
 
-### OOBAccessor Interface
+### `OOBAccessor` Interface
 
 ```cpp
 namespace chip::app::Clusters {
@@ -118,9 +118,11 @@ public:
 } // namespace chip::app::Clusters
 ```
 
-### OOBAccessorRegistry Interface
+### `OOBAccessorRegistry` Interface
 
 ```cpp
+namespace chip::app {
+
 class InMemoryOOBAccessorRegistry
 {
 public:
@@ -144,11 +146,15 @@ public:
         RegisterOOBAccessors(device, *this);
     }
 };
+
+} // namespace chip::app
 ```
 
-### NamedPipeCommandTranslator Interface
+### `NamedPipeCommandTranslator` Interface
 
 ```cpp
+namespace chip::app {
+
 class NamedPipeCommandTranslator
 {
 public:
@@ -160,11 +166,15 @@ public:
      */
     virtual CHIP_ERROR TranslateAndExecute(const Json::Value & json) = 0;
 };
+
+} // namespace chip::app
 ```
 
-### PosixNamedPipeDispatcher Interface
+### `PosixNamedPipeDispatcher` Interface
 
 ```cpp
+namespace chip::app {
+
 class PosixNamedPipeDispatcher
 {
 public:
@@ -202,6 +212,8 @@ private:
     InMemoryOOBAccessorRegistry & mOobRegistry;
     std::unordered_map<std::string, std::unique_ptr<NamedPipeCommandTranslator>> mTranslators;
 };
+
+} // namespace chip::app
 ```
 
 ---
@@ -213,10 +225,10 @@ private:
 ```mermaid
 sequenceDiagram
     participant Pipe as Named Pipe
-    participant Trans as OnOffTranslator
-    participant Reg as OOBAccessorRegistry
-    participant Accessor as OnOffOobAccessor
-    participant Cluster as OnOffCluster
+    participant Trans as Command Translator
+    participant Reg as OOB Accessor Registry
+    participant Accessor as Cluster OOB Accessor
+    participant Cluster as OnOff Cluster
 
     Pipe->>Trans: {"action": "SetOnOff", "endpoint": 1, "value": true}
     Trans->>Reg: HandleAction("SetOnOff", TLV[endpoint: 1, value: true])
@@ -224,8 +236,8 @@ sequenceDiagram
     Accessor->>Cluster: SetOnOff(true)
 ```
 
-1. **Ingress**: External process writes JSON string to named pipe (e.g.
-   `/tmp/chip_all_devices_fifo`):
+1.  **Ingress**: External process writes JSON string to named pipe (e.g.
+    `/tmp/chip_all_devices_fifo`):
     ```json
     {
         "action": "SetOnOff",
@@ -233,19 +245,19 @@ sequenceDiagram
         "value": true
     }
     ```
-2. **Dispatch**: `PosixNamedPipeDispatcher` reads pipe, parses JSON, and
-   extracts `"action"`.
-3. **Translation**: Dispatcher invokes
-   `OnOffTranslator::TranslateAndExecute(json)`:
-    - Extracts `endpoint = 1` and `value = true`.
-    - Encodes flat TLV payload:
-        - Tag 1: `EndpointId` (`uint16_t`)
-        - Tag 2: `Value` (`bool`)
-    - Calls `mOobRegistry.HandleAction("SetOnOff", tlvBuffer)`.
-4. **Execution**: `OOBAccessorRegistry` routes to `OnOffOobAccessor` registered
-   for Endpoint 1:
-    - Decodes TLV fields.
-    - Calls `mCluster.SetOnOff(true)` on target cluster instance.
+2.  **Dispatch**: `PosixNamedPipeDispatcher` reads pipe, parses JSON, and
+    extracts `"action"`.
+3.  **Translation**: Dispatcher invokes
+    `OnOffTranslator::TranslateAndExecute(json)`:
+    -   Extracts `endpoint = 1` and `value = true`.
+    -   Encodes flat TLV payload:
+        -   Tag 1: `EndpointId` (`uint16_t`)
+        -   Tag 2: `Value` (`bool`)
+    -   Calls `mOobRegistry.HandleAction("SetOnOff", tlvBuffer)`.
+4.  **Execution**: `OOBAccessorRegistry` routes to `OnOffOobAccessor` registered
+    for Endpoint 1:
+    -   Decodes TLV fields.
+    -   Calls `mCluster.SetOnOff(true)` on target cluster instance.
 
 ---
 


### PR DESCRIPTION
#### Summary

Documents the Out-of-Band (OOB) control architecture for `all-devices-app` at `examples/all-devices-app/docs/design/out_of_band_control.md` and links it from `architecture.md`.

This design establishes a unified backend for controlling simulated devices and clusters outside of the Matter data model (such as via Named Pipes, Pigweed RPC, or test triggers):
- Decouples ingress transport translators (e.g. Named Pipe JSON, RPC Protobuf) from execution logic.
- Routes external commands through a centralized `OOBAccessorRegistry` to reusable cluster accessors (`all-devices-common/oob-accessors/clusters/`) and device-specific handlers (`all-devices-common/device/types/<device>/`).
- Uses dependency injection via `DeviceFactory::Context` with zero-overhead no-op stubs for embedded platforms without Named Pipes or RPC.
- Includes a phased implementation checklist to track subsequent development.

#### Testing

N/A: Documentation only.
