### PR TITLE
Darwin: fix Q-quality cache behavior

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -415,6 +415,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 #ifdef DEBUG
     NSUInteger _unitTestAttributesReportedSinceLastCheck;
     NSUInteger _unitTestEventsReportedSinceLastCheck;
+    NSUInteger _unitTestReadThroughsSinceLastCheck;
 #endif
 
     // _deviceCachePrimed is true if we have the data that comes from an initial
@@ -3324,6 +3325,15 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     _unitTestEventsReportedSinceLastCheck = 0;
     return eventsReportedSinceLastCheck;
 }
+
+- (NSUInteger)unitTestReadThroughsSinceLastCheck
+{
+    std::lock_guard lock(_lock);
+
+    NSUInteger readThroughsSinceLastCheck = _unitTestReadThroughsSinceLastCheck;
+    _unitTestReadThroughsSinceLastCheck = 0;
+    return readThroughsSinceLastCheck;
+}
 #endif
 
 #pragma mark Device Interactions
@@ -3454,6 +3464,159 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     }
 }
 
+// Helper function to determine whether an attribute has "Quieter Reporting" quality (Q), which indicates that
+// the server only reports it under the conditions named in its own description, so a working subscription is
+// no guarantee that the cached value is current
+//   * TODO: xml+codegen version to replace this hardcoded list.  Unlike Changes Omitted, Q is not expressed
+//     in the data model XML yet, so that needs a spec-side change first.
+// Omitted: ProximityRanging's RangingConstraints (0x0007), which has no generated attribute ID in this SDK.
+static BOOL AttributeHasQuieterReportingQuality(MTRAttributePath * attributePath)
+{
+    switch (attributePath.cluster.unsignedLongValue) {
+    case MTRClusterIDTypeClosureControlID:
+        return attributePath.attribute.unsignedLongValue == MTRAttributeIDTypeClusterClosureControlAttributeCountdownTimeID;
+    case MTRClusterIDTypeClosureDimensionID:
+        return attributePath.attribute.unsignedLongValue == MTRAttributeIDTypeClusterClosureDimensionAttributeCurrentStateID;
+    case MTRClusterIDTypeColorControlID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterColorControlAttributeCurrentHueID:
+        case MTRAttributeIDTypeClusterColorControlAttributeCurrentSaturationID:
+        case MTRAttributeIDTypeClusterColorControlAttributeRemainingTimeID:
+        case MTRAttributeIDTypeClusterColorControlAttributeCurrentXID:
+        case MTRAttributeIDTypeClusterColorControlAttributeCurrentYID:
+        case MTRAttributeIDTypeClusterColorControlAttributeColorTemperatureMiredsID:
+        case MTRAttributeIDTypeClusterColorControlAttributeEnhancedCurrentHueID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeDeviceEnergyManagementID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterDeviceEnergyManagementAttributePowerAdjustmentCapabilityID:
+        case MTRAttributeIDTypeClusterDeviceEnergyManagementAttributeForecastID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeElectricalEnergyMeasurementID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterElectricalEnergyMeasurementAttributeCumulativeEnergyImportedID:
+        case MTRAttributeIDTypeClusterElectricalEnergyMeasurementAttributeCumulativeEnergyExportedID:
+        case MTRAttributeIDTypeClusterElectricalEnergyMeasurementAttributePeriodicEnergyImportedID:
+        case MTRAttributeIDTypeClusterElectricalEnergyMeasurementAttributePeriodicEnergyExportedID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeElectricalPowerMeasurementID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeRangesID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeVoltageID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeActiveCurrentID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeReactiveCurrentID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeApparentCurrentID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeActivePowerID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeReactivePowerID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeApparentPowerID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeRMSVoltageID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeRMSCurrentID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeRMSPowerID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeFrequencyID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeHarmonicCurrentsID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeHarmonicPhasesID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributePowerFactorID:
+        case MTRAttributeIDTypeClusterElectricalPowerMeasurementAttributeNeutralCurrentID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeEnergyEVSEID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterEnergyEVSEAttributeSessionDurationID:
+        case MTRAttributeIDTypeClusterEnergyEVSEAttributeSessionEnergyChargedID:
+        case MTRAttributeIDTypeClusterEnergyEVSEAttributeSessionEnergyDischargedID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeFanControlID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterFanControlAttributePercentCurrentID:
+        case MTRAttributeIDTypeClusterFanControlAttributeSpeedCurrentID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeIdentifyID:
+        return attributePath.attribute.unsignedLongValue == MTRAttributeIDTypeClusterIdentifyAttributeIdentifyTimeID;
+    case MTRClusterIDTypeLevelControlID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterLevelControlAttributeCurrentLevelID:
+        case MTRAttributeIDTypeClusterLevelControlAttributeRemainingTimeID:
+        case MTRAttributeIDTypeClusterLevelControlAttributeCurrentFrequencyID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeMediaFileManagementID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterMediaFileManagementAttributeAvailableStorageID:
+        case MTRAttributeIDTypeClusterMediaFileManagementAttributeAvailableFilesID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeNetworkIdentityManagementID:
+        return attributePath.attribute.unsignedLongValue == MTRAttributeIDTypeClusterNetworkIdentityManagementAttributeClientsID;
+    case MTRClusterIDTypeOnOffID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterOnOffAttributeOnTimeID:
+        case MTRAttributeIDTypeClusterOnOffAttributeOffWaitTimeID:
+            return YES;
+        default:
+            return NO;
+        }
+    // CountdownTime is defined by the base Operational State cluster and inherited by each derived
+    // cluster at the same attribute ID.
+    case MTRClusterIDTypeOperationalStateID:
+        return attributePath.attribute.unsignedLongValue == MTRAttributeIDTypeClusterOperationalStateAttributeCountdownTimeID;
+    case MTRClusterIDTypeOvenCavityOperationalStateID:
+        return attributePath.attribute.unsignedLongValue == MTRAttributeIDTypeClusterOvenCavityOperationalStateAttributeCountdownTimeID;
+    case MTRClusterIDTypeRVCOperationalStateID:
+        return attributePath.attribute.unsignedLongValue == MTRAttributeIDTypeClusterRVCOperationalStateAttributeCountdownTimeID;
+    case MTRClusterIDTypePowerSourceID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterPowerSourceAttributeBatPercentRemainingID:
+        case MTRAttributeIDTypeClusterPowerSourceAttributeBatTimeRemainingID:
+        case MTRAttributeIDTypeClusterPowerSourceAttributeBatTimeToFullChargeID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypePumpConfigurationAndControlID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeCapacityID:
+        case MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributeSpeedID:
+        case MTRAttributeIDTypeClusterPumpConfigurationAndControlAttributePowerID:
+            return YES;
+        default:
+            return NO;
+        }
+    case MTRClusterIDTypeServiceAreaID:
+        return attributePath.attribute.unsignedLongValue == MTRAttributeIDTypeClusterServiceAreaAttributeEstimatedEndTimeID;
+    case MTRClusterIDTypeValveConfigurationAndControlID:
+        switch (attributePath.attribute.unsignedLongValue) {
+        case MTRAttributeIDTypeClusterValveConfigurationAndControlAttributeRemainingDurationID:
+        case MTRAttributeIDTypeClusterValveConfigurationAndControlAttributeCurrentLevelID:
+            return YES;
+        default:
+            return NO;
+        }
+    default:
+        return NO;
+    }
+}
+
 - (NSDictionary<NSString *, id> * _Nullable)readAttributeWithEndpointID:(NSNumber *)endpointID
                                                               clusterID:(NSNumber *)clusterID
                                                             attributeID:(NSNumber *)attributeID
@@ -3483,6 +3646,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     // 2. The attribute has the Changes Omitted quality, so we won't get reports for it.
     // 3. The attribute is not in the spec, and the read params asks to assume
     //    an unknown attribute has the Changes Omitted quality.
+    // 4. The attribute has the Quieter Reporting quality, so we won't get reports for all its changes.
     //
     // But all this only happens if this device is not suspended.  If it's suspended, read-throughs will fail
     // anyway, so we should not bother trying.
@@ -3491,7 +3655,14 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         std::lock_guard lock(_lock);
         readThroughsAllowed = !self.suspended;
     }
-    if (readThroughsAllowed && (![self _subscriptionAbleToReport] || hasChangesOmittedQuality)) {
+    BOOL hasQuieterReportingQuality = attributeIsSpecified && AttributeHasQuieterReportingQuality(attributePath);
+    if (readThroughsAllowed && (![self _subscriptionAbleToReport] || hasChangesOmittedQuality || hasQuieterReportingQuality)) {
+#ifdef DEBUG
+        {
+            std::lock_guard lock(_lock);
+            _unitTestReadThroughsSinceLastCheck++;
+        }
+#endif
         // Read requests container will be a mutable array of items, each being an array containing:
         //   [attribute request path, params]
         // Batching handler should only coalesce when params are equal.

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6399,6 +6399,174 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTAssertGreaterThan(values.count, 100);
 }
 
+- (void)test051_QuieterReportingAttributeReadsGoToTheDevice
+{
+    // Q-quality attributes are deliberately not reported on change, so a live subscription is
+    // precisely when the cached value goes stale and a read has to reach the device.  The counter and
+    // the report are separate assertions: a read-through can be coalesced into a duplicate, or fail.
+
+    __auto_type * endpointID = @(1);
+    __auto_type * clusterID = @(MTRClusterIDTypeOperationalStateID);
+    __auto_type * countdownID = @(MTRAttributeIDTypeClusterOperationalStateAttributeCountdownTimeID);
+
+    __auto_type * device = [MTRDevice deviceWithNodeID:@(kDeviceId1) controller:sController];
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+
+    // Otherwise a wire read returning the already-cached value is filtered and proves nothing.
+    delegate.forceAttributeReportsIfMatchingCache = YES;
+
+    dispatch_queue_t delegateQueue = dispatch_queue_create("qread.test", DISPATCH_QUEUE_SERIAL);
+
+    XCTestExpectation * primed = [self expectationWithDescription:@"subscription primed"];
+    __block BOOL alreadyPrimed = NO;
+    delegate.onReportEnd = ^{
+        if (!alreadyPrimed) {
+            alreadyPrimed = YES;
+            [primed fulfill];
+        }
+    };
+
+    // __block: reassigned per phase below, so the handler must see the current one, not the initial nil.
+    __block XCTestExpectation * countdownReport = nil;
+    delegate.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * reports) {
+        for (NSDictionary<NSString *, id> * report in reports) {
+            MTRAttributePath * path = report[MTRAttributePathKey];
+            if ([path.endpoint isEqual:endpointID] && [path.cluster isEqual:clusterID] &&
+                [path.attribute isEqual:countdownID]) {
+                [countdownReport fulfill];
+            }
+        }
+    };
+
+    [device setDelegate:delegate queue:delegateQueue];
+    [self waitForExpectations:@[ primed ] timeout:60];
+
+    // Start a cycle so CountdownTime becomes non-null and advances.  Waits for the report Start itself
+    // produces, not just the command completion: a state change IS reportable for this attribute, and that
+    // report would otherwise land inside the inverted window below and fail it for the wrong reason.
+    countdownReport = [self expectationWithDescription:@"CountdownTime report caused by Start"];
+
+    XCTestExpectation * started = [self expectationWithDescription:@"Start command completed"];
+    [device invokeCommandWithEndpointID:endpointID
+                              clusterID:clusterID
+                              commandID:@(MTRCommandIDTypeClusterOperationalStateCommandStartID)
+                          commandFields:nil
+                         expectedValues:nil
+                  expectedValueInterval:nil
+                                  queue:delegateQueue
+                             completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
+                                 NSError * _Nullable error) {
+                                 XCTAssertNil(error);
+                                 [started fulfill];
+                             }];
+    [self waitForExpectations:@[ started, countdownReport ] timeout:10];
+
+    // Let the accessory tick without reporting.  Kept short: the example app's cycle is only
+    // kExampleCountDown seconds long and everything below has to happen inside it.
+    countdownReport = [self expectationWithDescription:@"no countdown report while merely ticking"];
+    countdownReport.inverted = YES;
+    [self waitForExpectations:@[ countdownReport ] timeout:5];
+
+    // Baseline the counter immediately before the read under test, so nothing above is counted.
+    (void) [device unitTestReadThroughsSinceLastCheck];
+
+    countdownReport = [self expectationWithDescription:@"report produced by the read-through"];
+
+    __auto_type * cachedValue = [device readAttributeWithEndpointID:endpointID
+                                                          clusterID:clusterID
+                                                        attributeID:countdownID
+                                                             params:nil];
+    XCTAssertNotNil(cachedValue, @"CountdownTime should be in the cache from the priming report");
+
+    XCTAssertEqual([device unitTestReadThroughsSinceLastCheck], 1UL,
+        @"Reading a Q-quality attribute while subscribed must go to the device");
+
+    [self waitForExpectations:@[ countdownReport ] timeout:10];
+
+    XCTestExpectation * stopped = [self expectationWithDescription:@"Stop command completed"];
+    [device invokeCommandWithEndpointID:endpointID
+                              clusterID:clusterID
+                              commandID:@(MTRCommandIDTypeClusterOperationalStateCommandStopID)
+                          commandFields:nil
+                         expectedValues:nil
+                  expectedValueInterval:nil
+                                  queue:delegateQueue
+                             completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
+                                 NSError * _Nullable error) {
+                                 [stopped fulfill];
+                             }];
+    [self waitForExpectations:@[ stopped ] timeout:10];
+
+    [device removeDelegate:delegate];
+}
+
+- (void)test051b_NonQuieterReportingAttributeReadsStillUseTheCache
+{
+    // The negative control for test051: an ordinary attribute is reported on every change, so its cached
+    // value is trustworthy while subscribed and a read must not reach the wire.  Asserting "no reports"
+    // alone would pass either way, since the unchanged-value filter hides a wire read's identical result.
+
+    __auto_type * device = [MTRDevice deviceWithNodeID:@(kDeviceId1) controller:sController];
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+
+    // Without this the unchanged-value filter would hide a wire read's result.
+    delegate.forceAttributeReportsIfMatchingCache = YES;
+
+    XCTestExpectation * primed = [self expectationWithDescription:@"subscription primed"];
+    __block BOOL alreadyPrimed = NO;
+    delegate.onReportEnd = ^{
+        if (!alreadyPrimed) {
+            alreadyPrimed = YES;
+            [primed fulfill];
+        }
+    };
+
+    __auto_type * endpointID = @(1);
+    __auto_type * clusterID = @(MTRClusterIDTypeOnOffID);
+    __auto_type * onOffID = @(MTRAttributeIDTypeClusterOnOffAttributeOnOffID);
+
+    __block BOOL sawOnOffReport = NO;
+    __block BOOL countingReports = NO;
+    delegate.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * reports) {
+        if (!countingReports) {
+            return;
+        }
+        for (NSDictionary<NSString *, id> * report in reports) {
+            MTRAttributePath * path = report[MTRAttributePathKey];
+            if ([path.endpoint isEqual:endpointID] && [path.cluster isEqual:clusterID] &&
+                [path.attribute isEqual:onOffID]) {
+                sawOnOffReport = YES;
+            }
+        }
+    };
+
+    dispatch_queue_t delegateQueue = dispatch_queue_create("nonq.read.test", DISPATCH_QUEUE_SERIAL);
+    [device setDelegate:delegate queue:delegateQueue];
+    [self waitForExpectations:@[ primed ] timeout:60];
+
+    // Baseline: ignore anything the priming report produced.
+    (void) [device unitTestReadThroughsSinceLastCheck];
+    countingReports = YES;
+
+    for (int i = 0; i < 5; i++) {
+        __auto_type * value = [device readAttributeWithEndpointID:endpointID
+                                                        clusterID:clusterID
+                                                      attributeID:onOffID
+                                                           params:nil];
+        XCTAssertNotNil(value);
+    }
+
+    XCTAssertEqual([device unitTestReadThroughsSinceLastCheck], 0UL,
+        @"Reads of a normally-reported attribute must not go to the device while subscribed");
+
+    [NSThread sleepForTimeInterval:3.0];
+    XCTAssertFalse(sawOnOffReport,
+        @"A cache-served read must not produce an attribute report");
+
+    countingReports = NO;
+    [device removeDelegate:delegate];
+}
+
 @end
 
 @interface MTRDeviceEncoderTests : XCTestCase

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6493,6 +6493,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                   queue:delegateQueue
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
                                  NSError * _Nullable error) {
+                                 XCTAssertNil(error);
                                  [stopped fulfill];
                              }];
     [self waitForExpectations:@[ stopped ] timeout:10];
@@ -6546,7 +6547,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Baseline: ignore anything the priming report produced.
     (void) [device unitTestReadThroughsSinceLastCheck];
-    countingReports = YES;
+    // Both flags are touched on delegateQueue, so hand them across it rather than racing: an unseen
+    // write here would make the report assertion below pass for the wrong reason.
+    dispatch_sync(delegateQueue, ^{
+        countingReports = YES;
+    });
 
     for (int i = 0; i < 5; i++) {
         __auto_type * value = [device readAttributeWithEndpointID:endpointID
@@ -6560,7 +6565,12 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         @"Reads of a normally-reported attribute must not go to the device while subscribed");
 
     [NSThread sleepForTimeInterval:3.0];
-    XCTAssertFalse(sawOnOffReport,
+    // Draining delegateQueue also orders the flag's last write before this read.
+    __block BOOL sawReport = NO;
+    dispatch_sync(delegateQueue, ^{
+        sawReport = sawOnOffReport;
+    });
+    XCTAssertFalse(sawReport,
         @"A cache-served read must not produce an attribute report");
 
     countingReports = NO;

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -86,6 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unitTestInjectAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport fromSubscription:(BOOL)isFromSubscription;
 - (NSUInteger)unitTestAttributesReportedSinceLastCheck;
 - (NSUInteger)unitTestEventsReportedSinceLastCheck;
+- (NSUInteger)unitTestReadThroughsSinceLastCheck;
 - (void)unitTestClearClusterData;
 - (MTRInternalDeviceState)_getInternalState;
 - (void)unitTestSetReportToPersistenceDelayTime:(NSTimeInterval)reportToPersistenceDelayTime


### PR DESCRIPTION
### Summary
Q-quality values are not required to regularly update subscribers during predictable changes (i.e. `CountdownTime`'s normal procession of 1 second per second); allow read-throughs for those attributes for re-anchoring.

### Testing
- Added unit tests for Q-quality reads (specifically `CountdownTime` which is implemented in all-clusters app)