### PR TITLE
[ICD] Add FuzzTest harnesses for the Check-In client path and ICD Management commands

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -14,6 +14,8 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/app/icd/icd.gni")
 import("//build_overrides/mbedtls.gni")
 import("//build_overrides/pigweed.gni")
 
@@ -73,6 +75,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     group("pw_fuzz_tests") {
       deps = [
         "${chip_root}/src/app/clusters/tls-certificate-management-server/tests:fuzz-tls-certificate-management-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/app/icd/client/tests:fuzz-icd-check-in-handler-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/app/icd/client/tests:fuzz-icd-check-in-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/ble/tests:fuzz-ble-endpoint-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/ble/tests:fuzz-ble-layer-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/ble/tests:fuzz-btp-engine-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
@@ -96,6 +100,12 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/src/wifipaf/tests:fuzz-wifipaf-endpoint-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/wifipaf/tests:fuzz-wifipaf-tp-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
       ]
+
+      # The ICD Management command handlers are only compiled when the ICD
+      # server is enabled, so the target follows the same condition.
+      if (chip_enable_icd_server) {
+        deps += [ "${chip_root}/src/app/clusters/icd-management-server/tests:fuzz-icd-management-cluster-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)" ]
+      }
 
       # These two exercise ActiveResolveAttempts and IncrementalResolve, which
       # //src/lib/dnssd only compiles for chip_mdns == "minimal".

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -15,9 +15,9 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
-import("${chip_root}/src/app/icd/icd.gni")
 import("//build_overrides/mbedtls.gni")
 import("//build_overrides/pigweed.gni")
+import("${chip_root}/src/app/icd/icd.gni")
 
 import("//src/lwip/lwip.gni")
 import("//src/platform/device.gni")

--- a/build/toolchain/pw_fuzzer/BUILD.gn
+++ b/build/toolchain/pw_fuzzer/BUILD.gn
@@ -170,8 +170,13 @@ gcc_toolchain("chip_pw_fuzztest") {
           [ "$dir_pw_toolchain/host_clang:sanitize_address" ]
       default_configs += [ "//build/config/compiler:sanitize_memory" ]
     } else {
-      # Local builds keep pigweed's base -fsanitize=address. Optional UBSan on top via the
-      # `ubsan` modifier on a -pw-fuzztest target.
+      # Pigweed's -fsanitize=address comes from this toolchain's default_configs, which
+      # only reaches pigweed-template targets. Chip targets key sanitizers off is_asan, so
+      # set it to instrument them too; config("sanitize_address") also carries the
+      # -fsanitize-coverage= counters.
+      is_asan = true
+
+      # Optional UBSan on top via the `ubsan` modifier on a -pw-fuzztest target.
       if (chip_pw_fuzz_ubsan) {
         default_configs += [ "//build/toolchain/pw_fuzzer:fuzztest_ubsan" ]
       }

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -585,6 +585,13 @@ class HostBuilder(GnBuilder):
             self.extra_gn_options.append('is_libfuzzer=true')
         elif fuzzing_type == HostFuzzingType.PW_FUZZTEST:
             self.extra_gn_options.append('pw_enable_fuzz_test_targets=true')
+            # The ICD Management cluster command handlers are compiled only when
+            # the ICD server is enabled, and RegisterClient/UnregisterClient
+            # additionally require the Check-In Protocol, which chip_enable_icd_lit
+            # turns on. Without these the corresponding fuzz target is configured
+            # out and never built.
+            self.extra_gn_options.append('chip_enable_icd_server=true')
+            self.extra_gn_options.append('chip_enable_icd_lit=true')
             if pw_fuzz_libfuzzer_compat:
                 self.extra_gn_options.append('chip_pw_fuzz_libfuzzer_compat=true')
             if use_ubsan:

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -587,11 +587,12 @@ class HostBuilder(GnBuilder):
             self.extra_gn_options.append('pw_enable_fuzz_test_targets=true')
             # The ICD Management cluster command handlers are compiled only when
             # the ICD server is enabled, and RegisterClient/UnregisterClient
-            # additionally require the Check-In Protocol, which chip_enable_icd_lit
-            # turns on. Without these the corresponding fuzz target is configured
-            # out and never built.
+            # additionally require the Check-In Protocol. Without these the
+            # corresponding fuzz target is configured out and never built. CIP is
+            # enabled directly rather than via chip_enable_icd_lit, which would
+            # also pull in LIT and UAT that the target does not need.
             self.extra_gn_options.append('chip_enable_icd_server=true')
-            self.extra_gn_options.append('chip_enable_icd_lit=true')
+            self.extra_gn_options.append('chip_enable_icd_checkin=true')
             if pw_fuzz_libfuzzer_compat:
                 self.extra_gn_options.append('chip_pw_fuzz_libfuzzer_compat=true')
             if use_ubsan:

--- a/src/app/clusters/icd-management-server/tests/BUILD.gn
+++ b/src/app/clusters/icd-management-server/tests/BUILD.gn
@@ -15,6 +15,8 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
+import("${chip_root}/build/chip/fuzz_test.gni")
+
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
 chip_test_suite("tests") {
@@ -34,4 +36,17 @@ chip_test_suite("tests") {
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support:testing",
   ]
+}
+
+if (pw_enable_fuzz_test_targets) {
+  chip_pw_fuzz_target("fuzz-icd-management-cluster-pw") {
+    test_source = [ "FuzzICDManagementClusterPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/app/clusters/icd-management-server",
+      "${chip_root}/src/app/server-cluster/testing",
+      "${chip_root}/src/crypto",
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/platform/logging:default",
+    ]
+  }
 }

--- a/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
+++ b/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
@@ -50,11 +50,11 @@
 #include <pw_fuzzer/fuzztest.h>
 #include <pw_unit_test/framework.h>
 
+#include <access/AccessControl.h>
+#include <access/examples/ExampleAccessControlDelegate.h>
 #include <app/clusters/icd-management-server/ICDManagementCluster.h>
 #include <app/icd/server/ICDConfigurationData.h>
 #include <app/server-cluster/OptionalAttributeSet.h>
-#include <access/AccessControl.h>
-#include <access/examples/ExampleAccessControlDelegate.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/FabricTestFixture.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
@@ -108,8 +108,7 @@ struct Fixture
 #endif
 
     Fixture() :
-        cluster(kEndpoint, keystore, fabricFixture.GetFabricTable(), ICDConfigurationData::GetInstance(),
-                OptionalAttributeSet(0),
+        cluster(kEndpoint, keystore, fabricFixture.GetFabricTable(), ICDConfigurationData::GetInstance(), OptionalAttributeSet(0),
                 ICDManagementCluster::OptionalCommandSet().Set<IcdManagement::Commands::StayActiveRequest::Id>(),
                 BitMask<IcdManagement::UserActiveModeTriggerBitmap>(0), CharSpan())
     {}
@@ -164,14 +163,17 @@ std::vector<std::vector<uint8_t>> KeySeeds()
 {
     return {
         {},
-        std::vector<uint8_t>(1, 0xAA),  std::vector<uint8_t>(15, 0xAA), std::vector<uint8_t>(16, 0xAA),
-        std::vector<uint8_t>(17, 0xAA), std::vector<uint8_t>(32, 0xAA), std::vector<uint8_t>(64, 0xAA),
+        std::vector<uint8_t>(1, 0xAA),
+        std::vector<uint8_t>(15, 0xAA),
+        std::vector<uint8_t>(16, 0xAA),
+        std::vector<uint8_t>(17, 0xAA),
+        std::vector<uint8_t>(32, 0xAA),
+        std::vector<uint8_t>(64, 0xAA),
     };
 }
 
 void RegisterClientDoesNotCrash(uint64_t checkInNodeID, uint64_t monitoredSubject, const std::vector<uint8_t> & key,
-                               uint8_t clientTypeRaw, const std::vector<uint8_t> & verificationKey,
-                               bool sendVerificationKey)
+                                uint8_t clientTypeRaw, const std::vector<uint8_t> & verificationKey, bool sendVerificationKey)
 {
     Fixture & fx = GetFixture();
 
@@ -216,8 +218,8 @@ FUZZ_TEST(ICDManagementClusterPW, RegisterClientDoesNotCrash)
                  // Only 0 and 1 are valid ClientTypeEnum values; anything else is
                  // rejected by the first guard in the handler. Left unconstrained,
                  // ~254/256 inputs return before the entry is ever looked up.
-                 ElementOf<uint8_t>({ 0, 1, 2, 3, 0xFF }),
-                 Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128), Arbitrary<bool>());
+                 ElementOf<uint8_t>({ 0, 1, 2, 3, 0xFF }), Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),
+                 Arbitrary<bool>());
 
 FUZZ_TEST(ICDManagementClusterPW, UnregisterClientDoesNotCrash)
     .WithDomains(Arbitrary<uint64_t>(), Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),

--- a/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
+++ b/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
@@ -44,6 +44,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <mutex>
 #include <vector>
 

--- a/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
+++ b/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
@@ -270,8 +270,8 @@ FUZZ_TEST(ICDManagementClusterPW, RegisterClientDoesNotCrash)
 FUZZ_TEST(ICDManagementClusterPW, UnregisterClientDoesNotCrash)
     // Same node-ID set as RegisterClient, so unregistration finds an entry
     // rather than returning NotFound on almost every input.
-    .WithDomains(ElementOf<uint64_t>({ 0x1234, 0x1235, 0x1236 }), Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),
-                 Arbitrary<bool>());
+    .WithDomains(ElementOf<uint64_t>({ 0x1234, 0x1235, 0x1236 }),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128), Arbitrary<bool>());
 
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 

--- a/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
+++ b/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
@@ -1,0 +1,245 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      FuzzTest harness for the ICD Management cluster command handlers.
+ *
+ *      The three commands the cluster accepts all arrive as decoded structs, so
+ *      the fuzzer drives the decoded fields and lets ClusterTester encode them
+ *      rather than mutating raw TLV -- otherwise nearly every input is spent
+ *      failing to decode instead of exercising the handlers.
+ *
+ *      The field worth the most attention is RegisterClient's `key`: it is a
+ *      caller-sized ByteSpan that ends up in the monitoring table's fixed-size
+ *      symmetric key storage, so the domain deliberately straddles the expected
+ *      16-byte length in both directions.
+ *
+ *      RegisterClient's behaviour also forks on whether the invoking subject has
+ *      administrator privileges: an admin may overwrite an existing entry
+ *      outright, while a non-admin must present a matching verificationKey. Both
+ *      are driven, since the non-admin arm is the one that compares
+ *      caller-supplied bytes against stored key material.
+ *
+ *      Each property runs against a table that persists across inputs, so entries
+ *      left by earlier iterations are what later ones find, update, and evict --
+ *      including at the per-fabric capacity limit.
+ *
+ *      Oracle: no sanitizer error, and the handler must always return a status
+ *      rather than leaving the table in a state that trips a later read-back.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <app/clusters/icd-management-server/ICDManagementCluster.h>
+#include <app/icd/server/ICDConfigurationData.h>
+#include <app/server-cluster/OptionalAttributeSet.h>
+#include <access/AccessControl.h>
+#include <access/examples/ExampleAccessControlDelegate.h>
+#include <app/server-cluster/testing/ClusterTester.h>
+#include <app/server-cluster/testing/FabricTestFixture.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <clusters/IcdManagement/Commands.h>
+#include <clusters/IcdManagement/Enums.h>
+#include <clusters/IcdManagement/Metadata.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/BitFlags.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <lib/support/logging/Constants.h>
+#include <lib/support/logging/TextOnlyLogging.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::IcdManagement;
+using namespace fuzztest;
+
+using chip::Testing::ClusterTester;
+using chip::Testing::FabricTestFixture;
+using chip::Testing::TestServerClusterContext;
+
+constexpr EndpointId kEndpoint = kRootEndpointId;
+
+class HarnessDeviceTypeResolver : public Access::AccessControl::DeviceTypeResolver
+{
+public:
+    bool IsDeviceTypeOnEndpoint(DeviceTypeId, EndpointId) override { return false; }
+};
+
+HarnessDeviceTypeResolver gDeviceTypeResolver;
+
+struct Fixture
+{
+    Crypto::DefaultSessionKeystore keystore;
+    TestServerClusterContext context;
+    FabricTestFixture fabricFixture{ &context.StorageDelegate() };
+    // SetUpTestFabric takes this as an in/out parameter and rejects the
+    // undefined index, so it must name a concrete fabric to create.
+    FabricIndex fabricIndex = 1;
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+    ICDManagementClusterWithCIP cluster;
+#else
+    ICDManagementCluster cluster;
+#endif
+
+    Fixture() :
+        cluster(kEndpoint, keystore, fabricFixture.GetFabricTable(), ICDConfigurationData::GetInstance(),
+                OptionalAttributeSet(0),
+                ICDManagementCluster::OptionalCommandSet().Set<IcdManagement::Commands::StayActiveRequest::Id>(),
+                BitMask<IcdManagement::UserActiveModeTriggerBitmap>(0), CharSpan())
+    {}
+};
+
+Fixture * gFixture = nullptr;
+
+Fixture & GetFixture()
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+        // The cluster logs per command; at fuzzing rates that dominates runtime
+        // and output volume both.
+        Logging::SetLogFilter(Logging::kLogCategory_None);
+
+        // RegisterClient/UnregisterClient gate on CheckAdmin, which consults the
+        // global AccessControl. Uninitialized, Check() returns neither success nor
+        // ACCESS_DENIED, so both handlers bail at their second guard and never
+        // reach the monitoring table at all.
+        VerifyOrDie(Access::GetAccessControl().Init(Access::Examples::GetAccessControlDelegate(), gDeviceTypeResolver) ==
+                    CHIP_NO_ERROR);
+
+        auto * fx = new Fixture();
+        VerifyOrDie(fx->fabricFixture.SetUpTestFabric(fx->fabricIndex) == CHIP_NO_ERROR);
+        VerifyOrDie(fx->cluster.Startup(fx->context.Get()) == CHIP_NO_ERROR);
+
+        gFixture = fx;
+        // Teardown via atexit rather than a static destructor: the cluster and
+        // fabric table assert on their own shutdown state, and running that
+        // during static destruction aborts the process after the run has already
+        // finished -- which looks like a crash and loses the coverage profile.
+        std::atexit([] {
+            if (gFixture != nullptr)
+            {
+                gFixture->cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+                delete gFixture;
+                gFixture = nullptr;
+            }
+            Access::GetAccessControl().Finish();
+            Platform::MemoryShutdown();
+        });
+    });
+    return *gFixture;
+}
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+
+// The registration key is a caller-sized span copied into fixed-size key
+// storage, so the sizes either side of 16 are the ones that matter.
+std::vector<std::vector<uint8_t>> KeySeeds()
+{
+    return {
+        {},
+        std::vector<uint8_t>(1, 0xAA),  std::vector<uint8_t>(15, 0xAA), std::vector<uint8_t>(16, 0xAA),
+        std::vector<uint8_t>(17, 0xAA), std::vector<uint8_t>(32, 0xAA), std::vector<uint8_t>(64, 0xAA),
+    };
+}
+
+void RegisterClientDoesNotCrash(uint64_t checkInNodeID, uint64_t monitoredSubject, const std::vector<uint8_t> & key,
+                               uint8_t clientTypeRaw, const std::vector<uint8_t> & verificationKey,
+                               bool sendVerificationKey)
+{
+    Fixture & fx = GetFixture();
+
+    ClusterTester tester(fx.cluster, &fx.fabricFixture);
+    tester.SetFabricIndex(fx.fabricIndex);
+
+    Commands::RegisterClient::Type request;
+    request.checkInNodeID    = checkInNodeID;
+    request.monitoredSubject = monitoredSubject;
+    request.key              = ByteSpan(key.data(), key.size());
+    request.clientType       = static_cast<ClientTypeEnum>(clientTypeRaw);
+    if (sendVerificationKey)
+    {
+        request.verificationKey.SetValue(ByteSpan(verificationKey.data(), verificationKey.size()));
+    }
+
+    auto result = tester.Invoke(Commands::RegisterClient::Id, request);
+    (void) result;
+}
+
+void UnregisterClientDoesNotCrash(uint64_t checkInNodeID, const std::vector<uint8_t> & verificationKey, bool sendVerificationKey)
+{
+    Fixture & fx = GetFixture();
+
+    ClusterTester tester(fx.cluster, &fx.fabricFixture);
+    tester.SetFabricIndex(fx.fabricIndex);
+
+    Commands::UnregisterClient::Type request;
+    request.checkInNodeID = checkInNodeID;
+    if (sendVerificationKey)
+    {
+        request.verificationKey.SetValue(ByteSpan(verificationKey.data(), verificationKey.size()));
+    }
+
+    auto result = tester.Invoke(Commands::UnregisterClient::Id, request);
+    (void) result;
+}
+
+FUZZ_TEST(ICDManagementClusterPW, RegisterClientDoesNotCrash)
+    .WithDomains(Arbitrary<uint64_t>(), Arbitrary<uint64_t>(),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),
+                 // Only 0 and 1 are valid ClientTypeEnum values; anything else is
+                 // rejected by the first guard in the handler. Left unconstrained,
+                 // ~254/256 inputs return before the entry is ever looked up.
+                 ElementOf<uint8_t>({ 0, 1, 2, 3, 0xFF }),
+                 Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128), Arbitrary<bool>());
+
+FUZZ_TEST(ICDManagementClusterPW, UnregisterClientDoesNotCrash)
+    .WithDomains(Arbitrary<uint64_t>(), Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),
+                 Arbitrary<bool>());
+
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
+
+void StayActiveRequestDoesNotCrash(uint32_t stayActiveDuration)
+{
+    Fixture & fx = GetFixture();
+
+    ClusterTester tester(fx.cluster, &fx.fabricFixture);
+    tester.SetFabricIndex(fx.fabricIndex);
+
+    Commands::StayActiveRequest::Type request;
+    request.stayActiveDuration = stayActiveDuration;
+
+    auto result = tester.Invoke(Commands::StayActiveRequest::Id, request);
+    (void) result;
+}
+
+FUZZ_TEST(ICDManagementClusterPW, StayActiveRequestDoesNotCrash)
+    .WithDomains(Arbitrary<uint32_t>().WithSeeds({ 0u, 1u, 30u, 60u, 0x7FFFFFFFu, 0x80000000u, 0xFFFFFFFFu }));
+
+} // namespace

--- a/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
+++ b/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
@@ -255,11 +255,13 @@ void UnregisterClientDoesNotCrash(uint64_t checkInNodeID, const std::vector<uint
 
 FUZZ_TEST(ICDManagementClusterPW, RegisterClientDoesNotCrash)
     // The monitoring table holds CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC (2)
-    // entries per fabric, so unconstrained 64-bit node IDs fill it within two
-    // inputs and every later one returns ResourceExhausted without registering.
-    // A small set makes registrations collide, which is what reaches the
-    // existing-entry path and its verificationKey comparison.
-    .WithDomains(ElementOf<uint64_t>({ 0x1234, 0x1235, 0x1236 }), Arbitrary<uint64_t>(),
+    // entries per fabric, so seeding a small node-ID set makes registrations
+    // collide from the second input and reaches the existing-entry path without
+    // waiting for the corpus to warm up. Seeded rather than restricted: measured
+    // coverage of the handler is the same either way (89.36% region), since the
+    // corpus replays node IDs that registered successfully, so there is nothing
+    // to gain by giving up the rest of the range.
+    .WithDomains(Arbitrary<uint64_t>().WithSeeds({ 0x1234, 0x1235, 0x1236 }), Arbitrary<uint64_t>(),
                  Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),
                  // Only 0 and 1 are valid ClientTypeEnum values; anything else is
                  // rejected by the first guard in the handler. Left unconstrained,
@@ -270,7 +272,7 @@ FUZZ_TEST(ICDManagementClusterPW, RegisterClientDoesNotCrash)
 FUZZ_TEST(ICDManagementClusterPW, UnregisterClientDoesNotCrash)
     // Same node-ID set as RegisterClient, so unregistration finds an entry
     // rather than returning NotFound on almost every input.
-    .WithDomains(ElementOf<uint64_t>({ 0x1234, 0x1235, 0x1236 }),
+    .WithDomains(Arbitrary<uint64_t>().WithSeeds({ 0x1234, 0x1235, 0x1236 }),
                  Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128), Arbitrary<bool>());
 
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP

--- a/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
+++ b/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
@@ -155,6 +155,7 @@ Fixture & GetFixture()
             if (gFixture != nullptr)
             {
                 gFixture->cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+                gFixture->fabricFixture.TearDownTestFabric(gFixture->fabricIndex);
                 delete gFixture;
                 gFixture = nullptr;
             }

--- a/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
+++ b/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
@@ -61,7 +61,11 @@
 #include <clusters/IcdManagement/Commands.h>
 #include <clusters/IcdManagement/Enums.h>
 #include <clusters/IcdManagement/Metadata.h>
+#include <crypto/CryptoBuildConfig.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/BitFlags.h>
@@ -121,6 +125,11 @@ Fixture & GetFixture()
     static std::once_flag once;
     std::call_once(once, [] {
         VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        // Fuzz binaries use gmock_main and so miss the unit-test main's PSA
+        // initialization; the backend must be initialized before any crypto runs.
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
+#endif
         // The cluster logs per command; at fuzzing rates that dominates runtime
         // and output volume both.
         Logging::SetLogFilter(Logging::kLogCategory_None);

--- a/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
+++ b/src/app/clusters/icd-management-server/tests/FuzzICDManagementClusterPW.cpp
@@ -28,11 +28,13 @@
  *      symmetric key storage, so the domain deliberately straddles the expected
  *      16-byte length in both directions.
  *
- *      RegisterClient's behaviour also forks on whether the invoking subject has
- *      administrator privileges: an admin may overwrite an existing entry
- *      outright, while a non-admin must present a matching verificationKey. Both
- *      are driven, since the non-admin arm is the one that compares
- *      caller-supplied bytes against stored key material.
+ *      RegisterClient and UnregisterClient fork on whether the invoking subject
+ *      has administrator privileges: an admin may act on an existing entry
+ *      outright, while a non-admin must present a matching verificationKey. The
+ *      access-control delegate here grants nothing, so CheckAdmin resolves every
+ *      subject to non-admin and it is the verificationKey comparison against
+ *      stored key material that gets driven. Reaching the administrator arm would
+ *      need access-control entries granting that privilege.
  *
  *      Each property runs against a table that persists across inputs, so entries
  *      left by earlier iterations are what later ones find, update, and evict --
@@ -202,7 +204,14 @@ void RegisterClientDoesNotCrash(uint64_t checkInNodeID, uint64_t monitoredSubjec
     }
 
     auto result = tester.Invoke(Commands::RegisterClient::Id, request);
-    (void) result;
+    // ClusterTester returns no status when it could not encode the request --
+    // which a large fuzzer-chosen key can cause -- so that case is not a handler
+    // defect. When the command did reach the handler it must not come back
+    // without having produced a response or a status.
+    if (result.status.has_value())
+    {
+        EXPECT_NE(result.status.value(), app::DataModel::ActionReturnStatus(CHIP_ERROR_INCORRECT_STATE));
+    }
 }
 
 void UnregisterClientDoesNotCrash(uint64_t checkInNodeID, const std::vector<uint8_t> & verificationKey, bool sendVerificationKey)
@@ -212,6 +221,20 @@ void UnregisterClientDoesNotCrash(uint64_t checkInNodeID, const std::vector<uint
     ClusterTester tester(fx.cluster, &fx.fabricFixture);
     tester.SetFabricIndex(fx.fabricIndex);
 
+    // Each property runs as its own process, so nothing has registered a client
+    // yet and every unregistration would return NotFound. Register first, with a
+    // key the fuzzer also controls, so the lookup succeeds and the key
+    // verification and removal paths are reachable.
+    {
+        Commands::RegisterClient::Type seed;
+        seed.checkInNodeID    = checkInNodeID;
+        seed.monitoredSubject = checkInNodeID;
+        seed.key              = ByteSpan(verificationKey.data(), verificationKey.size());
+        seed.clientType       = ClientTypeEnum::kPermanent;
+        auto seedResult       = tester.Invoke(Commands::RegisterClient::Id, seed);
+        (void) seedResult;
+    }
+
     Commands::UnregisterClient::Type request;
     request.checkInNodeID = checkInNodeID;
     if (sendVerificationKey)
@@ -220,11 +243,23 @@ void UnregisterClientDoesNotCrash(uint64_t checkInNodeID, const std::vector<uint
     }
 
     auto result = tester.Invoke(Commands::UnregisterClient::Id, request);
-    (void) result;
+    // ClusterTester returns no status when it could not encode the request --
+    // which a large fuzzer-chosen key can cause -- so that case is not a handler
+    // defect. When the command did reach the handler it must not come back
+    // without having produced a response or a status.
+    if (result.status.has_value())
+    {
+        EXPECT_NE(result.status.value(), app::DataModel::ActionReturnStatus(CHIP_ERROR_INCORRECT_STATE));
+    }
 }
 
 FUZZ_TEST(ICDManagementClusterPW, RegisterClientDoesNotCrash)
-    .WithDomains(Arbitrary<uint64_t>(), Arbitrary<uint64_t>(),
+    // The monitoring table holds CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC (2)
+    // entries per fabric, so unconstrained 64-bit node IDs fill it within two
+    // inputs and every later one returns ResourceExhausted without registering.
+    // A small set makes registrations collide, which is what reaches the
+    // existing-entry path and its verificationKey comparison.
+    .WithDomains(ElementOf<uint64_t>({ 0x1234, 0x1235, 0x1236 }), Arbitrary<uint64_t>(),
                  Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),
                  // Only 0 and 1 are valid ClientTypeEnum values; anything else is
                  // rejected by the first guard in the handler. Left unconstrained,
@@ -233,7 +268,9 @@ FUZZ_TEST(ICDManagementClusterPW, RegisterClientDoesNotCrash)
                  Arbitrary<bool>());
 
 FUZZ_TEST(ICDManagementClusterPW, UnregisterClientDoesNotCrash)
-    .WithDomains(Arbitrary<uint64_t>(), Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),
+    // Same node-ID set as RegisterClient, so unregistration finds an entry
+    // rather than returning NotFound on almost every input.
+    .WithDomains(ElementOf<uint64_t>({ 0x1234, 0x1235, 0x1236 }), Arbitrary<std::vector<uint8_t>>().WithSeeds(KeySeeds()).WithMaxSize(128),
                  Arbitrary<bool>());
 
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
@@ -249,7 +286,14 @@ void StayActiveRequestDoesNotCrash(uint32_t stayActiveDuration)
     request.stayActiveDuration = stayActiveDuration;
 
     auto result = tester.Invoke(Commands::StayActiveRequest::Id, request);
-    (void) result;
+    // ClusterTester returns no status when it could not encode the request --
+    // which a large fuzzer-chosen key can cause -- so that case is not a handler
+    // defect. When the command did reach the handler it must not come back
+    // without having produced a response or a status.
+    if (result.status.has_value())
+    {
+        EXPECT_NE(result.status.value(), app::DataModel::ActionReturnStatus(CHIP_ERROR_INCORRECT_STATE));
+    }
 }
 
 FUZZ_TEST(ICDManagementClusterPW, StayActiveRequestDoesNotCrash)

--- a/src/app/icd/client/tests/BUILD.gn
+++ b/src/app/icd/client/tests/BUILD.gn
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/build/chip/fuzz_test.gni")
+
+if (pw_enable_fuzz_test_targets) {
+  chip_pw_fuzz_target("fuzz-icd-check-in-handler-pw") {
+    test_source = [ "FuzzICDCheckInHandlerPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/app",
+      "${chip_root}/src/app/icd/client:handler",
+      "${chip_root}/src/app/tests:helpers",
+      "${chip_root}/src/crypto",
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/support:testing",
+      "${chip_root}/src/platform/logging:default",
+      "${chip_root}/src/protocols/secure_channel",
+    ]
+  }
+
+  chip_pw_fuzz_target("fuzz-icd-check-in-pw") {
+    test_source = [ "FuzzICDCheckInPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/app/icd/client:manager",
+      "${chip_root}/src/crypto",
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/support:testing",
+      "${chip_root}/src/platform/logging:default",
+      "${chip_root}/src/protocols/secure_channel",
+    ]
+  }
+}

--- a/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
@@ -140,9 +140,9 @@ struct Fixture
         HarnessContext::SetUpTestSuite();
         context.SetUp();
 
+        // AppContext::SetUp() has already initialized the engine (and the access
+        // control), so take the instance rather than initializing it again.
         InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
-        VerifyOrDie(engine->Init(&context.GetExchangeManager(), &context.GetFabricTable(),
-                                 app::reporting::GetDefaultReportScheduler()) == CHIP_NO_ERROR);
 
         VerifyOrDie(storage.Init(&clientInfoStore, &keystore) == CHIP_NO_ERROR);
         VerifyOrDie(delegate.Init(&storage, engine) == CHIP_NO_ERROR);
@@ -166,7 +166,7 @@ struct Fixture
     {
         handler.Shutdown();
         storage.Shutdown();
-        InteractionModelEngine::GetInstance()->Shutdown();
+        // AppContext::TearDown() shuts the engine down, so do not do it here too.
         context.TearDown();
         HarnessContext::TearDownTestSuite();
     }

--- a/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
@@ -53,6 +53,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <utility>
 #include <vector>
 
 #include <pw_fuzzer/fuzztest.h>

--- a/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
@@ -1,0 +1,231 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      FuzzTest harness for CheckInHandler::OnMessageReceived — the state layer
+ *      above the Check-In payload parser.
+ *
+ *      FuzzICDCheckInPW.cpp covers the decrypt path (ProcessCheckInPayload ->
+ *      ParseCheckinMessagePayload). Everything that happens once a payload
+ *      authenticates lives here instead, and none of it is reachable from that
+ *      harness because it links src/app/icd/client:manager and not :handler:
+ *
+ *        - the counter-offset computation, which is modular arithmetic on the
+ *          difference between the received counter and the stored
+ *          start_icd_counter, both of which this harness drives;
+ *        - the duplicate test against the stored offset;
+ *        - the key-refresh threshold, which on crossing hands control to
+ *          CheckInDelegate::OnKeyRefreshNeeded and RefreshKeySender.
+ *
+ *      The interesting inputs are therefore not payload bytes but the
+ *      relationship between three counters: the one encoded in the message and
+ *      the two held in the stored ICDClientInfo. Payload bytes are generated
+ *      correctly under a known key so that every iteration gets past the MIC
+ *      and reaches the state machine.
+ *
+ *      Scaffolding is a one-time AppContext (loopback exchange stack, fabric
+ *      table, InteractionModelEngine) plus the production DefaultCheckInDelegate
+ *      — not a stub, so the real RefreshKeySender allocation and its
+ *      failure paths are exercised. Only the per-entry counters are rewritten
+ *      per iteration.
+ *
+ *      Oracle: no sanitizer error, and OnMessageReceived absorbs every input —
+ *      by contract it returns CHIP_NO_ERROR even for malformed or duplicate
+ *      messages, so any other return is itself a finding.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <app/InteractionModelEngine.h>
+#include <app/icd/client/CheckInHandler.h>
+#include <app/icd/client/DefaultCheckInDelegate.h>
+#include <app/icd/client/DefaultICDClientStorage.h>
+#include <app/reporting/tests/MockReportScheduler.h>
+#include <app/tests/AppTestContext.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <lib/core/ScopedNodeId.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <lib/support/logging/Constants.h>
+#include <lib/support/logging/TextOnlyLogging.h>
+#include <protocols/secure_channel/CheckinMessage.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::Crypto;
+using namespace chip::Protocols::SecureChannel;
+using namespace fuzztest;
+
+constexpr FabricIndex kFabricIndex = 1;
+constexpr NodeId kNodeId           = 0x1234;
+constexpr uint8_t kKeyMaterial[]   = { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+                                       0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f };
+
+// OnMessageReceived is protected on CheckInHandler (it is an ExchangeDelegate
+// override). Same wrapper the unit test uses.
+class CheckInHandlerWrapper : public CheckInHandler
+{
+public:
+    CHIP_ERROR Deliver(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader, System::PacketBufferHandle && payload)
+    {
+        return OnMessageReceived(ec, payloadHeader, std::move(payload));
+    }
+};
+
+// AppContext derives from ::testing::Test, whose TestBody() is pure virtual, so
+// it cannot be instantiated outside the gtest machinery without a concrete leaf.
+class HarnessContext : public Testing::AppContext
+{
+public:
+    void TestBody() override {}
+};
+
+// One-time scaffolding. The exchange stack, fabric table and IM engine cost far
+// more to stand up than a single iteration costs to run, so they are built once
+// and only the stored counters are rewritten per input.
+struct Fixture
+{
+    HarnessContext context;
+    TestPersistentStorageDelegate clientInfoStore;
+    DefaultSessionKeystore keystore;
+    DefaultICDClientStorage storage;
+    DefaultCheckInDelegate delegate;
+    CheckInHandlerWrapper handler;
+    ICDClientInfo seededClient;
+
+    Fixture()
+    {
+        VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+        // The check-in path logs per message; at fuzzing rates that dominates
+        // both runtime and output volume.
+        Logging::SetLogFilter(Logging::kLogCategory_None);
+
+        HarnessContext::SetUpTestSuite();
+        context.SetUp();
+
+        InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
+        VerifyOrDie(engine->Init(&context.GetExchangeManager(), &context.GetFabricTable(),
+                                 app::reporting::GetDefaultReportScheduler()) == CHIP_NO_ERROR);
+
+        VerifyOrDie(storage.Init(&clientInfoStore, &keystore) == CHIP_NO_ERROR);
+        VerifyOrDie(delegate.Init(&storage, engine) == CHIP_NO_ERROR);
+        VerifyOrDie(handler.Init(&context.GetExchangeManager(), &storage, &delegate, engine) == CHIP_NO_ERROR);
+
+        seededClient.peer_node         = ScopedNodeId(kNodeId, kFabricIndex);
+        seededClient.check_in_node     = seededClient.peer_node;
+        seededClient.start_icd_counter = 0;
+        seededClient.offset            = 0;
+
+        VerifyOrDie(storage.UpdateFabricList(kFabricIndex) == CHIP_NO_ERROR);
+        VerifyOrDie(storage.SetKey(seededClient, ByteSpan(kKeyMaterial)) == CHIP_NO_ERROR);
+        VerifyOrDie(storage.StoreEntry(seededClient) == CHIP_NO_ERROR);
+    }
+
+    // MessagingContextData's destructor asserts the context was shut down
+    // (MessagingContext.h:208). Without this the assert trips during static
+    // destruction, which aborts the process before the coverage profile is
+    // written -- a run that looks like a crash and reports 0% coverage.
+    ~Fixture()
+    {
+        handler.Shutdown();
+        storage.Shutdown();
+        InteractionModelEngine::GetInstance()->Shutdown();
+        context.TearDown();
+        HarnessContext::TearDownTestSuite();
+    }
+};
+
+Fixture & GetFixture()
+{
+    static Fixture sFixture;
+    return sFixture;
+}
+
+// Builds a Check-In payload that authenticates against the seeded entry's key,
+// so the state machine is reached on every iteration rather than 1-in-2^128.
+std::vector<uint8_t> BuildValidPayload(const ICDClientInfo & info, uint32_t counter, const std::vector<uint8_t> & appData)
+{
+    std::vector<uint8_t> payload(CheckinMessage::GetCheckinPayloadSize(appData.size()));
+    MutableByteSpan output(payload.data(), payload.size());
+
+    ICDClientInfo mutableInfo(info);
+    if (CheckinMessage::GenerateCheckinMessagePayload(mutableInfo.aes_key_handle, mutableInfo.hmac_key_handle, counter,
+                                                      ByteSpan(appData.data(), appData.size()), output) != CHIP_NO_ERROR)
+    {
+        return {};
+    }
+    payload.resize(output.size());
+    return payload;
+}
+
+// The three counters that decide which arm of the state machine runs: the one
+// in the message, and the two persisted alongside the key.
+void CheckInStateMachineAbsorbsAnyCounter(uint32_t encodedCounter, uint32_t storedStartCounter, uint32_t storedOffset,
+                                          const std::vector<uint8_t> & appData)
+{
+    Fixture & f = GetFixture();
+
+    ICDClientInfo info               = f.seededClient;
+    info.start_icd_counter           = storedStartCounter;
+    info.offset                      = storedOffset;
+    ASSERT_EQ(f.storage.StoreEntry(info), CHIP_NO_ERROR);
+
+    std::vector<uint8_t> payload = BuildValidPayload(f.seededClient, encodedCounter, appData);
+    if (payload.empty())
+    {
+        return;
+    }
+
+    System::PacketBufferHandle buffer = System::PacketBufferHandle::NewWithData(payload.data(), payload.size());
+    if (buffer.IsNull())
+    {
+        return;
+    }
+
+    PayloadHeader payloadHeader;
+    payloadHeader.SetExchangeID(0);
+    payloadHeader.SetMessageType(MsgType::ICD_CheckIn);
+
+    // Contract: the handler absorbs malformed and duplicate messages and reports
+    // success, so anything else is a finding in its own right.
+    EXPECT_EQ(f.handler.Deliver(nullptr, payloadHeader, std::move(buffer)), CHIP_NO_ERROR);
+}
+
+FUZZ_TEST(ICDCheckInHandlerPW, CheckInStateMachineAbsorbsAnyCounter)
+    .WithDomains(
+        // Seeded at the boundaries that select each arm: equality and +/-1 around
+        // the duplicate test, and values that straddle the key-refresh threshold
+        // once the modular difference is taken.
+        Arbitrary<uint32_t>().WithSeeds({ 0u, 1u, 2u, 0x7FFFFFFFu, 0x80000000u, 0x80000001u, 0xFFFFFFFFu }),
+        Arbitrary<uint32_t>().WithSeeds({ 0u, 1u, 0x7FFFFFFFu, 0x80000000u, 0xFFFFFFFFu }),
+        Arbitrary<uint32_t>().WithSeeds({ 0u, 1u, 0x7FFFFFFEu, 0x7FFFFFFFu, 0x80000000u }),
+        Arbitrary<std::vector<uint8_t>>().WithMaxSize(2));
+
+} // namespace

--- a/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
@@ -85,8 +85,9 @@ using namespace fuzztest;
 
 constexpr FabricIndex kFabricIndex = 1;
 constexpr NodeId kNodeId           = 0x1234;
-constexpr uint8_t kKeyMaterial[]   = { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-                                       0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f };
+constexpr uint8_t kKeyMaterial[]   = {
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
+};
 
 // OnMessageReceived is protected on CheckInHandler (it is an ExchangeDelegate
 // override). Same wrapper the unit test uses.
@@ -192,9 +193,9 @@ void CheckInStateMachineAbsorbsAnyCounter(uint32_t encodedCounter, uint32_t stor
 {
     Fixture & f = GetFixture();
 
-    ICDClientInfo info               = f.seededClient;
-    info.start_icd_counter           = storedStartCounter;
-    info.offset                      = storedOffset;
+    ICDClientInfo info     = f.seededClient;
+    info.start_icd_counter = storedStartCounter;
+    info.offset            = storedOffset;
     ASSERT_EQ(f.storage.StoreEntry(info), CHIP_NO_ERROR);
 
     std::vector<uint8_t> payload = BuildValidPayload(f.seededClient, encodedCounter, appData);

--- a/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
@@ -64,7 +64,11 @@
 #include <app/icd/client/DefaultICDClientStorage.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>
+#include <crypto/CryptoBuildConfig.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
 #include <lib/core/ScopedNodeId.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
@@ -124,6 +128,11 @@ struct Fixture
     Fixture()
     {
         VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        // Fuzz binaries use gmock_main and so miss the unit-test main's PSA
+        // initialization; the backend must be initialized before any crypto runs.
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
+#endif
         // The check-in path logs per message; at fuzzing rates that dominates
         // both runtime and output volume.
         Logging::SetLogFilter(Logging::kLogCategory_None);

--- a/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInHandlerPW.cpp
@@ -170,6 +170,11 @@ struct Fixture
         // AppContext::TearDown() shuts the engine down, so do not do it here too.
         context.TearDown();
         HarnessContext::TearDownTestSuite();
+        // MemoryInit/MemoryShutdown are reference counted. SetUpTestSuite above
+        // takes one reference and TearDownTestSuite releases it, so without this
+        // the reference taken in the constructor is never released and the
+        // allocator is never torn down.
+        Platform::MemoryShutdown();
     }
 };
 

--- a/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
@@ -1,0 +1,367 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      FuzzTest harnesses for the Check-In message client path:
+ *      CheckinMessage::ParseCheckinMessagePayload and its caller
+ *      DefaultICDClientStorage::ProcessCheckInPayload.
+ *
+ *      A flat-buffer fuzzer makes very little progress here. The parser
+ *      accepts only payloads of exactly nonce(13) + counter(4) + appData(n) +
+ *      MIC(16) bytes, and ProcessCheckInPayload's kAppDataLength(6) work
+ *      buffer caps n at 2 -- so the whole accept window is 33..35 bytes and
+ *      everything else returns before any crypto runs. Past the length gates
+ *      sits an AES-CCM decrypt and an HMAC-derived nonce comparison, both of
+ *      which need the entry's key to satisfy.
+ *
+ *      So the harnesses below construct payloads with GenerateCheckinMessagePayload
+ *      under a known key and then let the fuzzer mutate them, rather than
+ *      asking the mutator to discover a valid MIC. That puts the counter
+ *      decode, the nonce recomputation and comparison, the appData memmove
+ *      and span narrowing, and (for ProcessCheckInPayload) the multi-entry
+ *      key-iteration loop over a fixed-size work buffer inside the reachable
+ *      set.
+ *
+ *      Three properties:
+ *        - ParseRejectsArbitraryPayload      -- unconstrained bytes; covers the
+ *          length/bounds arms ahead of the crypto, seeded with valid payloads
+ *          and with sizes on both sides of the accept window.
+ *        - ParseHandlesMutatedValidPayload   -- a valid payload with one
+ *          fuzzer-chosen byte overwritten; reaches the decrypt/nonce/appData
+ *          tail. appData sizes here exceed what ProcessCheckInPayload's work
+ *          buffer allows, so this is the only property that drives the
+ *          non-empty memmove.
+ *        - ProcessSearchesAllStoredEntries   -- the storage-level caller with
+ *          several stored entries, exercising the iterate-every-key loop and
+ *          the 6-byte work buffer at and past its appData limit.
+ *
+ *      Oracle: no sanitizer error, plus the API contracts that the callers
+ *      rely on -- on success the counter is the one that was encoded and
+ *      appData is narrowed to exactly the encoded application data; on
+ *      failure the call returns an error rather than reporting success.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <app/icd/client/DefaultICDClientStorage.h>
+#include <app/icd/client/ICDClientInfo.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/ScopedNodeId.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <lib/support/logging/Constants.h>
+#include <lib/support/logging/TextOnlyLogging.h>
+#include <protocols/secure_channel/CheckinMessage.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::Crypto;
+using namespace chip::Protocols::SecureChannel;
+using namespace fuzztest;
+
+constexpr size_t kKeyLength = sizeof(Symmetric128BitsKeyByteArray);
+
+// Application data that ParseCheckinMessagePayload can accept when the caller
+// supplies a work buffer larger than ProcessCheckInPayload's kAppDataLength.
+constexpr size_t kMaxParseAppDataSize = 32;
+
+void EnsureInitialized()
+{
+    static const bool sInitialized = [] {
+        VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+        // The storage layer logs a line per stored entry, which at fuzzing rates dominates
+        // both runtime and output volume.
+        Logging::SetLogFilter(Logging::kLogCategory_None);
+        return true;
+    }();
+    (void) sInitialized;
+}
+
+// Distinct key material per index so that a payload built for one entry does
+// not authenticate against another. Both the AES and HMAC handle for an entry
+// are derived from the same material, matching how SetKey provisions them.
+void FillKeyMaterial(uint8_t index, uint8_t (&out)[kKeyLength])
+{
+    for (size_t i = 0; i < kKeyLength; i++)
+    {
+        out[i] = static_cast<uint8_t>(index * 0x11u + i);
+    }
+}
+
+// Builds a Check-In payload under `index`'s key. Returns an empty vector when
+// the parameters cannot produce one, so callers can simply skip the iteration.
+std::vector<uint8_t> BuildPayload(uint8_t index, uint32_t counter, const std::vector<uint8_t> & appData)
+{
+    DefaultSessionKeystore keystore;
+
+    uint8_t material[kKeyLength];
+    FillKeyMaterial(index, material);
+
+    Symmetric128BitsKeyByteArray aesMaterial;
+    memcpy(aesMaterial, material, kKeyLength);
+    Symmetric128BitsKeyByteArray hmacMaterial;
+    memcpy(hmacMaterial, material, kKeyLength);
+
+    Aes128KeyHandle aesHandle;
+    Hmac128KeyHandle hmacHandle;
+    if (keystore.CreateKey(aesMaterial, aesHandle) != CHIP_NO_ERROR)
+    {
+        return {};
+    }
+    if (keystore.CreateKey(hmacMaterial, hmacHandle) != CHIP_NO_ERROR)
+    {
+        keystore.DestroyKey(aesHandle);
+        return {};
+    }
+
+    std::vector<uint8_t> payload(CheckinMessage::GetCheckinPayloadSize(appData.size()));
+    MutableByteSpan output(payload.data(), payload.size());
+
+    CHIP_ERROR err = CheckinMessage::GenerateCheckinMessagePayload(aesHandle, hmacHandle, counter,
+                                                                   ByteSpan(appData.data(), appData.size()), output);
+
+    keystore.DestroyKey(aesHandle);
+    keystore.DestroyKey(hmacHandle);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        return {};
+    }
+    payload.resize(output.size());
+    return payload;
+}
+
+// A handful of well-formed payloads plus sizes either side of the accept
+// window, so the mutator starts from inputs that already clear the length
+// gates instead of having to find a 33-byte shape on its own.
+std::vector<std::vector<uint8_t>> PayloadSeeds()
+{
+    std::vector<std::vector<uint8_t>> seeds;
+
+    for (uint8_t index = 0; index < 2; index++)
+    {
+        for (uint32_t counter : { 0u, 1u, 0x7FFFFFFFu, 0x80000000u, 0xFFFFFFFFu })
+        {
+            for (size_t appDataSize : { 0u, 1u, 2u, 3u })
+            {
+                std::vector<uint8_t> appData(appDataSize, 0xAB);
+                std::vector<uint8_t> payload = BuildPayload(index, counter, appData);
+                if (!payload.empty())
+                {
+                    seeds.push_back(std::move(payload));
+                }
+            }
+        }
+    }
+
+    // Boundary sizes around kMinPayloadSize that carry no valid MIC.
+    seeds.push_back({});
+    seeds.push_back(std::vector<uint8_t>(CheckinMessage::kMinPayloadSize - 1, 0x00));
+    seeds.push_back(std::vector<uint8_t>(CheckinMessage::kMinPayloadSize, 0x00));
+    seeds.push_back(std::vector<uint8_t>(CheckinMessage::kMinPayloadSize + 1, 0xFF));
+
+    return seeds;
+}
+
+// ---------------------------------------------------------------------------
+
+// Unconstrained bytes against the parser under a fixed key. Almost every input
+// is rejected before the crypto; the value is in covering which arm rejects it.
+void ParseRejectsArbitraryPayload(const std::vector<uint8_t> & payload)
+{
+    EnsureInitialized();
+
+    DefaultSessionKeystore keystore;
+
+    uint8_t material[kKeyLength];
+    FillKeyMaterial(0, material);
+
+    Symmetric128BitsKeyByteArray aesMaterial;
+    memcpy(aesMaterial, material, kKeyLength);
+    Symmetric128BitsKeyByteArray hmacMaterial;
+    memcpy(hmacMaterial, material, kKeyLength);
+
+    Aes128KeyHandle aesHandle;
+    Hmac128KeyHandle hmacHandle;
+    ASSERT_EQ(keystore.CreateKey(aesMaterial, aesHandle), CHIP_NO_ERROR);
+    ASSERT_EQ(keystore.CreateKey(hmacMaterial, hmacHandle), CHIP_NO_ERROR);
+
+    uint8_t appDataBuffer[sizeof(CounterType) + kMaxParseAppDataSize];
+    MutableByteSpan appData(appDataBuffer);
+    CounterType counter = 0;
+
+    CHIP_ERROR err = CheckinMessage::ParseCheckinMessagePayload(aesHandle, hmacHandle, ByteSpan(payload.data(), payload.size()),
+                                                                counter, appData);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        // A success implies the payload was well formed: appData must have been
+        // narrowed to exactly the application-data length the size arithmetic
+        // predicts, and must still sit inside the buffer that was handed in.
+        EXPECT_EQ(appData.size(), CheckinMessage::GetAppDataSize(ByteSpan(payload.data(), payload.size())));
+        EXPECT_LE(appData.size(), sizeof(appDataBuffer));
+        EXPECT_EQ(appData.data(), appDataBuffer);
+    }
+
+    keystore.DestroyKey(aesHandle);
+    keystore.DestroyKey(hmacHandle);
+}
+
+// A valid payload with one byte overwritten. Mutating a byte in the nonce, the
+// ciphertext or the MIC selects which of the post-length checks rejects it;
+// leaving the payload intact (when the mutation is a no-op) drives the success
+// tail including the appData memmove.
+void ParseHandlesMutatedValidPayload(uint32_t encodedCounter, const std::vector<uint8_t> & appDataIn, uint16_t mutationIndex,
+                                     uint8_t mutationValue)
+{
+    EnsureInitialized();
+
+    std::vector<uint8_t> payload = BuildPayload(0, encodedCounter, appDataIn);
+    if (payload.empty())
+    {
+        return;
+    }
+
+    const bool mutated = mutationIndex < payload.size() && payload[mutationIndex] != mutationValue;
+    if (mutationIndex < payload.size())
+    {
+        payload[mutationIndex] = mutationValue;
+    }
+
+    DefaultSessionKeystore keystore;
+
+    uint8_t material[kKeyLength];
+    FillKeyMaterial(0, material);
+
+    Symmetric128BitsKeyByteArray aesMaterial;
+    memcpy(aesMaterial, material, kKeyLength);
+    Symmetric128BitsKeyByteArray hmacMaterial;
+    memcpy(hmacMaterial, material, kKeyLength);
+
+    Aes128KeyHandle aesHandle;
+    Hmac128KeyHandle hmacHandle;
+    ASSERT_EQ(keystore.CreateKey(aesMaterial, aesHandle), CHIP_NO_ERROR);
+    ASSERT_EQ(keystore.CreateKey(hmacMaterial, hmacHandle), CHIP_NO_ERROR);
+
+    uint8_t appDataBuffer[sizeof(CounterType) + kMaxParseAppDataSize];
+    MutableByteSpan appData(appDataBuffer);
+    CounterType decodedCounter = 0;
+
+    CHIP_ERROR err = CheckinMessage::ParseCheckinMessagePayload(aesHandle, hmacHandle, ByteSpan(payload.data(), payload.size()),
+                                                                decodedCounter, appData);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        // An untouched payload must round-trip exactly.
+        if (!mutated)
+        {
+            EXPECT_EQ(decodedCounter, encodedCounter);
+            ASSERT_EQ(appData.size(), appDataIn.size());
+            EXPECT_EQ(memcmp(appData.data(), appDataIn.data(), appDataIn.size()), 0);
+        }
+        EXPECT_EQ(appData.size(), CheckinMessage::GetAppDataSize(ByteSpan(payload.data(), payload.size())));
+    }
+
+    keystore.DestroyKey(aesHandle);
+    keystore.DestroyKey(hmacHandle);
+}
+
+// The storage-level caller: several entries stored across distinct fabrics,
+// with a payload built for one of them. ProcessCheckInPayload has to walk every
+// stored key until one decrypts, using a kAppDataLength work buffer that is
+// smaller than what the parser alone accepts.
+void ProcessSearchesAllStoredEntries(uint8_t entryCount, uint8_t targetEntry, uint32_t encodedCounter,
+                                     const std::vector<uint8_t> & appDataIn, uint16_t mutationIndex, uint8_t mutationValue)
+{
+    EnsureInitialized();
+
+    // Keep the fabric count inside what the storage will accept and make sure
+    // the target names one of the entries actually stored.
+    const uint8_t entries = static_cast<uint8_t>(1 + (entryCount % 4));
+    const uint8_t target  = static_cast<uint8_t>(targetEntry % entries);
+
+    TestPersistentStorageDelegate clientInfoStore;
+    DefaultSessionKeystore keystore;
+    DefaultICDClientStorage storage;
+
+    ASSERT_EQ(storage.Init(&clientInfoStore, &keystore), CHIP_NO_ERROR);
+
+    for (uint8_t index = 0; index < entries; index++)
+    {
+        const FabricIndex fabricIndex = static_cast<FabricIndex>(index + 1);
+
+        uint8_t material[kKeyLength];
+        FillKeyMaterial(index, material);
+
+        ICDClientInfo clientInfo;
+        clientInfo.peer_node         = ScopedNodeId(static_cast<NodeId>(0x1000 + index), fabricIndex);
+        clientInfo.check_in_node     = clientInfo.peer_node;
+        clientInfo.start_icd_counter = encodedCounter;
+        clientInfo.offset            = 0;
+
+        ASSERT_EQ(storage.UpdateFabricList(fabricIndex), CHIP_NO_ERROR);
+        ASSERT_EQ(storage.SetKey(clientInfo, ByteSpan(material, kKeyLength)), CHIP_NO_ERROR);
+        ASSERT_EQ(storage.StoreEntry(clientInfo), CHIP_NO_ERROR);
+    }
+
+    std::vector<uint8_t> payload = BuildPayload(target, encodedCounter, appDataIn);
+    if (!payload.empty() && mutationIndex < payload.size())
+    {
+        payload[mutationIndex] = mutationValue;
+    }
+
+    ICDClientInfo matchedInfo;
+    CounterType decodedCounter = 0;
+    CHIP_ERROR err = storage.ProcessCheckInPayload(ByteSpan(payload.data(), payload.size()), matchedInfo, decodedCounter);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        // Only a payload whose application data fits the kAppDataLength work
+        // buffer alongside the counter can be accepted here at all.
+        EXPECT_LE(appDataIn.size(), DefaultICDClientStorage::kAppDataLength - sizeof(CounterType));
+    }
+
+    storage.Shutdown();
+}
+
+// ---------------------------------------------------------------------------
+
+FUZZ_TEST(ICDCheckInPW, ParseRejectsArbitraryPayload)
+    .WithDomains(Arbitrary<std::vector<uint8_t>>().WithSeeds(PayloadSeeds()).WithMaxSize(128));
+
+FUZZ_TEST(ICDCheckInPW, ParseHandlesMutatedValidPayload)
+    .WithDomains(Arbitrary<uint32_t>(), Arbitrary<std::vector<uint8_t>>().WithMaxSize(kMaxParseAppDataSize), Arbitrary<uint16_t>(),
+                 Arbitrary<uint8_t>());
+
+FUZZ_TEST(ICDCheckInPW, ProcessSearchesAllStoredEntries)
+    .WithDomains(Arbitrary<uint8_t>(), Arbitrary<uint8_t>(), Arbitrary<uint32_t>(),
+                 Arbitrary<std::vector<uint8_t>>().WithMaxSize(8), Arbitrary<uint16_t>(), Arbitrary<uint8_t>());
+
+} // namespace

--- a/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
@@ -172,6 +172,11 @@ std::vector<uint8_t> BuildPayload(uint8_t index, uint32_t counter, const std::ve
 // gates instead of having to find a 33-byte shape on its own.
 std::vector<std::vector<uint8_t>> PayloadSeeds()
 {
+    // Called while the FUZZ_TEST domains are registered, which happens before
+    // any property body runs -- so this, not the property, is the first thing
+    // to construct a keystore and must do the initialization itself.
+    EnsureInitialized();
+
     std::vector<std::vector<uint8_t>> seeds;
 
     for (uint8_t index = 0; index < 2; index++)

--- a/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
@@ -304,6 +304,13 @@ void ParseHandlesMutatedValidPayload(uint32_t encodedCounter, const std::vector<
     {
         EXPECT_NE(err, CHIP_NO_ERROR);
     }
+    else
+    {
+        // Conversely an untouched payload was generated under the same key the
+        // parser is given, so rejecting it is a defect. Without this a parser
+        // that always fails would satisfy every other assertion here.
+        ASSERT_EQ(err, CHIP_NO_ERROR);
+    }
 
     if (err == CHIP_NO_ERROR)
     {
@@ -375,6 +382,17 @@ void ProcessSearchesAllStoredEntries(uint8_t entryCount, uint8_t targetEntry, ui
     if (mutated || appDataIn.size() > DefaultICDClientStorage::kAppDataLength - sizeof(CounterType))
     {
         EXPECT_NE(err, CHIP_NO_ERROR);
+    }
+
+    else if (!payload.empty())
+    {
+        // An untouched payload whose application data fits the work buffer is
+        // valid for exactly one stored entry, so it must be found -- and must
+        // resolve to that entry rather than any other.
+        ASSERT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(decodedCounter, encodedCounter);
+        EXPECT_EQ(matchedInfo.peer_node,
+                  ScopedNodeId(static_cast<NodeId>(0x1000 + target), static_cast<FabricIndex>(target + 1)));
     }
 
     if (err == CHIP_NO_ERROR)

--- a/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
@@ -67,7 +67,11 @@
 
 #include <app/icd/client/DefaultICDClientStorage.h>
 #include <app/icd/client/ICDClientInfo.h>
+#include <crypto/CryptoBuildConfig.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
 #include <lib/core/CHIPError.h>
 #include <lib/core/ScopedNodeId.h>
 #include <lib/support/CHIPMem.h>
@@ -96,6 +100,11 @@ void EnsureInitialized()
 {
     static const bool sInitialized = [] {
         VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        // Fuzz binaries use gmock_main and so miss the unit-test main's PSA
+        // initialization; the backend must be initialized before any crypto runs.
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
+#endif
         // The storage layer logs a line per stored entry, which at fuzzing rates dominates
         // both runtime and output volume.
         Logging::SetLogFilter(Logging::kLogCategory_None);

--- a/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
@@ -234,6 +234,14 @@ void ParseRejectsArbitraryPayload(const std::vector<uint8_t> & payload)
     CHIP_ERROR err = CheckinMessage::ParseCheckinMessagePayload(aesHandle, hmacHandle, ByteSpan(payload.data(), payload.size()),
                                                                 counter, appData);
 
+    // A payload too short to hold nonce + counter + MIC, or one whose application
+    // data cannot fit the work buffer alongside the counter, can never be accepted.
+    if (payload.size() < CheckinMessage::kMinPayloadSize ||
+        payload.size() > CheckinMessage::kMinPayloadSize + kMaxParseAppDataSize)
+    {
+        EXPECT_NE(err, CHIP_NO_ERROR);
+    }
+
     if (err == CHIP_NO_ERROR)
     {
         // A success implies the payload was well formed: appData must have been
@@ -291,6 +299,13 @@ void ParseHandlesMutatedValidPayload(uint32_t encodedCounter, const std::vector<
     CHIP_ERROR err = CheckinMessage::ParseCheckinMessagePayload(aesHandle, hmacHandle, ByteSpan(payload.data(), payload.size()),
                                                                 decodedCounter, appData);
 
+    // Any byte actually changed invalidates the MIC, so the parse must fail. A
+    // mutated payload that still authenticates would itself be a finding.
+    if (mutated)
+    {
+        EXPECT_NE(err, CHIP_NO_ERROR);
+    }
+
     if (err == CHIP_NO_ERROR)
     {
         // An untouched payload must round-trip exactly.
@@ -346,6 +361,8 @@ void ProcessSearchesAllStoredEntries(uint8_t entryCount, uint8_t targetEntry, ui
     }
 
     std::vector<uint8_t> payload = BuildPayload(target, encodedCounter, appDataIn);
+    const bool mutated           = !payload.empty() && mutationIndex < payload.size() &&
+        payload[mutationIndex] != mutationValue;
     if (!payload.empty() && mutationIndex < payload.size())
     {
         payload[mutationIndex] = mutationValue;
@@ -355,10 +372,15 @@ void ProcessSearchesAllStoredEntries(uint8_t entryCount, uint8_t targetEntry, ui
     CounterType decodedCounter = 0;
     CHIP_ERROR err = storage.ProcessCheckInPayload(ByteSpan(payload.data(), payload.size()), matchedInfo, decodedCounter);
 
+    // A changed byte breaks the MIC, and application data larger than the
+    // kAppDataLength work buffer leaves alongside the counter cannot be accepted.
+    if (mutated || appDataIn.size() > DefaultICDClientStorage::kAppDataLength - sizeof(CounterType))
+    {
+        EXPECT_NE(err, CHIP_NO_ERROR);
+    }
+
     if (err == CHIP_NO_ERROR)
     {
-        // Only a payload whose application data fits the kAppDataLength work
-        // buffer alongside the counter can be accepted here at all.
         EXPECT_LE(appDataIn.size(), DefaultICDClientStorage::kAppDataLength - sizeof(CounterType));
     }
 

--- a/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
@@ -236,8 +236,7 @@ void ParseRejectsArbitraryPayload(const std::vector<uint8_t> & payload)
 
     // A payload too short to hold nonce + counter + MIC, or one whose application
     // data cannot fit the work buffer alongside the counter, can never be accepted.
-    if (payload.size() < CheckinMessage::kMinPayloadSize ||
-        payload.size() > CheckinMessage::kMinPayloadSize + kMaxParseAppDataSize)
+    if (payload.size() < CheckinMessage::kMinPayloadSize || payload.size() > CheckinMessage::kMinPayloadSize + kMaxParseAppDataSize)
     {
         EXPECT_NE(err, CHIP_NO_ERROR);
     }
@@ -361,8 +360,7 @@ void ProcessSearchesAllStoredEntries(uint8_t entryCount, uint8_t targetEntry, ui
     }
 
     std::vector<uint8_t> payload = BuildPayload(target, encodedCounter, appDataIn);
-    const bool mutated           = !payload.empty() && mutationIndex < payload.size() &&
-        payload[mutationIndex] != mutationValue;
+    const bool mutated           = !payload.empty() && mutationIndex < payload.size() && payload[mutationIndex] != mutationValue;
     if (!payload.empty() && mutationIndex < payload.size())
     {
         payload[mutationIndex] = mutationValue;

--- a/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
@@ -391,8 +391,7 @@ void ProcessSearchesAllStoredEntries(uint8_t entryCount, uint8_t targetEntry, ui
         // resolve to that entry rather than any other.
         ASSERT_EQ(err, CHIP_NO_ERROR);
         EXPECT_EQ(decodedCounter, encodedCounter);
-        EXPECT_EQ(matchedInfo.peer_node,
-                  ScopedNodeId(static_cast<NodeId>(0x1000 + target), static_cast<FabricIndex>(target + 1)));
+        EXPECT_EQ(matchedInfo.peer_node, ScopedNodeId(static_cast<NodeId>(0x1000 + target), static_cast<FabricIndex>(target + 1)));
     }
 
     if (err == CHIP_NO_ERROR)

--- a/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
+++ b/src/app/icd/client/tests/FuzzICDCheckInPW.cpp
@@ -60,6 +60,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <utility>
 #include <vector>
 
 #include <pw_fuzzer/fuzztest.h>
@@ -397,6 +398,14 @@ void ProcessSearchesAllStoredEntries(uint8_t entryCount, uint8_t targetEntry, ui
     if (err == CHIP_NO_ERROR)
     {
         EXPECT_LE(appDataIn.size(), DefaultICDClientStorage::kAppDataLength - sizeof(CounterType));
+    }
+
+    // SetKey imports two key handles per entry and Shutdown does not release
+    // them, so under a keystore with finite slots they would accumulate for the
+    // life of the run.
+    for (uint8_t index = 0; index < entries; index++)
+    {
+        EXPECT_EQ(storage.DeleteAllEntries(static_cast<FabricIndex>(index + 1)), CHIP_NO_ERROR);
     }
 
     storage.Shutdown();


### PR DESCRIPTION
#### Summary

Adds three pw_fuzzer/FuzzTest harnesses covering the ICD Check-In client path and the ICD Management cluster commands.

##### Problem

-   No fuzz target existed for any ICD parser or command handler.
-   A byte-oriented harness makes little progress here:
    -   **Narrow accept window**: `ParseCheckinMessagePayload` needs 33 bytes and `ProcessCheckInPayload`'s 6-byte work buffer caps application data at 2, so only 33-35 byte inputs reach the body.
    -   **Authenticated payload**: past the length checks the input must satisfy an AES-CCM decrypt and an HMAC-derived nonce comparison.

##### Solution

-   `fuzz-icd-check-in-pw` - `ParseCheckinMessagePayload` and `ProcessCheckInPayload`. Payloads are generated with `GenerateCheckinMessagePayload` under a known key and then mutated, so inputs clear both checks.
-   `fuzz-icd-check-in-handler-pw` - `CheckInHandler::OnMessageReceived`. Drives the received counter plus the `start_icd_counter` and `offset` stored in `ICDClientInfo`, which selects between the offset arithmetic, the duplicate check and the key-refresh threshold.
-   `fuzz-icd-management-cluster-pw` - `RegisterClient`, `UnregisterClient`, `StayActiveRequest` as decoded command structs via `ClusterTester`.
-   The `pw-fuzztest` builder now sets `chip_enable_icd_server` and `chip_enable_icd_checkin` so the last target is configured in.

##### Caveats

-   The ICD Management handlers compile only with the ICD server enabled, and `RegisterClient`/`UnregisterClient` also need the Check-In Protocol, so that target is conditioned on `chip_enable_icd_server`. A follow-up in `google/oss-fuzz` `build.sh` is needed for it to be fuzzed upstream; until then CI builds but does not fuzz it.
-   Enabling the ICD server changes the compiled configuration of every target in that build. All 28 were rebuilt, and PASE, CASE, WiFiPAF-endpoint, BDX-transfer-session and chip-cert re-run unchanged.
-   The access-control delegate grants nothing, so every subject resolves to non-admin and it is the `verificationKey` comparison that is driven. The administrator arm of `RegisterClient`/`UnregisterClient` needs access-control entries and is not reached.
-   `ICDManager.cpp` and `ICDConfigurationData.cpp` stay cold; they are timer- and event-driven and need a different harness.

#### Testing

1,000,000 runs per property (7 properties), no crashes or artifacts. Coverage from those runs, per binary:

| Files | Region | Branch |
| --- | --- | --- |
| `CheckinMessage.cpp`, `DefaultICDClientStorage.cpp` | 72.74% | 58.28% |
| `CheckInHandler.cpp`, `DefaultCheckInDelegate.cpp`, `RefreshKeySender.cpp` | 44.69% | 30.82% |
| `ICDManagementCluster.cpp`, `ICDMonitoringTable.cpp` | 71.43% | 54.73% |

`CheckinMessage.cpp` reaches 100% function and line coverage; `RegisterClient` and `UnregisterClient` reach 89% and 94% region respectively.


