### PR TITLE
[Silabs][Zephyr] Add dishwasher app skeleton

### DIFF
--- a/examples/dishwasher-app/silabs/zephyr/CMakeLists.txt
+++ b/examples/dishwasher-app/silabs/zephyr/CMakeLists.txt
@@ -1,0 +1,143 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+cmake_minimum_required(VERSION 3.20)
+
+get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/connectedhomeip REALPATH)
+get_filename_component(GEN_DIR ${CHIP_ROOT}/zzz_generated/ REALPATH)
+get_filename_component(ZEPHYR_PLATFORM_COMMON ${CHIP_ROOT}/examples/platform/silabs/zephyr REALPATH)
+get_filename_component(SILABS_DISHWASHER_COMMON ${CHIP_ROOT}/examples/dishwasher-app/silabs REALPATH)
+
+
+# Need this as wiseconnect abstraction is causing a build failure
+add_definitions(-DMBEDTLS_X509_REMOVE_INFO )
+
+list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/silabs)
+find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+
+if(CONFIG_OPENTHREAD AND TARGET ot-config AND TARGET zephyr_interface)
+    get_target_property(OT_CONFIG_DEFS ot-config INTERFACE_COMPILE_DEFINITIONS)
+    if(OT_CONFIG_DEFS)
+        list(FILTER OT_CONFIG_DEFS EXCLUDE REGEX "TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS")
+    else()
+        set(OT_CONFIG_DEFS "")
+    endif()
+    get_target_property(ZEPHYR_INTERFACE_DEFS zephyr_interface INTERFACE_COMPILE_DEFINITIONS)
+    if(ZEPHYR_INTERFACE_DEFS)
+        list(FILTER ZEPHYR_INTERFACE_DEFS EXCLUDE REGEX "COMPILE_LANGUAGE:CXX")
+    else()
+        set(ZEPHYR_INTERFACE_DEFS "")
+    endif()
+    set_target_properties(ot-config PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "${OT_CONFIG_DEFS};${ZEPHYR_INTERFACE_DEFS}")
+endif()
+
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    foreach(_mbedtls_lib mbedtls mbedx509 tfpsacrypto builtin p256-m pqcp extras platform utilities)
+        if(TARGET ${_mbedtls_lib})
+            target_compile_options(${_mbedtls_lib} PRIVATE -Wno-documentation -Wno-c99-extensions)
+        endif()
+    endforeach()
+
+    if(CONFIG_OPENTHREAD)
+        foreach(_ot_lib openthread-ftd openthread-mtd openthread-radio openthread-cli-ftd openthread-cli-mtd)
+            if(TARGET ${_ot_lib})
+                target_compile_options(${_ot_lib} PRIVATE -Wno-c99-extensions)
+            endif()
+        endforeach()
+    endif()
+endif()
+
+# -Wmaybe-uninitialized has too many false positives, including on std::optional
+# and chip::Optional.  Make it nonfatal.
+#
+# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
+target_compile_options(app PRIVATE -Werror -Wno-error=format)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(app PRIVATE -Werror -Wno-error=maybe-uninitialized)
+endif()
+
+project(matter-zephyr-dishwasher)
+
+include(${CHIP_ROOT}/config/silabs/app/enable-gnu-std.cmake)
+include(${CHIP_ROOT}/src/app/chip_data_model.cmake)
+
+target_include_directories(app
+    PRIVATE
+    include
+    ${ZEPHYR_PLATFORM_COMMON}
+)
+
+target_sources(app
+    PRIVATE
+    src/AppTask.cpp
+    src/DeviceCallbacks.cpp
+    ../include/CHIPProjectConfig.h
+    ${ZEPHYR_PLATFORM_COMMON}/main.cpp
+    ${ZEPHYR_PLATFORM_COMMON}/AppTaskBase.cpp
+    ${ZEPHYR_PLATFORM_COMMON}/AppTaskZephyr.cpp
+    ${ZEPHYR_PLATFORM_COMMON}/CHIPDeviceManager.cpp
+    ${ZEPHYR_PLATFORM_COMMON}/CommonDeviceCallbacks.cpp
+    ${ZEPHYR_PLATFORM_COMMON}/DataModelCallbacks.cpp
+)
+
+if(CONFIG_CHIP_FACTORY_DATA)
+    target_sources(app PRIVATE
+                    ${CHIP_ROOT}/examples/platform/silabs/provision/ProvisionStorageZephyr.cpp
+                    ${CHIP_ROOT}/examples/platform/silabs/provision/ProvisionStorageCustom.cpp
+    )
+    target_include_directories(app PRIVATE
+                    ${CHIP_ROOT}/third_party/silabs/matter_support/provision
+    )
+    target_compile_definitions(app PRIVATE
+        SL_PROVISION_GENERATOR=0
+    )
+endif()
+
+if(CONFIG_CHIP_OTA_REQUESTOR)
+    target_sources(app PRIVATE
+                    ${ZEPHYR_PLATFORM_COMMON}/ota_requestor/source/OTARequestorInitiatorCommon.cpp
+                    ${ZEPHYR_PLATFORM_COMMON}/ota_requestor/source/OTARequestorInitiatorZephyr.cpp
+    )
+    target_include_directories(app PRIVATE
+                    ${ZEPHYR_PLATFORM_COMMON}/ota_requestor/include/
+    )
+endif()
+
+if(CONFIG_CHIP_WIFI)
+  chip_configure_data_model(app INCLUDE_SERVER
+      ZAP_FILE ${SILABS_DISHWASHER_COMMON}/data_model/dishwasher-wifi-app.zap
+  )
+else()
+  chip_configure_data_model(app INCLUDE_SERVER
+      ZAP_FILE ${SILABS_DISHWASHER_COMMON}/data_model/dishwasher-thread-app.zap
+  )
+endif()
+
+if(CONFIG_CHIP_LIB_SHELL)
+    target_compile_definitions(app PRIVATE ENABLE_CHIP_SHELL)
+    target_include_directories(app PRIVATE
+                               ${CHIP_ROOT}/examples/shell/shell_common/include
+                               ${ZEPHYR_PLATFORM_COMMON}/include
+    )
+    target_sources(app PRIVATE
+                   ${ZEPHYR_PLATFORM_COMMON}/AppCLIZephyr.cpp
+                   ${CHIP_ROOT}/examples/shell/shell_common/cmd_misc.cpp
+                   ${CHIP_ROOT}/examples/shell/shell_common/cmd_otcli.cpp
+                   ${CHIP_ROOT}/examples/shell/shell_common/cmd_server.cpp
+    )
+endif()
+
+include(${CHIP_ROOT}/config/silabs/app/zephyr-post-build.cmake)

--- a/examples/dishwasher-app/silabs/zephyr/CMakeLists.txt
+++ b/examples/dishwasher-app/silabs/zephyr/CMakeLists.txt
@@ -96,6 +96,7 @@ target_sources(app
 if(CONFIG_CHIP_FACTORY_DATA)
     target_sources(app PRIVATE
                     ${CHIP_ROOT}/examples/platform/silabs/provision/ProvisionStorageZephyr.cpp
+                    ${CHIP_ROOT}/examples/platform/silabs/provision/ProvisionStorageCommon.cpp
                     ${CHIP_ROOT}/examples/platform/silabs/provision/ProvisionStorageCustom.cpp
     )
     target_include_directories(app PRIVATE

--- a/examples/dishwasher-app/silabs/zephyr/Kconfig
+++ b/examples/dishwasher-app/silabs/zephyr/Kconfig
@@ -1,0 +1,27 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+mainmenu "Matter Silabs Dishwasher Example Application"
+
+# Sample configuration used for Thread networking
+if NET_L2_OPENTHREAD
+choice OPENTHREAD_DEVICE_TYPE
+	default OPENTHREAD_FTD
+endchoice
+endif # NET_L2_OPENTHREAD
+
+rsource "../../../../config/silabs/Kconfig.defaults"
+rsource "../../../../config/silabs/Kconfig"
+source "Kconfig.zephyr"

--- a/examples/dishwasher-app/silabs/zephyr/README.md
+++ b/examples/dishwasher-app/silabs/zephyr/README.md
@@ -368,8 +368,8 @@ This example has the following limitations:
    EFR32MG24 boards; the two cannot be combined in a single image.
 
 3. **Memory Constraints:** Both SoCs have limited RAM and flash memory. The
-   four-endpoint dishwasher data model may require stack/heap tuning relative
-   to the lighting example.
+   four-endpoint dishwasher data model may require stack/heap tuning relative to
+   the lighting example.
 
 4. **Power Management:** Advanced power management features available in other
    Silicon Labs SDKs may not yet be exposed in this Zephyr-based example.

--- a/examples/dishwasher-app/silabs/zephyr/README.md
+++ b/examples/dishwasher-app/silabs/zephyr/README.md
@@ -1,0 +1,388 @@
+# Matter Silicon Labs Dishwasher Example (Zephyr)
+
+An example showing the use of Matter on Silicon Labs SoCs running Zephyr RTOS.
+The same application can be built for either:
+
+-   **Wi-Fi** transport on the **SiWx917** Wi-Fi SoC (board `siwx917_rb4338a`).
+-   **Thread (OpenThread)** transport on the **EFR32MG24** SoC (board
+    `xg24_rb4187c`).
+
+<hr>
+
+-   [Matter Silicon Labs Dishwasher Example (Zephyr)](#matter-silicon-labs-dishwasher-example-zephyr)
+    -   [Introduction](#introduction)
+    -   [Supported Hardware](#supported-hardware)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Commissioning over BLE](#commissioning-over-ble)
+        -   [Testing with chip-tool](#testing-with-chip-tool)
+    -   [Building Options](#building-options)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling logging](#disabling-logging)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Limitations](#limitations)
+
+<hr>
+
+## Introduction
+
+The Silicon Labs dishwasher example provides a baseline demonstration of a
+dishwasher control device, built using Matter on Silicon Labs SoCs running
+Zephyr RTOS. Depending on the selected board, it can be controlled by a Matter
+controller over either a Wi-Fi network (SiWx917) or a Thread network
+(EFR32MG24).
+
+In both cases, the device is commissioned over Bluetooth Low Energy: the device
+and the Matter controller exchange security information through the Rendez-vous
+procedure, and the controller then provisions the operational network
+credentials:
+
+-   On **SiWx917 (Wi-Fi)**, Wi-Fi SSID and passphrase are sent and the device
+    joins the Wi-Fi network.
+-   On **EFR32MG24 (Thread)**, the Thread operational dataset is sent and the
+    device joins the Thread network.
+
+This example is the Zephyr port of the FreeRTOS Silabs dishwasher app. The data
+model includes a dishwasher endpoint with Operational State, plus electrical
+sensor and Device Energy Management endpoints (see parent
+`data_model/dishwasher-*-app.zap`). Application managers and Zephyr-specific
+button/LED behavior continue to be ported on top of this scaffold.
+
+The dishwasher example is intended to serve both as a means to explore the
+workings of Matter as well as a template for creating real products based on
+Silicon Labs platforms.
+
+### Configuring the application
+
+You can configure various aspects of the application using Zephyr's menuconfig
+system. This provides an interactive interface to modify build-time
+configuration options such as logging levels, networking settings, memory
+allocation, and Matter-specific features.
+
+```bash
+# Wi-Fi (SiWx917)
+west build -b siwx917_rb4338a examples/dishwasher-app/silabs/zephyr -t menuconfig
+
+# Thread (EFR32MG24)
+west build -b xg24_rb4187c examples/dishwasher-app/silabs/zephyr -t menuconfig
+```
+
+This will open an interactive configuration menu where you can browse and modify
+settings. Changes are automatically saved to the build configuration.
+
+## Supported Hardware
+
+The example can be built for any of the following Silicon Labs boards:
+
+| Board             | SoC       | Transport           |
+| ----------------- | --------- | ------------------- |
+| `siwx917_rb4338a` | SiWx917   | Wi-Fi (2.4 GHz)     |
+| `xg24_rb4187c`    | EFR32MG24 | Thread (OpenThread) |
+
+The board name selected with `west build -b <board>` determines both the target
+SoC and the network transport used by Matter.
+
+## Building
+
+-   Install the required dependencies for Matter development:
+
+    -   [Matter Prerequisites](../../../../docs/guides/BUILDING.md)
+
+-   Install the Simplicity SDK for Zephyr and tools:
+
+    -   Follow the
+        [Silicon Labs Zephyr Repo](https://github.com/SiliconLabsSoftware/zephyr-silabs)
+    -   With additional instructions
+        [here](https://docs.silabs.com/zephyr/2026.6.0/zephyr-getting-started/getting-started-guide)
+
+-   Build the example application for your target:
+
+    ```bash
+    cd workspace
+
+    # Wi-Fi build (SiWx917)
+    west build -b siwx917_rb4338a connectedhomeip/examples/dishwasher-app/silabs/zephyr
+
+    # Thread build (EFR32MG24)
+    west build -b xg24_rb4187c connectedhomeip/examples/dishwasher-app/silabs/zephyr
+    ```
+
+-   To clean the build:
+
+    ```bash
+    west build -t clean
+    ```
+
+-   For a pristine build (removes all build artifacts):
+
+    ```bash
+    rm -rf build
+    ```
+
+    OR
+
+    ```bash
+    west build -p always -b <board> connectedhomeip/examples/dishwasher-app/silabs/zephyr
+    ```
+
+    where `<board>` is `siwx917_rb4338a` or `xg24_rb4187c`.
+
+## Flashing the Application
+
+-   Both SiWx917 and EFR32MG24 SoC devices are supported by the latest
+    Simplicity Commander. The build produces a `.hex` file that can be flashed
+    to either platform.
+
+-   Flash using west:
+
+    ```bash
+    west flash
+    ```
+
+-   Or flash using Simplicity Commander:
+
+    ```bash
+    commander flash build/zephyr/zephyr.hex (or .rps file if using the SiWx917)
+    ```
+
+-   **Bootloader and connectivity firmware:**
+
+    -   The **SiWx917** boards require connectivity firmware in addition to the
+        application image. Pre-built bootloader and connectivity firmware
+        binaries are available in the Assets section of the Releases page on
+        [Wiseconnect](https://github.com/SiliconLabs/wiseconnect/tree/v3.5.0/connectivity_firmware/standard).
+    -   The **EFR32MG24** boards require MCUBoot for OTA support.
+
+## Running the Complete Example
+
+### Commissioning over BLE
+
+To run the Matter application, you must first commission the device using a
+Matter controller over BLE. The controller will then provision the operational
+network credentials:
+
+-   On **SiWx917**, Wi-Fi SSID and passphrase.
+-   On **EFR32MG24**, the Thread operational dataset.
+
+**Creating the Matter Network**
+
+This procedure uses the chip-tool installed on the Matter Hub. The commissioning
+procedure does the following:
+
+-   chip-tool scans BLE and locates the Silicon Labs device that uses the
+    specified discriminator
+-   Establishes operational certificates
+-   Sends the operational network credentials (Wi-Fi credentials or Thread
+    dataset, depending on the platform)
+-   The Silicon Labs device joins the operational network and obtains an IPv6
+    (and IPv4 for Wi-Fi) address
+-   It then starts providing mDNS records on the operational network
+-   Future communications happen over the operational network (Wi-Fi or Thread)
+
+### Testing with chip-tool
+
+You can provision and control the CHIP device using the python controller, the
+chip-tool standalone, or the Android or iOS app.
+
+[CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
+
+Here are examples using chip-tool:
+
+#### Commission the device over BLE-Wi-Fi (SiWx917):
+
+```bash
+./out/linux-x64-chip-tool/chip-tool pairing ble-wifi ${NODE_ID} ${SSID} ${PASSWORD} 20202021 3840
+```
+
+#### Commission the device over BLE-Thread (EFR32MG24):
+
+```bash
+./out/linux-x64-chip-tool/chip-tool pairing ble-thread ${NODE_ID} hex:${THREAD_DATASET} 20202021 3840
+```
+
+`${THREAD_DATASET}` is the active Thread operational dataset in TLV hexadecimal
+format (for example as returned by `ot-ctl dataset active -x` on an OpenThread
+border router).
+
+#### Control Operational State (endpoint 1):
+
+```bash
+# Start the dishwasher
+./out/linux-x64-chip-tool/chip-tool operationalstate start ${NODE_ID} 1
+
+# Pause / resume / stop
+./out/linux-x64-chip-tool/chip-tool operationalstate pause ${NODE_ID} 1
+./out/linux-x64-chip-tool/chip-tool operationalstate resume ${NODE_ID} 1
+./out/linux-x64-chip-tool/chip-tool operationalstate stop ${NODE_ID} 1
+
+# Read current operational state
+./out/linux-x64-chip-tool/chip-tool operationalstate read operational-state ${NODE_ID} 1
+```
+
+Where:
+
+-   `${NODE_ID}` is the node ID assigned to the device
+-   `20202021` is the setup PIN code
+-   `3840` is the discriminator
+-   `${SSID}` and `${PASSWORD}` are your Wi-Fi network credentials (SiWx917)
+-   `${THREAD_DATASET}` is the Thread operational dataset (EFR32MG24)
+
+## Building Options
+
+The build options below apply to both supported boards. Replace `<board>` with
+either `siwx917_rb4338a` or `xg24_rb4187c`.
+
+### Debug build / release build
+
+By default, the application is built in debug mode. To build in release mode:
+
+```bash
+west build -b <board> examples/dishwasher-app/silabs/zephyr -- -DFILE_SUFFIX=release
+```
+
+### Disabling logging
+
+To reduce code size and improve performance, logging can be minimized:
+
+```bash
+west build -b <board> examples/dishwasher-app/silabs/zephyr -- -DCONFIG_LOG_MODE_MINIMAL=y
+```
+
+### KVS maximum entry count
+
+The Key-Value Storage (KVS) maximum entry count can be configured to optimize
+memory usage. The default configuration is optimized for typical Matter
+applications.
+
+To modify the KVS configuration, edit the `prj.conf` file:
+
+```
+CONFIG_NVS_LOOKUP_CACHE_SIZE=1024
+```
+
+## OTA Software Update
+
+This example supports Matter Over-The-Air (OTA) software updates via the generic
+Zephyr image processor (`src/platform/Zephyr/OTAImageProcessorImpl`) and
+MCUboot.
+
+Enabling `CONFIG_CHIP_OTA_REQUESTOR` implies `CONFIG_BOOTLOADER_MCUBOOT`.
+
+The app is signed with the MCUboot ECDSA-P256 development key
+(`CONFIG_MCUBOOT_SIGNATURE_KEY_FILE`, set in `config/silabs/Kconfig`); replace
+it with a private key for production.
+
+### Build
+
+```bash
+west build -b xg24_rb4187c -p always examples/dishwasher-app/silabs/zephyr \
+    -- -DCONFIG_CHIP_OTA_REQUESTOR=y -DCONFIG_CHIP_OTA_IMAGE_BUILD=y
+```
+
+Build the update image with a higher software version so the provider offers it
+as newer version:
+
+```bash
+west build -b xg24_rb4187c -p always examples/dishwasher-app/silabs/zephyr \
+    -- -DCONFIG_CHIP_OTA_REQUESTOR=y -DCONFIG_CHIP_OTA_IMAGE_BUILD=y \
+       -DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION=2 \
+       -DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING=\"2.0\"
+```
+
+Outputs in `build/zephyr/` (produced by
+`config/silabs/app/zephyr-post-build.cmake`):
+
+-   `zephyr_full.bin` — MCUboot + signed application; flash this for the initial
+    (factory) image.
+-   `matter.ota` — the image to serve from a Matter OTA Provider.
+
+### Flash the base image
+
+Use the following commander command to flash the app and bootloader.
+
+```bash
+commander flash ./build/zephyr/zephyr_full.bin --address 0x8000000
+```
+
+### Run an update
+
+The following commands are provided as examples using a
+[Silicon Labs Matter Hub image.](https://docs.silabs.com/matter/latest/matter-thread/raspi-img)
+Refer to the [Matter OTA guide](../../../../docs/guides/ota_software_update.md)
+for detailed instructions on setting up an OTA Provider.
+
+1. Flash the base (v1) image and commission the device.
+2. Serve the candidate (v2) image with `chip-ota-provider-app`
+
+```bash
+./chip-ota-provider-app \
+    --KVS /tmp/chip_kvs_provider \
+    --filepath /tmp/dishwasher-v2.ota \
+    --discriminator 1111 \
+    --passcode 123456789 \
+    --secured-device-port 5541 \
+    -q updateAvailable
+
+```
+
+3. Commission the OTA provider and update ACLs
+
+```bash
+PROVIDER_NODE_ID=1
+DISHWASHER_NODE_ID=<your-dishwasher-app-node-id>
+
+mattertool pairing onnetwork ${PROVIDER_NODE_ID} 123456789
+
+mattertool accesscontrol write acl \
+    '[{"fabricIndex":1,"privilege":5,"authMode":2,"subjects":[112233],"targets":null},{"fabricIndex":1,"privilege":3,"authMode":2,"subjects":null,"targets":[{"cluster":41,"endpoint":null,"deviceType":null}]}]' \
+    ${PROVIDER_NODE_ID} 0
+
+```
+
+3. Announce the provider to the device with `chip-tool`
+
+```bash
+mattertool otasoftwareupdaterequestor announce-otaprovider \
+    ${PROVIDER_NODE_ID} 0 0 0 ${DISHWASHER_NODE_ID} 0
+```
+
+4. Device will download and apply the OTA.
+5. Verify the OTA was applied
+
+```bash
+mattertool basicinformation read software-version ${DISHWASHER_NODE_ID} 0
+```
+
+## Limitations
+
+This example has the following limitations:
+
+1. **Scaffold in progress:** AppTask/DeviceCallbacks still contain temporary
+   lighting-style stubs until dishwasher managers (Operational State, DEM,
+   electrical sensor) are fully ported to Zephyr.
+
+2. **Single Transport per Build:** A given build targets a single transport.
+   Wi-Fi is supported on the SiWx917 boards and Thread is supported on the
+   EFR32MG24 boards; the two cannot be combined in a single image.
+
+3. **Memory Constraints:** Both SoCs have limited RAM and flash memory. The
+   four-endpoint dishwasher data model may require stack/heap tuning relative
+   to the lighting example.
+
+4. **Power Management:** Advanced power management features available in other
+   Silicon Labs SDKs may not yet be exposed in this Zephyr-based example.
+
+For the FreeRTOS Silabs dishwasher reference (LCD, full Gecko SDK path), see
+`examples/dishwasher-app/silabs/`.
+
+---
+
+### Additional Resources:
+
+-   [Silicon Labs Matter Documentation](https://github.com/SiliconLabsSoftware/matter_sdk)
+-   [SiWx917 Development Kit User Guide](https://www.silabs.com/development-tools/wireless/wi-fi/siwx917-development-kit)
+-   [EFR32xG24 Dev Kit User Guide](https://www.silabs.com/development-tools/wireless/efr32xg24-dev-kit)
+-   [Matter Specification](https://csa-iot.org/all-solutions/matter/)
+-   [Zephyr RTOS Documentation](https://docs.zephyrproject.org/)

--- a/examples/dishwasher-app/silabs/zephyr/boards/siwx917_rb4338a.overlay
+++ b/examples/dishwasher-app/silabs/zephyr/boards/siwx917_rb4338a.overlay
@@ -1,0 +1,59 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/ {
+	chosen {
+		zephyr,entropy = &rng0;
+		zephyr,flash = &flash0;
+		zephyr,flash-controller = &flashctrl0;
+		zephyr,shell-uart = &ulpuart;
+		zephyr,console = &ulpuart;
+		zephyr,code-partition = &code_partition;
+	};
+};
+
+&ulpuart {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&ulpuart_default>;
+	pinctrl-names = "default";
+};
+
+&sram0 {
+	status = "okay";
+	reg = <0x00000400 DT_SIZE_K(319)>;
+};
+
+&flash0 {
+	partitions {
+		factory_partition: partition@3e0000 {
+			reg = <0x003e0000 DT_SIZE_K(4)>;
+		};
+
+		settings_partition: partition@3e1000 {
+			reg = <0x003e1000 DT_SIZE_K(32)>;
+		};
+	};
+};
+
+&code_partition {
+	reg = <0x00202000 DT_SIZE_K(1912)>;
+};
+
+&storage_partition {
+	reg = <0x003e9000 DT_SIZE_K(92)>;
+};

--- a/examples/dishwasher-app/silabs/zephyr/boards/siwx917_rb4342a.overlay
+++ b/examples/dishwasher-app/silabs/zephyr/boards/siwx917_rb4342a.overlay
@@ -1,0 +1,59 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/ {
+	chosen {
+		zephyr,entropy = &rng0;
+		zephyr,flash = &flash0;
+		zephyr,flash-controller = &flashctrl0;
+		zephyr,shell-uart = &ulpuart;
+		zephyr,console = &ulpuart;
+		zephyr,code-partition = &code_partition;
+	};
+};
+
+&ulpuart {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&ulpuart_default>;
+	pinctrl-names = "default";
+};
+
+&sram0 {
+	status = "okay";
+	reg = <0x00000400 DT_SIZE_K(319)>;
+};
+
+&flash0 {
+	partitions {
+		factory_partition: partition@3e0000 {
+			reg = <0x003e0000 DT_SIZE_K(4)>;
+		};
+
+		settings_partition: partition@3e1000 {
+			reg = <0x003e1000 DT_SIZE_K(32)>;
+		};
+	};
+};
+
+&code_partition {
+	reg = <0x00202000 DT_SIZE_K(1912)>;
+};
+
+&storage_partition {
+	reg = <0x003e9000 DT_SIZE_K(92)>;
+};

--- a/examples/dishwasher-app/silabs/zephyr/boards/xg24_rb4187c.conf
+++ b/examples/dishwasher-app/silabs/zephyr/boards/xg24_rb4187c.conf
@@ -1,0 +1,27 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+
+# Drivers required to read/write the external SPI NOR;
+# Enables external flash for OTA support
+CONFIG_SPI=y
+CONFIG_SPI_SILABS_EUSART=y
+CONFIG_SPI_NOR=y
+
+# Bootloader overwrite-only mode for computing image padding/overflow.
+CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY=y
+CONFIG_MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY=y

--- a/examples/dishwasher-app/silabs/zephyr/boards/xg24_rb4187c.overlay
+++ b/examples/dishwasher-app/silabs/zephyr/boards/xg24_rb4187c.overlay
@@ -1,0 +1,67 @@
+/*
+ *	Copyright (c) 2026 Project CHIP Authors
+ *	All rights reserved.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *	    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ */
+
+/*
+ * Internal flash (1536 KiB): boot (48) + slot0 (1024) + unused (416) + storage (48).
+ * slot1 matches slot0 size on the external MX25R80.
+ * slot0/slot1 must match for MCUboot in overwrite-only mode.
+ */
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@c000 {
+			reg = <0x0000c000 DT_SIZE_K(1024)>;
+			label = "image-0";
+		};
+
+		unused_partition: partition@10c000 {
+			reg = <0x0010c000 DT_SIZE_K(416)>;
+			label = "unused";
+		};
+
+		storage_partition: partition@174000 {
+			reg = <0x00174000 DT_SIZE_K(48)>;
+			label = "storage";
+		};
+	};
+};
+
+&mx25r80 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot1_partition: partition@0 {
+			reg = <0x00000000 DT_SIZE_K(1024)>;
+			label = "image-1";
+		};
+	};
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&usart0 {
+	dmas = <&dma0 DMA_REQSEL_USART0TXBL>,
+		   <&dma0 DMA_REQSEL_USART0RXDATAV>;
+	dma-names = "tx", "rx";
+};

--- a/examples/dishwasher-app/silabs/zephyr/boards/xg24_rb4187c_bootloader.conf
+++ b/examples/dishwasher-app/silabs/zephyr/boards/xg24_rb4187c_bootloader.conf
@@ -1,0 +1,26 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Overwrite-only install: the secondary slot (slot1) lives on the external SPI
+# NOR and the primary (slot0) on internal flash, so the slots cannot be swapped
+CONFIG_BOOT_UPGRADE_ONLY=y
+
+# Drivers required to read/write the external SPI NOR;
+# Enables external flash for OTA support
+CONFIG_SPI=y
+CONFIG_SPI_SILABS_EUSART=y
+CONFIG_SPI_NOR=y

--- a/examples/dishwasher-app/silabs/zephyr/boards/xg26_rb4118a.conf
+++ b/examples/dishwasher-app/silabs/zephyr/boards/xg26_rb4118a.conf
@@ -1,0 +1,20 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Bootloader overwrite-only mode for computing image padding/overflow.
+CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY=y
+CONFIG_MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY=y

--- a/examples/dishwasher-app/silabs/zephyr/boards/xg26_rb4118a.overlay
+++ b/examples/dishwasher-app/silabs/zephyr/boards/xg26_rb4118a.overlay
@@ -1,0 +1,42 @@
+/*
+ *	Copyright (c) 2026 Project CHIP Authors
+ *	All rights reserved.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ */
+
+/*
+ * Internal flash (3200 KiB): boot (48) + slot0 (1552) + slot1 (1552) + storage (48).
+ */
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@c000 {
+			reg = <0x0000c000 DT_SIZE_K(1552)>;
+			label = "image-0";
+		};
+
+		slot1_partition: partition@190000 {
+			reg = <0x00190000 DT_SIZE_K(1552)>;
+			label = "image-1";
+		};
+
+		storage_partition: partition@314000 {
+			reg = <0x00314000 DT_SIZE_K(48)>;
+			label = "storage";
+		};
+	};
+};

--- a/examples/dishwasher-app/silabs/zephyr/boards/xg26_rb4118a_bootloader.conf
+++ b/examples/dishwasher-app/silabs/zephyr/boards/xg26_rb4118a_bootloader.conf
@@ -1,0 +1,18 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_BOOT_UPGRADE_ONLY=y

--- a/examples/dishwasher-app/silabs/zephyr/include/AppEvent.h
+++ b/examples/dishwasher-app/silabs/zephyr/include/AppEvent.h
@@ -1,0 +1,47 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+struct AppEvent;
+using EventHandler = void (*)(const AppEvent &);
+
+struct AppEvent
+{
+    enum AppEventTypes
+    {
+        kEventType_Timer = 0,
+        kEventType_TurnOn,
+    };
+
+    uint16_t Type;
+
+    union
+    {
+        struct
+        {
+            void * Context;
+        } TimerEvent;
+        struct
+        {
+            uint8_t Action;
+            int32_t Actor;
+        } ClusterEvent;
+    };
+
+    EventHandler Handler;
+};

--- a/examples/dishwasher-app/silabs/zephyr/include/AppTask.h
+++ b/examples/dishwasher-app/silabs/zephyr/include/AppTask.h
@@ -1,0 +1,36 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "AppTaskZephyr.h"
+
+class AppTask : public chip::Zephyr::App::AppTaskZephyr
+{
+public:
+    ~AppTask() override{};
+    void PreInitMatterStack(void) override;
+    void PostInitMatterStack(void) override;
+    void PostInitMatterServerInstance(void) override;
+    static AppTask & GetDefaultInstance();
+
+private:
+    static AppTask sAppTask;
+};
+
+chip::Zephyr::App::AppTaskBase & GetAppTask();

--- a/examples/dishwasher-app/silabs/zephyr/include/DeviceCallbacks.h
+++ b/examples/dishwasher-app/silabs/zephyr/include/DeviceCallbacks.h
@@ -1,0 +1,46 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file DeviceCallbacks.h
+ *
+ * Dishwasher app DeviceManager callbacks (skeleton).
+ *
+ **/
+
+#pragma once
+
+#include "CHIPDeviceManager.h"
+#include "CommonDeviceCallbacks.h"
+
+namespace DishwasherApp {
+
+class DeviceCallbacks : public chip::Zephyr::App::CommonDeviceCallbacks
+{
+public:
+    void PostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                     uint8_t type, uint16_t size, uint8_t * value) override;
+};
+
+} // namespace DishwasherApp
+
+namespace chip::Zephyr::App {
+
+chip::DeviceManager::CHIPDeviceManagerCallbacks & GetDeviceCallbacks();
+
+} // namespace chip::Zephyr::App

--- a/examples/dishwasher-app/silabs/zephyr/socs/siwg917m111mgtba.conf
+++ b/examples/dishwasher-app/silabs/zephyr/socs/siwg917m111mgtba.conf
@@ -1,0 +1,19 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_NVS_LOOKUP_CACHE=y
+CONFIG_NVS_LOOKUP_CACHE_SIZE=1024

--- a/examples/dishwasher-app/silabs/zephyr/src/AppTask.cpp
+++ b/examples/dishwasher-app/silabs/zephyr/src/AppTask.cpp
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "AppTask.h"
+
+#include <lib/support/logging/CHIPLogging.h>
+
+using namespace chip;
+
+void AppTask::PreInitMatterStack()
+{
+    ChipLogProgress(DeviceLayer, "Welcome to Zephyr Matter Dishwasher Demo App (skeleton)");
+}
+
+void AppTask::PostInitMatterStack() {}
+
+void AppTask::PostInitMatterServerInstance() {}
+
+AppTask & AppTask::GetDefaultInstance()
+{
+    static AppTask sAppTask;
+    return sAppTask;
+}
+
+chip::Zephyr::App::AppTaskBase & chip::Zephyr::App::GetAppTask()
+{
+    return AppTask::GetDefaultInstance();
+}

--- a/examples/dishwasher-app/silabs/zephyr/src/DeviceCallbacks.cpp
+++ b/examples/dishwasher-app/silabs/zephyr/src/DeviceCallbacks.cpp
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DeviceCallbacks.h"
+
+#include <lib/support/logging/CHIPLogging.h>
+
+void DishwasherApp::DeviceCallbacks::PostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                 chip::AttributeId attributeId, uint8_t type, uint16_t size,
+                                                                 uint8_t * value)
+{
+    // Skeleton: dishwasher-specific attribute handling added in a follow-up commit.
+    (void) endpoint;
+    (void) clusterId;
+    (void) attributeId;
+    (void) type;
+    (void) size;
+    (void) value;
+}
+
+chip::DeviceManager::CHIPDeviceManagerCallbacks & chip::Zephyr::App::GetDeviceCallbacks()
+{
+    static DishwasherApp::DeviceCallbacks sDeviceCallbacks;
+    return sDeviceCallbacks;
+}


### PR DESCRIPTION
### Summary
- Add `examples/dishwasher-app/silabs/zephyr/` scaffold: CMakeLists, Kconfig, README, board/soc overlays, and stub AppTask / DeviceCallbacks
- Include fixed SiWx917 flash partition overlays aligned with the lighting app
### Related issues
N/A
### Testing
- `west build` discovers the dishwasher Zephyr target
- Stub app builds for SiWx917
