### PR TITLE
Add SafeAttributeMigration logic to general BUILD for clusters

### DIFF
--- a/src/app/clusters/boolean-state-configuration-server/BUILD.gn
+++ b/src/app/clusters/boolean-state-configuration-server/BUILD.gn
@@ -18,9 +18,9 @@ source_set("boolean-state-configuration-server") {
   sources = [
     "BooleanStateConfigurationCluster.cpp",
     "BooleanStateConfigurationCluster.h",
-    "boolean-state-configuration-delegate.h",
     "MigrateBooleanStateConfigurationStorage.cpp",
     "MigrateBooleanStateConfigurationStorage.h",
+    "boolean-state-configuration-delegate.h",
   ]
 
   public_deps = [

--- a/src/app/clusters/boolean-state-configuration-server/BUILD.gn
+++ b/src/app/clusters/boolean-state-configuration-server/BUILD.gn
@@ -19,6 +19,8 @@ source_set("boolean-state-configuration-server") {
     "BooleanStateConfigurationCluster.cpp",
     "BooleanStateConfigurationCluster.h",
     "boolean-state-configuration-delegate.h",
+    "MigrateBooleanStateConfigurationStorage.cpp",
+    "MigrateBooleanStateConfigurationStorage.h",
   ]
 
   public_deps = [

--- a/src/app/clusters/boolean-state-configuration-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/boolean-state-configuration-server/app_config_dependent_sources.cmake
@@ -18,8 +18,6 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
     "${CLUSTER_DIR}/CodegenIntegration.h"
-    "${CLUSTER_DIR}/MigrateBooleanStateConfigurationStorage.cpp"
-    "${CLUSTER_DIR}/MigrateBooleanStateConfigurationStorage.h"
 )
 
 # These are the things that BUILD.gn dependencies would pull

--- a/src/app/clusters/boolean-state-configuration-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/boolean-state-configuration-server/app_config_dependent_sources.gni
@@ -16,7 +16,5 @@ app_config_dependent_sources = [
   "BooleanStateConfigurationTestEventTriggerHandler.h",
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
-  "MigrateBooleanStateConfigurationStorage.cpp",
-  "MigrateBooleanStateConfigurationStorage.h",
   "boolean-state-configuration-server.h",
 ]

--- a/src/app/clusters/chime-server/BUILD.gn
+++ b/src/app/clusters/chime-server/BUILD.gn
@@ -19,6 +19,8 @@ source_set("chime-server") {
   sources = [
     "ChimeCluster.cpp",
     "ChimeCluster.h",
+    "MigrateChimeServerStorage.cpp",
+    "MigrateChimeServerStorage.h",
   ]
 
   public_deps = [

--- a/src/app/clusters/chime-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/chime-server/app_config_dependent_sources.cmake
@@ -18,7 +18,5 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.h"
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
-    "${CLUSTER_DIR}/MigrateChimeServerStorage.h"
-    "${CLUSTER_DIR}/MigrateChimeServerStorage.cpp"
     "${CLUSTER_DIR}/chime-server.h"
 )

--- a/src/app/clusters/chime-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/chime-server/app_config_dependent_sources.gni
@@ -14,7 +14,5 @@
 app_config_dependent_sources = [
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
-  "MigrateChimeServerStorage.cpp",
-  "MigrateChimeServerStorage.h",
   "chime-server.h",
 ]

--- a/src/app/clusters/mode-base-server/BUILD.gn
+++ b/src/app/clusters/mode-base-server/BUILD.gn
@@ -17,6 +17,8 @@ import("//build_overrides/chip.gni")
 source_set("mode-base-server") {
   sources = [
     "AppDelegate.h",
+    "MigrateModeBaseServerStorage.cpp",
+    "MigrateModeBaseServerStorage.h",
     "ModeBaseCluster.cpp",
     "ModeBaseCluster.h",
     "mode-base-cluster-objects.h",

--- a/src/app/clusters/mode-base-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/mode-base-server/app_config_dependent_sources.cmake
@@ -19,7 +19,5 @@ TARGET_SOURCES(
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
     "${CLUSTER_DIR}/CodegenIntegration.h"
     "${CLUSTER_DIR}/Delegate.h"
-    "${CLUSTER_DIR}/MigrateModeBaseServerStorage.cpp"
-    "${CLUSTER_DIR}/MigrateModeBaseServerStorage.h"
     "${CLUSTER_DIR}/mode-base-server.h"
 )

--- a/src/app/clusters/mode-base-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/mode-base-server/app_config_dependent_sources.gni
@@ -15,7 +15,5 @@ app_config_dependent_sources = [
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
   "Delegate.h",
-  "MigrateModeBaseServerStorage.cpp",
-  "MigrateModeBaseServerStorage.h",
   "mode-base-server.h",
 ]

--- a/src/app/clusters/thread-network-directory-server/BUILD.gn
+++ b/src/app/clusters/thread-network-directory-server/BUILD.gn
@@ -18,6 +18,8 @@ source_set("thread-network-directory-server") {
   sources = [
     "DefaultThreadNetworkDirectoryStorage.cpp",
     "DefaultThreadNetworkDirectoryStorage.h",
+    "MigrateThreadNetworkDirectoryServerStorage.cpp",
+    "MigrateThreadNetworkDirectoryServerStorage.h",
     "ThreadNetworkDirectoryCluster.cpp",
     "ThreadNetworkDirectoryCluster.h",
     "ThreadNetworkDirectoryStorage.h",

--- a/src/app/clusters/thread-network-directory-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/thread-network-directory-server/app_config_dependent_sources.cmake
@@ -18,6 +18,4 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
     "${CLUSTER_DIR}/CodegenIntegration.h"
-    "${CLUSTER_DIR}/MigrateThreadNetworkDirectoryServerStorage.cpp"
-    "${CLUSTER_DIR}/MigrateThreadNetworkDirectoryServerStorage.h"
 )

--- a/src/app/clusters/thread-network-directory-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/thread-network-directory-server/app_config_dependent_sources.gni
@@ -14,6 +14,4 @@
 app_config_dependent_sources = [
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
-  "MigrateThreadNetworkDirectoryServerStorage.cpp",
-  "MigrateThreadNetworkDirectoryServerStorage.h",
 ]

--- a/src/app/clusters/thread-network-directory-server/tests/BUILD.gn
+++ b/src/app/clusters/thread-network-directory-server/tests/BUILD.gn
@@ -23,10 +23,7 @@ chip_test_suite("tests") {
 
   test_sources = [ "TestThreadNetworkDirectoryCluster.cpp" ]
 
-  sources = [
-    "../MigrateThreadNetworkDirectoryServerStorage.cpp",
-    "FakeThreadNetworkDirectoryStorage.h",
-  ]
+  sources = [ "FakeThreadNetworkDirectoryStorage.h" ]
 
   cflags = [ "-Wconversion" ]
 

--- a/src/app/clusters/unit-localization-server/BUILD.gn
+++ b/src/app/clusters/unit-localization-server/BUILD.gn
@@ -16,6 +16,8 @@ import("//build_overrides/chip.gni")
 
 source_set("unit-localization-server") {
   sources = [
+    "MigrateUnitLocalizationServerStorage.cpp",
+    "MigrateUnitLocalizationServerStorage.h",
     "UnitLocalizationCluster.cpp",
     "UnitLocalizationCluster.h",
   ]

--- a/src/app/clusters/unit-localization-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/unit-localization-server/app_config_dependent_sources.cmake
@@ -18,6 +18,4 @@ TARGET_SOURCES(
   PRIVATE
    "${CLUSTER_DIR}/CodegenIntegration.cpp"
    "${CLUSTER_DIR}/CodegenIntegration.h"
-   "${CLUSTER_DIR}/MigrateUnitLocalizationServerStorage.cpp"
-   "${CLUSTER_DIR}/MigrateUnitLocalizationServerStorage.h"
 )

--- a/src/app/clusters/unit-localization-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/unit-localization-server/app_config_dependent_sources.gni
@@ -15,7 +15,5 @@
 app_config_dependent_sources = [
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
-  "MigrateUnitLocalizationServerStorage.cpp",
-  "MigrateUnitLocalizationServerStorage.h",
   "unit-localization-server.h",
 ]

--- a/src/app/clusters/zone-management-server/BUILD.gn
+++ b/src/app/clusters/zone-management-server/BUILD.gn
@@ -25,6 +25,8 @@ source_set("zone-geometry") {
 
 source_set("zone-management-server") {
   sources = [
+    "MigrateZoneManagementServerStorage.cpp",
+    "MigrateZoneManagementServerStorage.h",
     "ZoneManagementCluster.cpp",
     "ZoneManagementCluster.h",
     "zone-geometry.h",
@@ -37,6 +39,7 @@ source_set("zone-management-server") {
 
   public_deps = [
     "${chip_root}/src/app:interaction-model",
+    "${chip_root}/src/app/persistence:migration",
     "${chip_root}/src/app/server-cluster",
     "${chip_root}/zzz_generated/app-common/clusters/ZoneManagement",
   ]

--- a/src/app/clusters/zone-management-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/zone-management-server/app_config_dependent_sources.cmake
@@ -18,7 +18,5 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
     "${CLUSTER_DIR}/CodegenIntegration.h"
-    "${CLUSTER_DIR}/MigrateZoneManagementServerStorage.cpp"
-    "${CLUSTER_DIR}/MigrateZoneManagementServerStorage.h"
     "${CLUSTER_DIR}/zone-management-server.h"
 )

--- a/src/app/clusters/zone-management-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/zone-management-server/app_config_dependent_sources.gni
@@ -14,7 +14,5 @@
 app_config_dependent_sources = [
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
-  "MigrateZoneManagementServerStorage.cpp",
-  "MigrateZoneManagementServerStorage.h",
   "zone-management-server.h",
 ]


### PR DESCRIPTION
### Summary

Currently the SafeAttributePersistence migration logic is only added to the Codegen related functionality in the cluster that migrated. CodeDriven clusters don't add this functionality so a cluster migrating from a ZAP enabled cluster using SafeAttributePersistence directly to a CodeDriven approach (without the codegen layer) won't have the migration functionality.

### Related issues

NA

### Testing

No functional change, the CI should still build and tests should work.
