### PR TITLE
[all-device-app] Add OTA Requestor device type to RootNode

### DIFF
--- a/examples/all-devices-app/all-devices-common/device/types/root-node/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/root-node/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("${chip_root}/src/platform/device.gni")
 
 source_set("root-node") {
   sources = [

--- a/examples/all-devices-app/all-devices-common/device/types/root-node/BUILD.gn
+++ b/examples/all-devices-app/all-devices-common/device/types/root-node/BUILD.gn
@@ -38,6 +38,10 @@ source_set("root-node") {
     "${chip_root}/src/lib/support",
     "${chip_root}/zzz_generated/app-common/devices/",
   ]
+
+  if (chip_enable_ota_requestor) {
+    public_deps += [ "${chip_root}/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider:ids" ]
+  }
 }
 
 source_set("wifi") {

--- a/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.cpp
@@ -32,6 +32,14 @@ using namespace chip::DeviceLayer;
 namespace chip {
 namespace app {
 
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+CHIP_ERROR RootNode::ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const
+{
+    static constexpr ClusterId kClientClusters[] = { OtaSoftwareUpdateProvider::Id };
+    return out.ReferenceExisting(Span<const ClusterId>(kClientClusters));
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+
 CHIP_ERROR RootNode::Register(EndpointId endpointId, CodeDrivenDataModelProvider & provider, EndpointComposition composition)
 {
     composition.pattern = DataModel::EndpointCompositionPattern::kFullFamily;

--- a/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.cpp
@@ -25,6 +25,10 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+#include <clusters/OtaSoftwareUpdateProvider/ClusterId.h>
+#endif // CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;

--- a/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.h
+++ b/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.h
@@ -36,6 +36,10 @@
 #include <lib/support/TimerDelegate.h>
 #include <platform/DiagnosticDataProvider.h>
 
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+#include <clusters/OtaSoftwareUpdateProvider/ClusterId.h>
+#endif // CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+
 namespace chip {
 namespace app {
 
@@ -69,7 +73,7 @@ public:
     };
 
     RootNode(const Context & context) :
-        SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRootNode, 1)), mContext(context)
+        SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(kDeviceTypes)), mContext(context)
     {}
     ~RootNode() override = default;
 
@@ -78,12 +82,22 @@ public:
 
     Clusters::BasicInformationCluster & BasicInformation() { return mBasicInformationCluster.Cluster(); }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+    CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const override;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+
 protected:
     Context mContext;
 
     LazyRegisteredServerCluster<Clusters::GeneralCommissioningCluster> mGeneralCommissioningCluster;
 
 private:
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+    static constexpr DataModel::DeviceTypeEntry kDeviceTypes[] = { Device::Type::kRootNode, Device::Type::kOtaRequestor };
+#else
+    static constexpr DataModel::DeviceTypeEntry kDeviceTypes[] = { Device::Type::kRootNode };
+#endif // CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+
     LazyRegisteredServerCluster<Clusters::BasicInformationCluster> mBasicInformationCluster;
     LazyRegisteredServerCluster<Clusters::AdministratorCommissioningWithBasicCommissioningWindowCluster>
         mAdministratorCommissioningCluster;

--- a/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.h
+++ b/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.h
@@ -72,9 +72,7 @@ public:
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     };
 
-    RootNode(const Context & context) :
-        SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(kDeviceTypes)), mContext(context)
-    {}
+    RootNode(const Context & context) : SingleEndpoint(Span<const DataModel::DeviceTypeEntry>(kDeviceTypes)), mContext(context) {}
     ~RootNode() override = default;
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointComposition composition = {}) override;

--- a/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.h
+++ b/examples/all-devices-app/all-devices-common/device/types/root-node/RootNode.h
@@ -36,10 +36,6 @@
 #include <lib/support/TimerDelegate.h>
 #include <platform/DiagnosticDataProvider.h>
 
-#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-#include <clusters/OtaSoftwareUpdateProvider/ClusterId.h>
-#endif // CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-
 namespace chip {
 namespace app {
 


### PR DESCRIPTION
### Summary

Adds the OTA Requestor Device type to the root node when chip_enable_ota_requestor is enabled.

### Related issues


### Testing

Tested on the Zephyr all-device-app (wip)