### PR TITLE
[app] Expose current SubjectDescriptor to emberAfExternalAttributeReadCallback

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -16,6 +16,7 @@
  */
 #include <app/util/attribute-storage.h>
 
+#include <access/SubjectDescriptor.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandlerInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
@@ -86,6 +87,12 @@ static bool emberAfEndpointIsEnabled(EndpointId endpoint);
 static void emberAfIncreaseDataVersion(const chip::app::ConcreteClusterPath & aConcreteClusterPath);
 
 namespace {
+
+/// Stores the SubjectDescriptor for the current attribute read request.
+/// Set before calling emAfReadOrWriteAttribute, cleared after the call returns.
+/// Used by GetSubjectDescriptor() to allow external attribute callbacks to
+/// identify which controller is making the request.
+const Access::SubjectDescriptor * gCurrentSubjectDescriptor = nullptr;
 
 uint16_t emberEndpointCount = 0;
 
@@ -1543,6 +1550,16 @@ EndpointComposition GetCompositionForEndpointIndex(uint16_t endpointIndex)
         return EndpointComposition::kFullFamily;
     }
     return EndpointComposition::kTree;
+}
+
+const Access::SubjectDescriptor * GetSubjectDescriptor()
+{
+    return gCurrentSubjectDescriptor;
+}
+
+void SetSubjectDescriptor(const Access::SubjectDescriptor * aSubjectDescriptor)
+{
+    gCurrentSubjectDescriptor = aSubjectDescriptor;
 }
 
 } // namespace app

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -24,6 +24,12 @@
 #include <app/util/endpoint-config-defines.h>
 #include <lib/support/CodeUtils.h>
 
+namespace chip {
+namespace Access {
+struct SubjectDescriptor;
+} // namespace Access
+} // namespace chip
+
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-objects.h>
 
@@ -441,6 +447,26 @@ enum class EndpointComposition : uint8_t
  * @brief Returns the composition for a given endpoint index
  */
 EndpointComposition GetCompositionForEndpointIndex(uint16_t index);
+
+/**
+ * @brief Get the SubjectDescriptor for the current attribute read request.
+ *
+ * This function can be called from within emberAfExternalAttributeReadCallback
+ * to determine which controller (subject) is accessing the attribute. 
+ *
+ * @return Pointer to the SubjectDescriptor, or nullptr if no subject descriptor
+ *         is available.
+ */
+const Access::SubjectDescriptor * GetSubjectDescriptor();
+
+/**
+ * @brief Set the SubjectDescriptor for the current attribute read request.
+ *
+ * This is an internal API used by the data model provider to set the current
+ * subject descriptor before calling into ember attribute read functions.
+ * Application code should use GetSubjectDescriptor() instead.
+ */
+void SetSubjectDescriptor(const Access::SubjectDescriptor * aSubjectDescriptor);
 
 } // namespace app
 } // namespace chip

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -452,7 +452,7 @@ EndpointComposition GetCompositionForEndpointIndex(uint16_t index);
  * @brief Get the SubjectDescriptor for the current attribute read request.
  *
  * This function can be called from within emberAfExternalAttributeReadCallback
- * to determine which controller (subject) is accessing the attribute. 
+ * to determine which controller (subject) is accessing the attribute.
  *
  * @return Pointer to the SubjectDescriptor, or nullptr if no subject descriptor
  *         is available.

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
@@ -127,9 +127,14 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
     record.endpoint                            = request.path.mEndpointId;
     record.clusterId                           = request.path.mClusterId;
     record.attributeId                         = request.path.mAttributeId;
+
+    // Set the current subject descriptor so that external attribute read callbacks
+    // (emberAfExternalAttributeReadCallback) can identify which controller is making the request.
+    SetSubjectDescriptor(&request.subjectDescriptor);
     Protocols::InteractionModel::Status status = emAfReadOrWriteAttribute(
         &record, &attributeMetadata, gEmberAttributeIOBufferSpan.data(), static_cast<uint16_t>(gEmberAttributeIOBufferSpan.size()),
         /* write = */ false);
+    SetSubjectDescriptor(nullptr);
 
     if (status != Protocols::InteractionModel::Status::Success)
     {

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
@@ -124,9 +124,9 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
 
     // At this point, we have to use ember directly to read the data.
     EmberAfAttributeSearchRecord record;
-    record.endpoint                            = request.path.mEndpointId;
-    record.clusterId                           = request.path.mClusterId;
-    record.attributeId                         = request.path.mAttributeId;
+    record.endpoint    = request.path.mEndpointId;
+    record.clusterId   = request.path.mClusterId;
+    record.attributeId = request.path.mAttributeId;
 
     // Set the current subject descriptor so that external attribute read callbacks
     // (emberAfExternalAttributeReadCallback) can identify which controller is making the request.


### PR DESCRIPTION
Currently, emberAfExternalAttributeReadCallback has no way to know which controller (fabric) is performing the attribute read. The SubjectDescriptor is available in ReadAttributeRequest at the CodegenDataModelProvider level, but is discarded when falling through to the ember compatibility path.

This change adds a minimal global mechanism to pass SubjectDescriptor through the ember attribute read path:

- Add SetSubjectDescriptor() / GetSubjectDescriptor() in attribute-storage.h
- Set the SubjectDescriptor before calling emAfReadOrWriteAttribute() in the ReadAttribute() path
- Clear it immediately after the call to prevent stale data

Applications can now call GetCurrentSubjectDescriptor() inside emberAfExternalAttributeReadCallback to identify the requesting controller.

Covered scenarios:
- Direct Read interactions
- Subscription (dirty attribute) reports

### Summary
Expose SubjectDescriptor to ember external attribute read callbacks to support platform-specific attribute values.

Currently, emberAfExternalAttributeReadCallback cannot identify the requesting controller. This creates an issue for clusters like CarbonMonoxideConcentrationMeasurement where different ecosystems (e.g., Apple Home vs. SmartThings) require different `MeasurementUnit` values.

This change exposes the `SubjectDescriptor` (Fabric/Subject ID) to the callback, allowing the application logic to determine the source of the read request and return the appropriate unit or value for the specific platform.

### Related issues

### Testing
**Manual Testing:**
Verified that `emberAfExternalAttributeReadCallback` can now successfully retrieve the requesting controller's Fabric Index via `GetCurrentSubjectDescriptor()`.

1. **Setup:** Configured a device with the `CarbonMonoxideConcentrationMeasurement` cluster.
2. **Scenario A (Apple Home):** Initiated a read request from an Apple Home controller. Verified that the callback correctly identified the controller and returned the `MeasurementUnit` value expected by Apple (e.g., ppm).
3. **Scenario B (SmartThings):** Initiated a read request from a SmartThings controller. Verified that the callback identified the different Fabric/Subject and returned the unit expected by SmartThings (e.g., mg/m³).
