### PR TITLE
add su-2.2 to nightly run

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -221,7 +221,7 @@ jobs:
                 # Regex filter by TC SU we think 45 minutes is more than engough for this task
                 # Each on one run to avoid all the jobs fail if one fails
                 # Add slow tests here as needed using the filter, individually or by group.
-                filter: ["", "TC_SU_2_5", "TC_SU_2_7", "!TC_SU"]
+                filter: ["", "TC_SU_2_2", "TC_SU_2_5", "TC_SU_2_7", "!TC_SU"]
         env:
             BUILD_VARIANT: ipv6only-no-ble-no-wifi-asan
             DISABLE_CCACHE: ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_ccache == 'true') && 'true' || (contains(github.event.head_commit.message, '[no-ccache]') && 'true') || 'false' }}


### PR DESCRIPTION
#### Summary

Adds `TC_SU_2_2.py` to the nightly test run.

##### Problem

-   The nightly REPL test job runs Software Update tests via a regex-filtered
    matrix (`""`, `TC_SU_2_5`, `TC_SU_2_7`, `!TC_SU`). Since the last bucket
    excludes every test matching `TC_SU`, and `TC_SU_2_2` had no dedicated
    bucket, it was never executed by the nightly workflow.

##### Solution

-   Added `TC_SU_2_2` as its own matrix filter entry in
    `.github/workflows/nightly.yaml`, alongside the existing `TC_SU_2_5` and
    `TC_SU_2_7` entries, so it runs as an individual job within the 45-minute
    timeout.

#### Testing

-   N/A — workflow-only change; verified by inspecting
    `execute_python_tests.py`'s regex filtering and confirming the new matrix
    entry follows the same pattern as the existing `TC_SU_2_5`/`TC_SU_2_7`
    buckets.
