### PR TITLE
[ModeSelect] Remove StartUpMode workaround

### DIFF
--- a/src/app/clusters/mode-select-server/ModeSelectCluster.cpp
+++ b/src/app/clusters/mode-select-server/ModeSelectCluster.cpp
@@ -88,15 +88,6 @@ void ModeSelectCluster::ApplyStartupModeLogic()
             ConcreteAttributePath(mPath.mEndpointId, mPath.mClusterId, CurrentMode::Id), mCurrentMode));
     }
 
-    // TODO: remove this workaround once TC_MOD_1_2.py is updated to accept a null StartUpMode.
-    // StartUpMode is nullable per spec (null = no startup override), but TC_MOD_1_2 step 5 asserts
-    // isinstance(startup_mode, int). Until that test is fixed, default to CurrentMode on first boot.
-    // See https://github.com/project-chip/connectedhomeip/issues/73795
-    if (mOptionalAttributeSet.IsSet(StartUpMode::Id) && mStartUpMode.IsNull())
-    {
-        mStartUpMode.SetNonNull(mCurrentMode);
-    }
-
     if (!mStartUpMode.IsNull())
     {
         BootReasonType bootReason = BootReasonType::kUnspecified;

--- a/src/app/clusters/mode-select-server/tests/TestModeSelectCluster.cpp
+++ b/src/app/clusters/mode-select-server/tests/TestModeSelectCluster.cpp
@@ -235,7 +235,7 @@ TEST_F(TestModeSelectCluster, ReadCurrentMode)
     EXPECT_EQ(currentMode, 0u);
 }
 
-TEST_F(TestModeSelectCluster, ReadStartUpModeDefaultsToCurrentMode)
+TEST_F(TestModeSelectCluster, ReadStartUpModeDefaultsToNull)
 {
     optionalAttributeSet.Set<StartUpMode::Id>();
     ModeSelectCluster cluster(kRootEndpointId, mockDelegate, MakeConfig());
@@ -244,11 +244,7 @@ TEST_F(TestModeSelectCluster, ReadStartUpModeDefaultsToCurrentMode)
 
     DataModel::Nullable<uint8_t> startUpMode;
     ASSERT_EQ(tester.ReadAttribute(StartUpMode::Id, startUpMode), CHIP_NO_ERROR);
-    // Workaround: StartUpMode is initialized to CurrentMode when unset, so that existing
-    // certification tests (which assert StartUpMode is an integer) continue to pass.
-    // CurrentMode defaults to mode 0 (first supported mode in mock).
-    ASSERT_FALSE(startUpMode.IsNull());
-    EXPECT_EQ(startUpMode.Value(), static_cast<uint8_t>(0));
+    EXPECT_TRUE(startUpMode.IsNull());
 }
 
 TEST_F(TestModeSelectCluster, ReadOnModeDefaultNull)


### PR DESCRIPTION
### Summary
Removes StartUpMode workaround

### Related issues
https://github.com/project-chip/connectedhomeip/pull/73810
https://github.com/project-chip/connectedhomeip/issues/73795

### Testing
CI passing