### PR TITLE
throwaway: CNET Wi-Fi CI probe for matter-test-scripts#609

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -873,6 +873,17 @@ jobs:
                   && rm -rf out/linux-x64-all-clusters-no-groupcast-${BUILD_VARIANT}-clang-test
                   "
 
+            # BUILD_VARIANT is no-wifi, which compiles out LinuxWiFiDriver, so --wifi
+            # is a no-op on the default app. This variant keeps Wi-Fi and Thread drivers
+            # so the CNET Wi-Fi feature map can be exercised.
+            - name: Build linux-x64-all-clusters with Wi-Fi drivers
+              run: >-
+                  ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
+                  --target linux-x64-all-clusters-ipv6only-no-ble-asan-clang-test
+                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  && rm -rf out/linux-x64-all-clusters-ipv6only-no-ble-asan-clang-test
+                  "
+
             - name: Build linux-x64-all-devices
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
@@ -1145,6 +1156,7 @@ jobs:
                   echo "AIR_PURIFIER_APP: objdir-clone/linux-x64-air-purifier-${BUILD_VARIANT}-clang-test-unified/chip-air-purifier-app" >> /tmp/test_env.yaml
                   echo "ALL_CLUSTERS_APP: objdir-clone/linux-x64-all-clusters-${BUILD_VARIANT}-clang-test/chip-all-clusters-app" >> /tmp/test_env.yaml
                   echo "ALL_CLUSTERS_NO_GROUPCAST_APP: objdir-clone/linux-x64-all-clusters-no-groupcast-${BUILD_VARIANT}-clang-test/chip-all-clusters-app" >> /tmp/test_env.yaml
+                  echo "ALL_CLUSTERS_WIFI_APP: objdir-clone/linux-x64-all-clusters-ipv6only-no-ble-asan-clang-test/chip-all-clusters-app" >> /tmp/test_env.yaml
                   echo "ALL_DEVICES_APP: objdir-clone/linux-x64-all-devices-${BUILD_VARIANT}-clang-test/all-devices-app" >> /tmp/test_env.yaml
                   echo "BRIDGE_APP: objdir-clone/linux-x64-bridge-${BUILD_VARIANT}-clang-test-unified/chip-bridge-app" >> /tmp/test_env.yaml
                   echo "CAMERA_APP: objdir-clone/linux-x64-camera-${BUILD_VARIANT}/chip-camera-app" >> /tmp/test_env.yaml

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -45,6 +45,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -33,19 +33,6 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
-#   run2:
-#     app: ${ALL_CLUSTERS_WIFI_APP}
-#     app-args: --thread --wifi --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-#     script-args: >
-#       --storage-path admin_storage.json
-#       --commissioning-method on-network
-#       --discriminator 1234
-#       --passcode 20202021
-#       --PICS src/app/tests/suites/certification/ci-pics-values
-#       --trace-to json:${TRACE_TEST_JSON}.json
-#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     factory-reset: true
-#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -33,6 +33,18 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
+#   run2:
+#     app: ${ALL_CLUSTERS_WIFI_APP}
+#     app-args: --thread --wifi --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_CNET_4_15.py
+++ b/src/python_testing/TC_CNET_4_15.py
@@ -20,7 +20,7 @@
 # The app runs with --wifi so the Network Commissioning cluster on endpoint 0
 # reports the Wi-Fi feature. No radio is needed: this test only requires that an
 # unknown NetworkID is rejected with NetworkIDNotFound, which an empty Networks
-# list satisfies. ci-pics-values sets CNET.S.F00=0, so --PICS is not passed here.
+# list satisfies. Note: --PICS is intentionally omitted; when omitted, the runner uses an empty PICS map (all keys default to False).
 #
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:

--- a/src/python_testing/TC_CNET_4_15.py
+++ b/src/python_testing/TC_CNET_4_15.py
@@ -16,6 +16,27 @@
 #
 # See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
 # for details about the block below.
+#
+# The app runs with --wifi so the Network Commissioning cluster on endpoint 0
+# reports the Wi-Fi feature. No radio is needed: this test only requires that an
+# unknown NetworkID is rejected with NetworkIDNotFound, which an empty Networks
+# list satisfies. ci-pics-values sets CNET.S.F00=0, so --PICS is not passed here.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_WIFI_APP}
+#     app-args: --wifi --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --endpoint 0
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_CNET_4_16.py
+++ b/src/python_testing/TC_CNET_4_16.py
@@ -14,6 +14,27 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# Throwaway probe (matter-test-scripts#609): does --thread alone work in REPL CI?
+# No radio needed to observe app init vs test-body failure. --PICS omitted (same as 4_15).
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --thread --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --endpoint 0
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -45,8 +45,6 @@ not_automated:
       reason: It has no CI execution block, is not executed in CI
     - name: TC_CNET_4_12.py
       reason: It has no CI execution block, is not executed in CI
-    - name: TC_CNET_4_15.py
-      reason: It has no CI execution block, is not executed in CI
     - name: TC_CNET_4_16.py
       reason: Can not run thread CNET tests in CI
     - name: TC_CNET_4_22.py

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -45,8 +45,6 @@ not_automated:
       reason: It has no CI execution block, is not executed in CI
     - name: TC_CNET_4_12.py
       reason: It has no CI execution block, is not executed in CI
-    - name: TC_CNET_4_16.py
-      reason: Can not run thread CNET tests in CI
     - name: TC_CNET_4_22.py
       reason: It has no CI execution block, is not executed in CI
     - name: TC_CNET_4_23.py


### PR DESCRIPTION
### Summary

Draft / throwaway probe for running a small subset of CNET Python tests in CI with `--wifi` / `--thread`. Not intended to merge as-is.

The default REPL `all-clusters` target is `no-wifi`, so `--wifi` does not enable `LinuxWiFiDriver`. This PR builds a second all-clusters binary with Wi-Fi compiled in (`ALL_CLUSTERS_WIFI_APP`) and uses it only for:

- `TC_CNET_4_15` with `--wifi` (unknown NetworkID → `NetworkIDNotFound`; no radio required)
- `TC_CNET_1_4` `run2` with `--wifi --thread` (secondary interface on EP 65534)

Existing Ethernet runs are unchanged (`TC_CNET_4_3`, `TC_CNET_1_4` `run1`). `TC_CNET_4_15` is removed from `not_automated` so the new CI block actually executes.

### Related issues

- https://github.com/project-chip/matter-test-scripts/issues/609
- https://github.com/project-chip/connectedhomeip/issues/36505 (not closed by this)

### Testing

- Locally: `TC_CNET_4_15` PASS with `--wifi`; `TC_CNET_1_4` PASS with `--wifi --thread` on a Wi-Fi-enabled `chip-all-clusters-app`.
- This draft PR is the CI confirmation: look at **REPL Tests - Linux (RUN)** shard `TC_[B-C]` for `TC_CNET_4_15`, `TC_CNET_1_4` (two runs), and `TC_CNET_4_3` (Ethernet control).