### PR TITLE
[app] Expose current SubjectDescriptor to external attribute reads

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -16,6 +16,7 @@
  */
 #include <app/util/attribute-storage.h>
 
+#include <access/SubjectDescriptor.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandlerInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
@@ -86,6 +87,8 @@ static bool emberAfEndpointIsEnabled(EndpointId endpoint);
 static void emberAfIncreaseDataVersion(const chip::app::ConcreteClusterPath & aConcreteClusterPath);
 
 namespace {
+
+const Access::SubjectDescriptor * gCurrentSubjectDescriptor = nullptr;
 
 uint16_t emberEndpointCount = 0;
 
@@ -1543,6 +1546,16 @@ EndpointComposition GetCompositionForEndpointIndex(uint16_t endpointIndex)
         return EndpointComposition::kFullFamily;
     }
     return EndpointComposition::kTree;
+}
+
+const Access::SubjectDescriptor * GetCurrentSubjectDescriptor()
+{
+    return gCurrentSubjectDescriptor;
+}
+
+void SetCurrentSubjectDescriptor(const Access::SubjectDescriptor * subjectDescriptor)
+{
+    gCurrentSubjectDescriptor = subjectDescriptor;
 }
 
 } // namespace app

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -24,6 +24,12 @@
 #include <app/util/endpoint-config-defines.h>
 #include <lib/support/CodeUtils.h>
 
+namespace chip {
+namespace Access {
+struct SubjectDescriptor;
+} // namespace Access
+} // namespace chip
+
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-objects.h>
 
@@ -441,6 +447,32 @@ enum class EndpointComposition : uint8_t
  * @brief Returns the composition for a given endpoint index
  */
 EndpointComposition GetCompositionForEndpointIndex(uint16_t index);
+
+/**
+ * @brief Gets the SubjectDescriptor associated with the current attribute read.
+ *
+ * This can be used by external attribute read callbacks to identify the
+ * subject associated with the current read request.
+ *
+ * The returned pointer is only valid for the duration of the current
+ * synchronous attribute read and must not be retained after the callback
+ * returns.
+ *
+ * @return A pointer to the current SubjectDescriptor, or nullptr if no
+ *         attribute read is currently being processed.
+ */
+const Access::SubjectDescriptor * GetCurrentSubjectDescriptor();
+
+/**
+ * @brief Sets the SubjectDescriptor associated with the current attribute read.
+ *
+ * This is an internal API used by the data model provider while processing
+ * an attribute read.
+ *
+ * @param[in] subjectDescriptor The SubjectDescriptor associated with the
+ *                              current attribute read.
+ */
+void SetCurrentSubjectDescriptor(const Access::SubjectDescriptor * subjectDescriptor);
 
 } // namespace app
 } // namespace chip

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -65,6 +65,7 @@ namespace {
 unsigned metadataStructureGeneration = 0;
 DataVersion dataVersion              = 0;
 const MockNodeConfig * mockConfig    = nullptr;
+const Access::SubjectDescriptor * gCurrentSubjectDescriptor = nullptr;
 
 const MockNodeConfig & DefaultMockNodeConfig()
 {
@@ -262,6 +263,16 @@ CHIP_ERROR emberAfGetEndpointUniqueIdForEndPoint(EndpointId endpoint, MutableCha
 
 namespace chip {
 namespace app {
+
+const Access::SubjectDescriptor * GetCurrentSubjectDescriptor()
+{
+    return gCurrentSubjectDescriptor;
+}
+
+void SetCurrentSubjectDescriptor(const Access::SubjectDescriptor * subjectDescriptor)
+{
+    gCurrentSubjectDescriptor = subjectDescriptor;
+}
 
 EndpointComposition GetCompositionForEndpointIndex(uint16_t endpointIndex)
 {

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -62,9 +62,9 @@ using namespace Clusters::Globals::Attributes;
 
 namespace {
 
-unsigned metadataStructureGeneration = 0;
-DataVersion dataVersion              = 0;
-const MockNodeConfig * mockConfig    = nullptr;
+unsigned metadataStructureGeneration                        = 0;
+DataVersion dataVersion                                     = 0;
+const MockNodeConfig * mockConfig                           = nullptr;
 const Access::SubjectDescriptor * gCurrentSubjectDescriptor = nullptr;
 
 const MockNodeConfig & DefaultMockNodeConfig()

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
@@ -127,9 +127,19 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
     record.endpoint                            = request.path.mEndpointId;
     record.clusterId                           = request.path.mClusterId;
     record.attributeId                         = request.path.mAttributeId;
+
+    // Preserve the SubjectDescriptor while reading through the legacy Ember
+    // attribute storage path so external attribute read callbacks can identify
+    // the controller associated with the current read.
+    const Access::SubjectDescriptor * previousSubjectDescriptor =
+    GetCurrentSubjectDescriptor();
+    SetCurrentSubjectDescriptor(&request.subjectDescriptor);
+
     Protocols::InteractionModel::Status status = emAfReadOrWriteAttribute(
         &record, &attributeMetadata, gEmberAttributeIOBufferSpan.data(), static_cast<uint16_t>(gEmberAttributeIOBufferSpan.size()),
         /* write = */ false);
+
+    SetCurrentSubjectDescriptor(previousSubjectDescriptor);
 
     if (status != Protocols::InteractionModel::Status::Success)
     {

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
@@ -124,15 +124,14 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
 
     // At this point, we have to use ember directly to read the data.
     EmberAfAttributeSearchRecord record;
-    record.endpoint                            = request.path.mEndpointId;
-    record.clusterId                           = request.path.mClusterId;
-    record.attributeId                         = request.path.mAttributeId;
+    record.endpoint    = request.path.mEndpointId;
+    record.clusterId   = request.path.mClusterId;
+    record.attributeId = request.path.mAttributeId;
 
     // Preserve the SubjectDescriptor while reading through the legacy Ember
     // attribute storage path so external attribute read callbacks can identify
     // the controller associated with the current read.
-    const Access::SubjectDescriptor * previousSubjectDescriptor =
-    GetCurrentSubjectDescriptor();
+    const Access::SubjectDescriptor * previousSubjectDescriptor = GetCurrentSubjectDescriptor();
     SetCurrentSubjectDescriptor(&request.subjectDescriptor);
 
     Protocols::InteractionModel::Status status = emAfReadOrWriteAttribute(


### PR DESCRIPTION
Expose the `SubjectDescriptor` associated with the current attribute read to external attribute read callbacks.

Preserve and restore the previous `SubjectDescriptor` so nested attribute reads retain the correct read context.

### Summary

`emberAfExternalAttributeReadCallback()` currently has no access to the `SubjectDescriptor` associated with the attribute read request.

The `SubjectDescriptor` is available in `ReadAttributeRequest` at the `CodegenDataModelProvider` level, but it is not propagated when the request falls through to the legacy Ember attribute storage path.

This change exposes the current `SubjectDescriptor` to external attribute read callbacks without changing the existing `emberAfExternalAttributeReadCallback()` API.

The `SubjectDescriptor` is temporarily associated with the current synchronous attribute read while `emAfReadOrWriteAttribute()` is being executed. The previous descriptor is restored when the read completes so that nested attribute reads retain their own context.

This allows applications to identify the requesting Matter controller/fabric from `emberAfExternalAttributeReadCallback()` and provide controller-specific attribute values when needed.

### Related issues

None.

### Testing

Manual testing:

* Verified that `emberAfExternalAttributeReadCallback()` can retrieve the `SubjectDescriptor` associated with the current attribute read.
* Verified direct attribute reads from different Matter controllers/fabrics.
* Verified Apple Home and SmartThings reads produce different Fabric/Subject information.
* Verified controller-specific `MeasurementUnit` values for the `CarbonMonoxideConcentrationMeasurement` cluster.
* Verified that the previous `SubjectDescriptor` is restored after the attribute read to preserve the correct context for nested reads.
