### PR TITLE
[Darwin] Avoid EXC_GUARD process abort when a watched socket is closed during teardown

### DIFF
--- a/src/platform/Darwin/system/SystemLayerImplDispatchSockets.mm
+++ b/src/platform/Darwin/system/SystemLayerImplDispatchSockets.mm
@@ -28,6 +28,8 @@
 
 #include <lib/support/CodeUtils.h>
 
+#include <unistd.h>
+
 // Note: CONFIG_BUILD_FOR_HOST_UNIT_TEST
 //
 // Certain unit tests are executed without a main dispatch queue, relying instead on a mock clock
@@ -96,8 +98,21 @@ namespace System {
         VerifyOrDie(nullptr != dispatchQueue);
 #endif
 
-        source = dispatch_source_create(sourceType, static_cast<uintptr_t>(watch->mFD), 0, dispatchQueue);
-        VerifyOrReturnError(nullptr != source, CHIP_ERROR_NO_MEMORY);
+        // Monitor a private duplicate of the socket descriptor rather than the caller's fd.
+        // libdispatch READ/WRITE sources require the monitored descriptor to remain valid until
+        // the source's cancel handler has run; otherwise, if the fd is close()d during socket /
+        // endpoint teardown before the asynchronous source cancellation completes, libdispatch
+        // aborts the process with _dispatch_bug_kevent_vanished (EXC_GUARD). The caller owns and
+        // may close watch->mFD at any time, so we dup() it and close the copy from the cancel
+        // handler, which libdispatch invokes only once it is completely done with the source.
+        int dupFD = ::dup(watch->mFD);
+        VerifyOrReturnError(dupFD >= 0, CHIP_ERROR_POSIX(errno));
+
+        source = dispatch_source_create(sourceType, static_cast<uintptr_t>(dupFD), 0, dispatchQueue);
+        if (nullptr == source) {
+            ::close(dupFD);
+            return CHIP_ERROR_NO_MEMORY;
+        }
 
         dispatch_source_set_event_handler(source, ^{
             if (watch->mPendingIO.Has(flag) && watch->mCallback != nullptr) {
@@ -105,6 +120,11 @@ namespace System {
                 events.Set(flag);
                 watch->mCallback(events, watch->mCallbackData);
             }
+        });
+        // Close our private duplicate of the descriptor only after libdispatch is completely
+        // finished with the source, guaranteeing the monitored fd never vanishes underneath it.
+        dispatch_source_set_cancel_handler(source, ^{
+            ::close(dupFD);
         });
         // only now we are sure the source exists and can become active
         dispatch_activate(source);

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -53,6 +53,10 @@ chip_test_suite("tests") {
     ]
   }
 
+  if (chip_system_config_event_loop == "Dispatch") {
+    test_sources += [ "TestSystemDispatchSocketWatch.cpp" ]
+  }
+
   cflags = [ "-Wconversion" ]
 
   public_deps = [

--- a/src/system/tests/TestSystemDispatchSocketWatch.cpp
+++ b/src/system/tests/TestSystemDispatchSocketWatch.cpp
@@ -1,0 +1,139 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Unit tests for the libdispatch-backed socket watch in
+ *      chip::System::LayerImplDispatch.
+ *
+ *      A libdispatch READ/WRITE source requires the descriptor it monitors to
+ *      remain valid until the source's asynchronous cancellation has completed.
+ *      If the layer monitors the caller's fd directly, a caller that closes
+ *      that fd during socket / endpoint teardown -- before the async source
+ *      cancellation completes -- makes the descriptor vanish underneath
+ *      libdispatch, which can abort the whole process.
+ *
+ *      The layer must therefore monitor a private duplicate of the caller's fd
+ *      that stays open until the source is torn down. These tests assert that
+ *      invariant behaviorally: once a watch is installed, closing the caller's
+ *      fd must not tear down the underlying socket description (the peer end
+ *      stays connected). That is observable and deterministic, and does not
+ *      depend on reproducing the platform abort.
+ */
+
+#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/support/CodeUtils.h>
+#include <system/SystemConfig.h>
+#include <system/SystemError.h>
+#include <system/SystemLayer.h>
+#include <system/SystemLayerImpl.h>
+
+// The dispatch-source fd-vanish hazard only exists in the libdispatch-backed
+// system layer (Darwin). On select-based builds LayerImplDispatch is not the
+// active implementation, so the whole suite is compiled out there.
+#if CHIP_SYSTEM_CONFIG_USE_DISPATCH && CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+#include <cerrno>
+#include <sys/socket.h>
+#include <unistd.h>
+
+using namespace chip;
+using namespace chip::System;
+
+namespace {
+
+void NoopSocketCallback(SocketEvents, intptr_t) {}
+
+class TestSystemDispatchSocketWatch : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_EQ(mLayer.Init(), CHIP_NO_ERROR);
+
+        // A live (non-suspended) serial queue so RequestCallback installs and
+        // activates a real dispatch source for the watched fd.
+        mQueue = dispatch_queue_create("org.csa-iot.matter.test.socketwatch", DISPATCH_QUEUE_SERIAL);
+        ASSERT_NE(mQueue, nullptr);
+        mLayer.SetDispatchQueue(mQueue);
+    }
+
+    void TearDown() override { mLayer.Shutdown(); }
+
+    // Installs a watch on one end of a socketpair, requests the given event
+    // callback (which installs the dispatch source), then closes the caller's
+    // fd while the watch is still active. Asserts that the underlying socket
+    // description is still open afterwards -- i.e. the peer end is still
+    // connected rather than at EOF. The dispatch source must monitor a private
+    // duplicate that outlives the caller's close(); if it monitors the caller's
+    // fd directly, close() tears down the only reference and the peer sees EOF.
+    void ExpectWatchedDescriptorOutlivesCallerClose(bool wantRead)
+    {
+        int fds[2];
+        ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+        SocketWatchToken token;
+        ASSERT_EQ(mLayer.StartWatchingSocket(fds[0], &token), CHIP_NO_ERROR);
+        ASSERT_EQ(mLayer.SetCallback(token, NoopSocketCallback, 0), CHIP_NO_ERROR);
+        if (wantRead)
+        {
+            ASSERT_EQ(mLayer.RequestCallbackOnPendingRead(token), CHIP_NO_ERROR);
+        }
+        else
+        {
+            ASSERT_EQ(mLayer.RequestCallbackOnPendingWrite(token), CHIP_NO_ERROR);
+        }
+
+        // Caller closes its fd during teardown, before the watch is stopped.
+        ASSERT_EQ(::close(fds[0]), 0);
+
+        // The socket description the dispatch source monitors must still be
+        // open, so the peer end is still connected: a non-blocking recv blocks
+        // (EAGAIN) rather than returning 0 (EOF). Pre-fix the source monitors
+        // the caller's fd directly, so this close() dropped the only reference
+        // and the peer sees EOF (recv == 0) -> this assertion fails (RED).
+        char buf[8];
+        ssize_t received = ::recv(fds[1], buf, sizeof(buf), MSG_DONTWAIT);
+        EXPECT_EQ(received, static_cast<ssize_t>(-1))
+            << "peer saw EOF after caller close(); watched descriptor did not outlive the caller's fd";
+        EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << "unexpected errno " << errno << " from peer recv";
+
+        ASSERT_EQ(mLayer.StopWatchingSocket(&token), CHIP_NO_ERROR);
+        ::close(fds[1]);
+    }
+
+    LayerImplDispatch mLayer;
+    dispatch_queue_t mQueue = nullptr;
+};
+
+// A read watch must monitor a descriptor that outlives the caller's close().
+TEST_F(TestSystemDispatchSocketWatch, ReadWatchedDescriptorOutlivesCallerClose)
+{
+    ExpectWatchedDescriptorOutlivesCallerClose(/* wantRead = */ true);
+}
+
+// Same invariant for the write source path (DISPATCH_SOURCE_TYPE_WRITE).
+TEST_F(TestSystemDispatchSocketWatch, WriteWatchedDescriptorOutlivesCallerClose)
+{
+    ExpectWatchedDescriptorOutlivesCallerClose(/* wantRead = */ false);
+}
+
+} // namespace
+
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH && CHIP_SYSTEM_CONFIG_USE_SOCKETS


### PR DESCRIPTION
### Summary

The Darwin platform layer watches sockets for read/write readiness by creating a libdispatch source directly on the file descriptor the caller owns. libdispatch requires that descriptor to stay valid until it has *fully* finished tearing the source down, and that teardown is asynchronous.

In practice, when a connection is closed — for example a socket/endpoint being torn down at the end of its life — the owning code closes its file descriptor right away, while libdispatch may still be mid-way through cancelling the source that was watching it. When libdispatch then notices the descriptor it was watching has "vanished", it deliberately aborts the entire process with `EXC_GUARD` (`_dispatch_bug_kevent_vanished`). The user-visible result is a hard crash during ordinary connection teardown, rather than a clean shutdown.

This change makes the platform layer watch a private `dup()` of the caller's descriptor instead of the caller's descriptor itself, and closes that duplicate only from the dispatch source's cancel handler — the one point at which libdispatch guarantees it is completely done with the source. The caller is now free to close its own descriptor whenever it likes; the descriptor libdispatch is watching never disappears out from under it. The duplicate is also closed on the error paths (dup failure, source-creation failure) so no descriptor is leaked.

### Related issues

N/A

### Testing

Added `TestSystemDispatchSocketWatch` (built only for Dispatch event-loop configurations) with two tests — one for a READ watch, one for a WRITE watch — asserting that the watched descriptor survives the caller closing its own descriptor. Both fail before the change and pass after (verified locally, two runs each).

The `_dispatch_bug_kevent_vanished` abort itself is timing- and OS-version-dependent and did not reproduce on the development host, so instead of relying on the crash the tests assert the invariant the fix establishes: the watched descriptor is a private duplicate that outlives the caller's `close()`. This is observed deterministically through the socketpair peer's state — the peer reports EOF before the fix (the caller's fd was the one being watched and got closed) and remains connected after (only the private duplicate was closed, from the cancel handler).
