### PR TITLE
ZoneManagement add safe attribute migration code

### DIFF
--- a/scripts/attribute_persistence_provider_exclusions.txt
+++ b/scripts/attribute_persistence_provider_exclusions.txt
@@ -55,6 +55,10 @@ src/app/clusters/thread-network-directory-server/CodegenIntegration.cpp
 src/app/clusters/thread-network-directory-server/MigrateThreadNetworkDirectoryServerStorage.cpp
 src/app/clusters/thread-network-directory-server/MigrateThreadNetworkDirectoryServerStorage.h
 src/app/clusters/thread-network-directory-server/tests/TestThreadNetworkDirectoryCluster.cpp
+# ZoneManagement migration
+src/app/clusters/zone-management-server/CodegenIntegration.cpp
+src/app/clusters/zone-management-server/MigrateZoneManagementServerStorage.cpp
+src/app/clusters/zone-management-server/MigrateZoneManagementServerStorage.h
 
 # Cluster server implementations that currently use SafeAttributePersistenceProvider
 src/app/clusters/mode-base-server/mode-base-server.cpp

--- a/src/app/clusters/zone-management-server/BUILD.gn
+++ b/src/app/clusters/zone-management-server/BUILD.gn
@@ -37,6 +37,7 @@ source_set("zone-management-server") {
 
   public_deps = [
     "${chip_root}/src/app:interaction-model",
+    "${chip_root}/src/app/persistence:migration",
     "${chip_root}/src/app/server-cluster",
     "${chip_root}/zzz_generated/app-common/clusters/ZoneManagement",
   ]

--- a/src/app/clusters/zone-management-server/BUILD.gn
+++ b/src/app/clusters/zone-management-server/BUILD.gn
@@ -37,7 +37,6 @@ source_set("zone-management-server") {
 
   public_deps = [
     "${chip_root}/src/app:interaction-model",
-    "${chip_root}/src/app/persistence:migration",
     "${chip_root}/src/app/server-cluster",
     "${chip_root}/zzz_generated/app-common/clusters/ZoneManagement",
   ]

--- a/src/app/clusters/zone-management-server/CodegenIntegration.cpp
+++ b/src/app/clusters/zone-management-server/CodegenIntegration.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app/clusters/zone-management-server/CodegenIntegration.h>
+#include <app/clusters/zone-management-server/MigrateZoneManagementServerStorage.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/support/CodeUtils.h>
 
@@ -25,10 +26,25 @@ namespace app {
 namespace Clusters {
 namespace ZoneManagement {
 
+CHIP_ERROR CodegenZoneManagementCluster::Startup(ServerClusterContext & context)
+{
+    // Migrate attributes for this cluster from SafeAttribute to AttributePersistence.
+    // This is done at Startup time when the persistence providers are guaranteed to be available.
+    SafeAttributePersistenceProvider * srcProvider = GetSafeAttributePersistenceProvider();
+    AttributePersistenceProvider & dstProvider     = context.attributeStorage;
+
+    if (srcProvider != nullptr)
+    {
+        LogErrorOnFailure(ZoneManagement::MigrateZoneManagementServerStorage(mPath.mEndpointId, *srcProvider, dstProvider));
+    }
+
+    return ZoneManagementCluster::Startup(context);
+}
+
 ZoneMgmtServer::ZoneMgmtServer(Delegate & delegate, EndpointId endpointId, BitFlags<Feature> features, uint8_t maxUserDefinedZones,
                                uint8_t maxZones, uint8_t sensitivityMax, const TwoDCartesianVertexStruct & twoDCartesianMax) :
-    mEndpointId(endpointId),
-    mDelegate(delegate), mFeatures(features), mConfig({ maxUserDefinedZones, maxZones, sensitivityMax, twoDCartesianMax })
+    mEndpointId(endpointId), mDelegate(delegate), mFeatures(features),
+    mConfig({ maxUserDefinedZones, maxZones, sensitivityMax, twoDCartesianMax })
 {}
 
 ZoneMgmtServer::~ZoneMgmtServer()

--- a/src/app/clusters/zone-management-server/CodegenIntegration.cpp
+++ b/src/app/clusters/zone-management-server/CodegenIntegration.cpp
@@ -43,8 +43,8 @@ CHIP_ERROR CodegenZoneManagementCluster::Startup(ServerClusterContext & context)
 
 ZoneMgmtServer::ZoneMgmtServer(Delegate & delegate, EndpointId endpointId, BitFlags<Feature> features, uint8_t maxUserDefinedZones,
                                uint8_t maxZones, uint8_t sensitivityMax, const TwoDCartesianVertexStruct & twoDCartesianMax) :
-    mEndpointId(endpointId), mDelegate(delegate), mFeatures(features),
-    mConfig({ maxUserDefinedZones, maxZones, sensitivityMax, twoDCartesianMax })
+    mEndpointId(endpointId),
+    mDelegate(delegate), mFeatures(features), mConfig({ maxUserDefinedZones, maxZones, sensitivityMax, twoDCartesianMax })
 {}
 
 ZoneMgmtServer::~ZoneMgmtServer()

--- a/src/app/clusters/zone-management-server/CodegenIntegration.h
+++ b/src/app/clusters/zone-management-server/CodegenIntegration.h
@@ -28,6 +28,18 @@ namespace app {
 namespace Clusters {
 namespace ZoneManagement {
 
+/**
+ * A ZoneManagementCluster subclass that performs storage migration during Startup.
+ * This ensures the persistence providers are available when migration runs.
+ */
+class CodegenZoneManagementCluster : public ZoneManagementCluster
+{
+public:
+    using ZoneManagementCluster::ZoneManagementCluster;
+
+    CHIP_ERROR Startup(ServerClusterContext & context) override;
+};
+
 class ZoneMgmtServer
 {
 public:
@@ -94,8 +106,8 @@ private:
     const EndpointId mEndpointId;
     Delegate & mDelegate;
     const BitFlags<Feature> mFeatures;
-    const ZoneManagementCluster::Context::Config mConfig;
-    chip::app::LazyRegisteredServerCluster<ZoneManagementCluster> mCluster;
+    const CodegenZoneManagementCluster::Context::Config mConfig;
+    chip::app::LazyRegisteredServerCluster<CodegenZoneManagementCluster> mCluster;
     std::optional<uint8_t> mPendingAppSensitivity;
 };
 

--- a/src/app/clusters/zone-management-server/MigrateZoneManagementServerStorage.cpp
+++ b/src/app/clusters/zone-management-server/MigrateZoneManagementServerStorage.cpp
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/zone-management-server/MigrateZoneManagementServerStorage.h>
+#include <clusters/ZoneManagement/Attributes.h>
+
+namespace chip::app::Clusters::ZoneManagement {
+
+CHIP_ERROR MigrateZoneManagementServerStorage(EndpointId endpointId, SafeAttributePersistenceProvider & safeProvider,
+                                              AttributePersistenceProvider & dstProvider)
+{
+    static constexpr AttrMigrationData attributesToUpdate[] = {
+        { Attributes::Sensitivity::Id, sizeof(uint8_t), true /* isScalar */ },
+    };
+    // We need to provide a buffer with enough space for the attributes that will be migrated.
+    static constexpr size_t kBufferSize = MaxAttrMigrationValueSize(attributesToUpdate);
+    static_assert(kBufferSize > 0, "All migration attributes have zero valueSize");
+    uint8_t attributeBuffer[kBufferSize] = {};
+    MutableByteSpan buffer(attributeBuffer);
+    return MigrateFromSafeToAttributePersistenceProvider(safeProvider, dstProvider, { endpointId, ZoneManagement::Id },
+                                                         Span(attributesToUpdate), buffer);
+}
+
+} // namespace chip::app::Clusters::ZoneManagement

--- a/src/app/clusters/zone-management-server/MigrateZoneManagementServerStorage.h
+++ b/src/app/clusters/zone-management-server/MigrateZoneManagementServerStorage.h
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/zone-management-server/ZoneManagementCluster.h>
+#include <app/persistence/AttributePersistenceMigration.h>
+
+namespace chip::app::Clusters::ZoneManagement {
+
+CHIP_ERROR MigrateZoneManagementServerStorage(EndpointId endpointId, SafeAttributePersistenceProvider & safeProvider,
+                                              AttributePersistenceProvider & dstProvider);
+
+} // namespace chip::app::Clusters::ZoneManagement

--- a/src/app/clusters/zone-management-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/zone-management-server/app_config_dependent_sources.cmake
@@ -18,5 +18,7 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
     "${CLUSTER_DIR}/CodegenIntegration.h"
+    "${CLUSTER_DIR}/MigrateZoneManagementServerStorage.cpp"
+    "${CLUSTER_DIR}/MigrateZoneManagementServerStorage.h"
     "${CLUSTER_DIR}/zone-management-server.h"
 )

--- a/src/app/clusters/zone-management-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/zone-management-server/app_config_dependent_sources.gni
@@ -14,5 +14,7 @@
 app_config_dependent_sources = [
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
+  "MigrateZoneManagementServerStorage.cpp",
+  "MigrateZoneManagementServerStorage.h",
   "zone-management-server.h",
 ]

--- a/src/app/clusters/zone-management-server/tests/BUILD.gn
+++ b/src/app/clusters/zone-management-server/tests/BUILD.gn
@@ -30,6 +30,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/app/clusters/zone-management-server",
+    "${chip_root}/src/app/persistence:migration",
     "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/app/server-cluster/testing:testing",
     "${chip_root}/src/lib/support",
@@ -54,6 +55,7 @@ chip_test_suite("tests-backwards-compatibility") {
 
   public_deps = [
     "${chip_root}/src/app/clusters/zone-management-server",
+    "${chip_root}/src/app/persistence:migration",
     "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/app/server-cluster/testing:testing",
     "${chip_root}/src/data-model-providers/codegen/tests:mock_model",


### PR DESCRIPTION
#### Summary

ZoneManagement add safe attribute migration code.

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/73757

#### Testing

Tested running chip-all-clusters-app and matter-repl.
