### PR TITLE
[Silabs] : Fix EM4 conditions

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -407,12 +407,14 @@ void OnEM4Trigger(uint32_t duration)
     BURTC_CounterReset();
     BURTC_CompareSet(0, duration);
 
-    BURTC_IntEnable(BURTC_IEN_COMP); // compare match
-    NVIC_EnableIRQ(BURTC_IRQn);
     BURTC_Enable(true);
     EMU_EM4Init_TypeDef em4Init = EMU_EM4INIT_DEFAULT;
     EMU_EM4Init(&em4Init);
     BURTC_CounterReset();
+
+    BURTC_IntClear(BURTC_IF_COMP);
+    BURTC_IntEnable(BURTC_IEN_COMP); // compare match
+    NVIC_EnableIRQ(BURTC_IRQn);
     EMU_EnterEM4();
 }
 

--- a/examples/platform/silabs/efr32/project_include/OpenThreadConfig.h
+++ b/examples/platform/silabs/efr32/project_include/OpenThreadConfig.h
@@ -45,6 +45,12 @@
 // Timeout after 2 missed checkin or 4 mins if sleep interval is too short.
 #define OPENTHREAD_CONFIG_MLE_CHILD_TIMEOUT_DEFAULT ((SL_MLE_TIMEOUT_s < 120) ? 240 : ((SL_MLE_TIMEOUT_s * 2) + 1))
 
+// Keep child-supervision check aligned with LIT idle so it cannot
+// wake the device mid-idle before the EM4 / slow-poll window.
+#ifndef OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT
+#define OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT SL_IDLE_MODE_DURATION_S
+#endif
+
 #if defined(SL_CSL_ENABLE) && SL_CSL_ENABLE || SL_CONFIG_OPENTHREAD_LIB
 
 #define OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE 1

--- a/examples/platform/silabs/efr32/project_include/OpenThreadConfig.h
+++ b/examples/platform/silabs/efr32/project_include/OpenThreadConfig.h
@@ -39,17 +39,9 @@
 #ifdef SL_ICD_ENABLED
 #define OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE 0
 
-// In seconds
-#define SL_MLE_TIMEOUT_s (SL_TRANSPORT_IDLE_INTERVAL / 1000)
-
-// Timeout after 2 missed checkin or 4 mins if sleep interval is too short.
-#define OPENTHREAD_CONFIG_MLE_CHILD_TIMEOUT_DEFAULT ((SL_MLE_TIMEOUT_s < 120) ? 240 : ((SL_MLE_TIMEOUT_s * 2) + 1))
-
-// Keep child-supervision check aligned with LIT idle so it cannot
-// wake the device mid-idle before the EM4 / slow-poll window.
-#ifndef OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT
-#define OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT SL_IDLE_MODE_DURATION_S
-#endif
+// Timeout after 2 missed check-ins, or 4 mins if sleep interval is too short.
+#define OPENTHREAD_CONFIG_MLE_CHILD_TIMEOUT_DEFAULT                                                                \
+    (((SL_TRANSPORT_IDLE_INTERVAL / 1000) < 120) ? 240 : (((SL_TRANSPORT_IDLE_INTERVAL / 1000) * 2) + 1))
 
 #if defined(SL_CSL_ENABLE) && SL_CSL_ENABLE || SL_CONFIG_OPENTHREAD_LIB
 
@@ -62,6 +54,12 @@
 #define SL_OPENTHREAD_CSL_TX_UNCERTAINTY 200
 
 #endif // SL_CSL_ENABLE || SL_CONFIG_OPENTHREAD_LIB
+
+// Keep child-supervision check aligned with LIT idle so it cannot wake the device
+// mid-idle before the EM4 / slow-poll window.
+#ifndef OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT
+#define OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT SL_IDLE_MODE_DURATION_S
+#endif
 
 #endif // SL_ICD_ENABLED
 

--- a/examples/platform/silabs/efr32/project_include/OpenThreadConfig.h
+++ b/examples/platform/silabs/efr32/project_include/OpenThreadConfig.h
@@ -40,7 +40,7 @@
 #define OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE 0
 
 // Timeout after 2 missed check-ins, or 4 mins if sleep interval is too short.
-#define OPENTHREAD_CONFIG_MLE_CHILD_TIMEOUT_DEFAULT                                                                \
+#define OPENTHREAD_CONFIG_MLE_CHILD_TIMEOUT_DEFAULT                                                                                \
     (((SL_TRANSPORT_IDLE_INTERVAL / 1000) < 120) ? 240 : (((SL_TRANSPORT_IDLE_INTERVAL / 1000) * 2) + 1))
 
 #if defined(SL_CSL_ENABLE) && SL_CSL_ENABLE || SL_CONFIG_OPENTHREAD_LIB


### PR DESCRIPTION
### Summary
Issue:
Device not able to reach EM4 caused by 
1. OT child trying to connect to parent every OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT = 190s  :: Fixed to use SL_IDLE_MODE_DURATION_S instead of the default
2. BURTC interrupts were enabled too early, leaving a race window where OT/FreeRTOS ISRs could fire while EM4 entry was incomplete → fault loop at ~1 mA.  :: moved the interrupt just before we enter EM4

### Related issues

N/A

### Testing
Tested lit-icd app getting into EM4
Build using

./scripts/examples/gn_silabs_example.sh \
  ./examples/lit-icd-app/silabs/ \
  ./out/lit-icd-em4 \
  BRD4187C \
  --low-power \
  sl_em4_sleep=true

commissioning using --icd-registration 1

Observe EM4 numbers about 300-500nA