### PR TITLE
DoorLock: implement UserType.ExpiringUser access expiry (5.2.6.18.8)

### DIFF
--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -3361,6 +3361,7 @@ endpoint 1 {
     ram      attribute wrongCodeEntryLimit default = 3;
     ram      attribute userCodeTemporaryDisableTime default = 10;
     ram      attribute requirePINforRemoteOperation default = 0;
+    ram      attribute expiringUserTimeout default = 0;
     callback attribute aliroReaderVerificationKey;
     callback attribute aliroReaderGroupIdentifier;
     callback attribute aliroReaderGroupSubIdentifier;

--- a/examples/lock-app/lock-common/lock-app.zap
+++ b/examples/lock-app/lock-common/lock-app.zap
@@ -6034,6 +6034,22 @@
               "reportableChange": 0
             },
             {
+              "name": "ExpiringUserTimeout",
+              "code": 53,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "AliroReaderVerificationKey",
               "code": 128,
               "mfgCode": null,

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -357,8 +357,8 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
                                              uint16_t userIndex, chip::FabricIndex creatorFabricIndex,
                                              chip::System::Clock::Timestamp currentTime)
 {
-    ExpiringUserFirstUseEntry * entry       = nullptr;
-    ExpiringUserFirstUseEntry * freeSlot     = nullptr;
+    ExpiringUserFirstUseEntry * entry    = nullptr;
+    ExpiringUserFirstUseEntry * freeSlot = nullptr;
     for (auto & candidate : endpointContext->expiringUserFirstUse)
     {
         if (candidate.valid && candidate.userIndex == userIndex)
@@ -378,8 +378,8 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
         // minutes *after the first use*, so this access itself is always granted.
         if (nullptr != freeSlot)
         {
-            freeSlot->valid            = true;
-            freeSlot->userIndex        = userIndex;
+            freeSlot->valid             = true;
+            freeSlot->userIndex         = userIndex;
             freeSlot->firstUseTimestamp = currentTime;
         }
         else
@@ -396,7 +396,7 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
     }
 
     uint16_t expiringUserTimeoutMinutes = 0;
-    auto status = Attributes::ExpiringUserTimeout::Get(endpointId, &expiringUserTimeoutMinutes);
+    auto status                         = Attributes::ExpiringUserTimeout::Get(endpointId, &expiringUserTimeoutMinutes);
     if (Status::Success != status)
     {
         ChipLogError(Zcl, "[checkExpiringUserAccess] Unable to read ExpiringUserTimeout attribute [status=%d]",
@@ -405,7 +405,8 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
         return true;
     }
 
-    auto expiresAt = entry->firstUseTimestamp + chip::System::Clock::Seconds32(static_cast<uint32_t>(expiringUserTimeoutMinutes) * 60);
+    auto expiresAt =
+        entry->firstUseTimestamp + chip::System::Clock::Seconds32(static_cast<uint32_t>(expiringUserTimeoutMinutes) * 60);
     if (currentTime < expiresAt)
     {
         // Still within the window granted by the first use. Per spec this times from the *first* use, so
@@ -413,15 +414,14 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
         return true;
     }
 
-    ChipLogProgress(Zcl,
-                    "ExpiringUserTimeout elapsed, disabling user [endpointId=%d,userIndex=%d,timeoutMinutes=%d]",
-                    endpointId, userIndex, expiringUserTimeoutMinutes);
+    ChipLogProgress(Zcl, "ExpiringUserTimeout elapsed, disabling user [endpointId=%d,userIndex=%d,timeoutMinutes=%d]", endpointId,
+                    userIndex, expiringUserTimeoutMinutes);
 
     // Persist the disabled status through the same path any other UserStatus change already uses, so it
     // survives a reboot even though the in-flight countdown itself does not (see the "Known limitation"
     // note on HandleRemoteLockOperation).
     modifyUser(endpointId, creatorFabricIndex, chip::kUndefinedNodeId, userIndex, NullNullable, NullNullable,
-              MakeNullable(UserStatusEnum::kOccupiedDisabled), NullNullable, NullNullable);
+               MakeNullable(UserStatusEnum::kOccupiedDisabled), NullNullable, NullNullable);
 
     entry->valid = false;
 

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -359,6 +359,7 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
 {
     ExpiringUserFirstUseEntry * entry    = nullptr;
     ExpiringUserFirstUseEntry * freeSlot = nullptr;
+    ExpiringUserFirstUseEntry * oldest   = nullptr;
     for (auto & candidate : endpointContext->expiringUserFirstUse)
     {
         if (candidate.valid && candidate.userIndex == userIndex)
@@ -366,32 +367,42 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
             entry = &candidate;
             break;
         }
-        if (!candidate.valid && freeSlot == nullptr)
+        if (!candidate.valid)
         {
-            freeSlot = &candidate;
+            if (freeSlot == nullptr)
+            {
+                freeSlot = &candidate;
+            }
+        }
+        else if (oldest == nullptr || candidate.firstUseTimestamp < oldest->firstUseTimestamp)
+        {
+            oldest = &candidate;
         }
     }
 
     if (nullptr == entry)
     {
         // First use: spec 5.2.6.18.8 -- the user has the ability to open the lock for ExpiringUserTimeout
-        // minutes *after the first use*, so this access itself is always granted.
-        if (nullptr != freeSlot)
+        // minutes *after the first use*, so this access itself is always granted. If the table is full,
+        // evict the oldest tracked entry (closest to its own expiry anyway) rather than leaving this user
+        // untracked -- an untracked ExpiringUser would never be disabled at all.
+        ExpiringUserFirstUseEntry * slot = (nullptr != freeSlot) ? freeSlot : oldest;
+        if (nullptr == slot)
         {
-            freeSlot->valid             = true;
-            freeSlot->userIndex         = userIndex;
-            freeSlot->firstUseTimestamp = currentTime;
+            // kDoorLockMaxTrackedExpiringUsers is 0, which never happens in practice; deny rather than
+            // grant untracked access if it somehow did.
+            return false;
         }
-        else
+        if (slot == oldest)
         {
-            // Tracking table exhausted (kDoorLockMaxTrackedExpiringUsers concurrent countdowns already in
-            // flight) -- access still granted per spec, but this user's expiry can't be timed, so it never
-            // gets disabled until some other pending entry frees up and this user is used again.
-            ChipLogError(Zcl,
-                         "[checkExpiringUserAccess] No free slot to track first use, ExpiringUserTimeout will "
-                         "not be enforced for this user until a slot frees up [endpointId=%d,userIndex=%d]",
-                         endpointId, userIndex);
+            ChipLogProgress(Zcl,
+                            "[checkExpiringUserAccess] Tracking table full, evicting oldest entry for "
+                            "userIndex=%d to track userIndex=%d [endpointId=%d]",
+                            oldest->userIndex, userIndex, endpointId);
         }
+        slot->valid             = true;
+        slot->userIndex         = userIndex;
+        slot->firstUseTimestamp = currentTime;
         return true;
     }
 
@@ -401,8 +412,9 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
     {
         ChipLogError(Zcl, "[checkExpiringUserAccess] Unable to read ExpiringUserTimeout attribute [status=%d]",
                      to_underlying(status));
-        // Can't evaluate expiry without the attribute; fail open rather than lock the user out on our own error.
-        return true;
+        // Can't evaluate expiry without the attribute; fail closed, consistent with how other attribute
+        // read failures are handled elsewhere in HandleRemoteLockOperation.
+        return false;
     }
 
     auto expiresAt =
@@ -419,11 +431,23 @@ bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberA
 
     // Persist the disabled status through the same path any other UserStatus change already uses, so it
     // survives a reboot even though the in-flight countdown itself does not (see the "Known limitation"
-    // note on HandleRemoteLockOperation).
-    modifyUser(endpointId, creatorFabricIndex, chip::kUndefinedNodeId, userIndex, NullNullable, NullNullable,
-               MakeNullable(UserStatusEnum::kOccupiedDisabled), NullNullable, NullNullable);
-
-    entry->valid = false;
+    // note on HandleRemoteLockOperation). The entry is only cleared once that actually succeeds -- if it
+    // fails, access must keep being denied on every subsequent attempt (this entry staying valid and
+    // already past expiresAt guarantees that), and the next attempt will retry the persist rather than
+    // silently reverting to "first use" and granting access again.
+    auto modifyStatus = modifyUser(endpointId, creatorFabricIndex, chip::kUndefinedNodeId, userIndex, NullNullable, NullNullable,
+                                   MakeNullable(UserStatusEnum::kOccupiedDisabled), NullNullable, NullNullable);
+    if (Status::Success != modifyStatus)
+    {
+        ChipLogError(Zcl,
+                     "[checkExpiringUserAccess] Failed to persist OccupiedDisabled, will retry on next access "
+                     "[endpointId=%d,userIndex=%d,status=%d]",
+                     endpointId, userIndex, to_underlying(modifyStatus));
+    }
+    else
+    {
+        entry->valid = false;
+    }
 
     return false;
 }

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -341,6 +341,93 @@ bool DoorLockServer::engageLockout(chip::EndpointId endpointId)
     return true;
 }
 
+void DoorLockServer::clearExpiringUserTracking(EmberAfDoorLockEndpointContext * endpointContext, uint16_t userIndex)
+{
+    for (auto & entry : endpointContext->expiringUserFirstUse)
+    {
+        if (entry.valid && entry.userIndex == userIndex)
+        {
+            entry.valid = false;
+            break;
+        }
+    }
+}
+
+bool DoorLockServer::checkExpiringUserAccess(chip::EndpointId endpointId, EmberAfDoorLockEndpointContext * endpointContext,
+                                             uint16_t userIndex, chip::FabricIndex creatorFabricIndex,
+                                             chip::System::Clock::Timestamp currentTime)
+{
+    ExpiringUserFirstUseEntry * entry       = nullptr;
+    ExpiringUserFirstUseEntry * freeSlot     = nullptr;
+    for (auto & candidate : endpointContext->expiringUserFirstUse)
+    {
+        if (candidate.valid && candidate.userIndex == userIndex)
+        {
+            entry = &candidate;
+            break;
+        }
+        if (!candidate.valid && freeSlot == nullptr)
+        {
+            freeSlot = &candidate;
+        }
+    }
+
+    if (nullptr == entry)
+    {
+        // First use: spec 5.2.6.18.8 -- the user has the ability to open the lock for ExpiringUserTimeout
+        // minutes *after the first use*, so this access itself is always granted.
+        if (nullptr != freeSlot)
+        {
+            freeSlot->valid            = true;
+            freeSlot->userIndex        = userIndex;
+            freeSlot->firstUseTimestamp = currentTime;
+        }
+        else
+        {
+            // Tracking table exhausted (kDoorLockMaxTrackedExpiringUsers concurrent countdowns already in
+            // flight) -- access still granted per spec, but this user's expiry can't be timed, so it never
+            // gets disabled until some other pending entry frees up and this user is used again.
+            ChipLogError(Zcl,
+                         "[checkExpiringUserAccess] No free slot to track first use, ExpiringUserTimeout will "
+                         "not be enforced for this user until a slot frees up [endpointId=%d,userIndex=%d]",
+                         endpointId, userIndex);
+        }
+        return true;
+    }
+
+    uint16_t expiringUserTimeoutMinutes = 0;
+    auto status = Attributes::ExpiringUserTimeout::Get(endpointId, &expiringUserTimeoutMinutes);
+    if (Status::Success != status)
+    {
+        ChipLogError(Zcl, "[checkExpiringUserAccess] Unable to read ExpiringUserTimeout attribute [status=%d]",
+                     to_underlying(status));
+        // Can't evaluate expiry without the attribute; fail open rather than lock the user out on our own error.
+        return true;
+    }
+
+    auto expiresAt = entry->firstUseTimestamp + chip::System::Clock::Seconds32(static_cast<uint32_t>(expiringUserTimeoutMinutes) * 60);
+    if (currentTime < expiresAt)
+    {
+        // Still within the window granted by the first use. Per spec this times from the *first* use, so
+        // the timestamp is not re-armed here.
+        return true;
+    }
+
+    ChipLogProgress(Zcl,
+                    "ExpiringUserTimeout elapsed, disabling user [endpointId=%d,userIndex=%d,timeoutMinutes=%d]",
+                    endpointId, userIndex, expiringUserTimeoutMinutes);
+
+    // Persist the disabled status through the same path any other UserStatus change already uses, so it
+    // survives a reboot even though the in-flight countdown itself does not (see the "Known limitation"
+    // note on HandleRemoteLockOperation).
+    modifyUser(endpointId, creatorFabricIndex, chip::kUndefinedNodeId, userIndex, NullNullable, NullNullable,
+              MakeNullable(UserStatusEnum::kOccupiedDisabled), NullNullable, NullNullable);
+
+    entry->valid = false;
+
+    return false;
+}
+
 bool DoorLockServer::GetAutoRelockTime(chip::EndpointId endpointId, uint32_t & autoRelockTime)
 {
     return GetAttribute(endpointId, Attributes::AutoRelockTime::Id, Attributes::AutoRelockTime::Get, autoRelockTime);
@@ -2017,6 +2104,15 @@ ClusterStatusCode DoorLockServer::createUser(chip::EndpointId endpointId, chip::
                     endpointId, creatorFabricIdx, userIndex, NullTerminated(newUserName).c_str(), newUserUniqueId,
                     to_underlying(newUserStatus), to_underlying(newUserType), to_underlying(newCredentialRule),
                     static_cast<unsigned int>(newTotalCredentials));
+
+    // This slot held Available (cleared) before this call, so no live ExpiringUser countdown should exist
+    // for it -- but a slot can be re-Added without an intervening ClearUser in some flows, so clear
+    // defensively rather than assume.
+    if (auto * endpointContext = getContext(endpointId))
+    {
+        clearExpiringUserTracking(endpointContext, userIndex);
+    }
+
     sendRemoteLockUserChange(endpointId, LockDataTypeEnum::kUserIndex, DataOperationTypeEnum::kAdd, sourceNodeId, creatorFabricIdx,
                              userIndex, userIndex);
 
@@ -2144,6 +2240,13 @@ Status DoorLockServer::clearUser(chip::EndpointId endpointId, chip::FabricIndex 
                                       nullptr, 0))
     {
         return Status::Failure;
+    }
+
+    // The slot may be reused by a different user later; don't let a stale first-use timestamp from this
+    // user leak onto whoever ends up at this index next.
+    if (auto * endpointContext = getContext(endpointId))
+    {
+        clearExpiringUserTracking(endpointContext, userIndex);
     }
 
     if (sendUserChangeEvent)
@@ -3690,6 +3793,19 @@ bool DoorLockServer::HandleRemoteLockOperation(chip::app::CommandHandler * comma
                             "Unable to perform remote lock operation: user is disabled [endpoint=%d, lock_op=%d, userIndex=%d]",
                             endpoint, to_underlying(opType), userIdx);
         });
+
+        // appclusters 5.2.6.18.8: an ExpiringUser may open the lock for ExpiringUserTimeout minutes after
+        // the first use of their credential, after which they SHALL be treated as OccupiedDisabled.
+        if (UserTypeEnum::kExpiringUser == user.userType)
+        {
+            VerifyOrExit(checkExpiringUserAccess(endpoint, endpointContext, userIdx, user.createdBy, currentTime), {
+                reason = OperationErrorEnum::kDisabledUserDenied;
+                ChipLogProgress(Zcl,
+                                "Unable to perform remote lock operation: ExpiringUser timeout elapsed "
+                                "[endpoint=%d, lock_op=%d, userIndex=%d]",
+                                endpoint, to_underlying(opType), userIdx);
+            });
+        }
     }
     else
     {

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -86,11 +86,31 @@ static constexpr size_t DOOR_LOCK_USER_NAME_BUFFER_SIZE =
 struct EmberAfPluginDoorLockCredentialInfo;
 struct EmberAfPluginDoorLockUserInfo;
 
+/**
+ * Bounds the number of ExpiringUser records this server can track a pending first-use timestamp for at
+ * once, per endpoint. Not a limit on NumberOfTotalUsersSupported -- most users are not UserType::kExpiringUser,
+ * so this only needs to cover those with a countdown actually in flight.
+ */
+static constexpr size_t kDoorLockMaxTrackedExpiringUsers = 16;
+
+/**
+ * Tracks when a UserType::kExpiringUser record was first successfully used, so HandleRemoteLockOperation
+ * can tell whether ExpiringUserTimeout has since elapsed. RAM-only, like the wrongCodeEntryAttempts/
+ * lockoutEndTimestamp state below it -- see the "Known limitation" note on HandleRemoteLockOperation.
+ */
+struct ExpiringUserFirstUseEntry
+{
+    bool valid = false;
+    uint16_t userIndex = 0;
+    chip::System::Clock::Timestamp firstUseTimestamp;
+};
+
 struct EmberAfDoorLockEndpointContext
 {
     chip::System::Clock::Timestamp lockoutEndTimestamp;
     int wrongCodeEntryAttempts;
     chip::app::Clusters::DoorLock::Delegate * delegate = nullptr;
+    ExpiringUserFirstUseEntry expiringUserFirstUse[kDoorLockMaxTrackedExpiringUsers];
 };
 
 /**
@@ -505,6 +525,21 @@ private:
     EmberAfDoorLockEndpointContext * getContext(chip::EndpointId endpointId);
 
     bool engageLockout(chip::EndpointId endpointId);
+
+    /**
+     * Implements the UserType::kExpiringUser access rule (spec 5.2.6.18.8) for a resolved user found by
+     * HandleRemoteLockOperation. Returns true if access should be granted. On first use, records the
+     * timestamp and grants access. On a later use, grants access if still within ExpiringUserTimeout
+     * minutes of that first use; once it has elapsed, denies access and persists UserStatus =
+     * OccupiedDisabled via modifyUser() so the disabled state itself survives a reboot even though the
+     * in-flight countdown does not.
+     */
+    bool checkExpiringUserAccess(chip::EndpointId endpointId, EmberAfDoorLockEndpointContext * endpointContext,
+                                 uint16_t userIndex, chip::FabricIndex creatorFabricIndex,
+                                 chip::System::Clock::Timestamp currentTime);
+
+    /** Clears any pending ExpiringUser first-use tracking for a user slot that is being freed or reused. */
+    void clearExpiringUserTracking(EmberAfDoorLockEndpointContext * endpointContext, uint16_t userIndex);
 
     static void sendClusterResponse(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                     chip::Protocols::InteractionModel::ClusterStatusCode status);

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -529,10 +529,14 @@ private:
     /**
      * Implements the UserType::kExpiringUser access rule (spec 5.2.6.18.8) for a resolved user found by
      * HandleRemoteLockOperation. Returns true if access should be granted. On first use, records the
-     * timestamp and grants access. On a later use, grants access if still within ExpiringUserTimeout
-     * minutes of that first use; once it has elapsed, denies access and persists UserStatus =
-     * OccupiedDisabled via modifyUser() so the disabled state itself survives a reboot even though the
-     * in-flight countdown does not.
+     * timestamp and grants access (evicting the oldest tracked entry if the table is full, rather than
+     * leaving this user untracked and so never disabled at all). On a later use, grants access if still
+     * within ExpiringUserTimeout minutes of that first use; once it has elapsed, or if the attribute can't
+     * be read to tell, denies access. On expiry it also persists UserStatus = OccupiedDisabled via
+     * modifyUser() so the disabled state itself survives a reboot even though the in-flight countdown does
+     * not -- the tracking entry is only cleared once that persist actually succeeds, so a failure there
+     * keeps denying (and retrying the persist) on every subsequent attempt instead of reverting to "first
+     * use" and granting again.
      */
     bool checkExpiringUserAccess(chip::EndpointId endpointId, EmberAfDoorLockEndpointContext * endpointContext, uint16_t userIndex,
                                  chip::FabricIndex creatorFabricIndex, chip::System::Clock::Timestamp currentTime);
@@ -808,7 +812,7 @@ struct EmberAfPluginDoorLockCredentialInfo
 #if DOOR_LOCK_USE_LOCAL_BUFFER
     chip::MutableByteSpan credentialData; /**< Credential data bytes. */
 #else
-    chip::ByteSpan credentialData;                  /**< Credential data bytes. */
+    chip::ByteSpan credentialData; /**< Credential data bytes. */
 #endif
     DlAssetSource creationSource;
     chip::FabricIndex createdBy; /**< Index of the fabric that created the user. */

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -100,7 +100,7 @@ static constexpr size_t kDoorLockMaxTrackedExpiringUsers = 16;
  */
 struct ExpiringUserFirstUseEntry
 {
-    bool valid = false;
+    bool valid         = false;
     uint16_t userIndex = 0;
     chip::System::Clock::Timestamp firstUseTimestamp;
 };
@@ -534,9 +534,8 @@ private:
      * OccupiedDisabled via modifyUser() so the disabled state itself survives a reboot even though the
      * in-flight countdown does not.
      */
-    bool checkExpiringUserAccess(chip::EndpointId endpointId, EmberAfDoorLockEndpointContext * endpointContext,
-                                 uint16_t userIndex, chip::FabricIndex creatorFabricIndex,
-                                 chip::System::Clock::Timestamp currentTime);
+    bool checkExpiringUserAccess(chip::EndpointId endpointId, EmberAfDoorLockEndpointContext * endpointContext, uint16_t userIndex,
+                                 chip::FabricIndex creatorFabricIndex, chip::System::Clock::Timestamp currentTime);
 
     /** Clears any pending ExpiringUser first-use tracking for a user slot that is being freed or reused. */
     void clearExpiringUserTracking(EmberAfDoorLockEndpointContext * endpointContext, uint16_t userIndex);

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -812,7 +812,7 @@ struct EmberAfPluginDoorLockCredentialInfo
 #if DOOR_LOCK_USE_LOCAL_BUFFER
     chip::MutableByteSpan credentialData; /**< Credential data bytes. */
 #else
-    chip::ByteSpan credentialData; /**< Credential data bytes. */
+    chip::ByteSpan credentialData;                  /**< Credential data bytes. */
 #endif
     DlAssetSource creationSource;
     chip::FabricIndex createdBy; /**< Index of the fabric that created the user. */


### PR DESCRIPTION
### Summary

`UserType.ExpiringUser` (Matter spec §5.2.6.18.8) was not implemented in `DoorLockServer`:
`HandleRemoteLockOperation` resolved a PIN to its user and only ever checked
`user.userStatus != UserStatusEnum::kOccupiedDisabled` before granting access — nothing armed a timer on
first use of an `ExpiringUser`'s credential, or re-checked elapsed time on later uses. A device declaring
this `UserType` was accepting access indefinitely, never disabling it after `ExpiringUserTimeout` minutes as
the spec requires.

This also surfaced a second, independent gap: `examples/lock-app` didn't expose `ExpiringUserTimeout` as an
attribute at all (`ZAP` config), so there was no way to even configure the feature end-to-end against the
reference example app.

**Fix, in `door-lock-server.{h,cpp}` only** (no change to `EmberAfPluginDoorLockUserInfo` or the app
callback contract, so no other app needs updating to keep building):

- Added a small bounded per-endpoint table (`EmberAfDoorLockEndpointContext::expiringUserFirstUse`,
  `kDoorLockMaxTrackedExpiringUsers = 16`) tracking the timestamp of a `ExpiringUser`'s first credential use
  — same "linear scan over a small bounded array" style already used elsewhere in this file
  (`findUserIndexByCredential`), and RAM-only, mirroring the existing wrong-code-lockout state
  (`lockoutEndTimestamp`/`wrongCodeEntryAttempts`) right next to it.
- `HandleRemoteLockOperation` now calls `checkExpiringUserAccess()` right after the existing
  `OccupiedDisabled` check, for users of type `ExpiringUser`: grants access and records the timestamp on
  first use; grants access without re-arming while still within `ExpiringUserTimeout` minutes of that first
  use; once elapsed, denies access and persists `UserStatus = OccupiedDisabled` through the existing private
  `modifyUser()` helper — the same path any other `UserStatus` change already goes through, so the
  *resulting* disabled state is durable across a reboot the same way any other user-record change is, even
  though the in-flight countdown itself is not (see "Known limitation" below).
- Table entries are cleared wherever a user slot is freed or reused (`clearUser`, the `SetUser` `Add` path
  in `createUser`), so a later, unrelated user placed at the same index can't inherit a stale timestamp.
- `examples/lock-app/lock-common/lock-app.zap`: added the missing `ExpiringUserTimeout` attribute
  (readable/writable, matching its Matter spec type `uint16`) so the example app can actually be configured
  to exercise this `UserType` at all.
- `examples/lock-app/lock-common/lock-app.matter`: updated.

**Known limitation:** the first-use timestamp lives in RAM, like the wrong-code lockout it mirrors — a
reboot between first use and expiry resets that user's countdown rather than continuing it. This is a
narrow window, and strictly better than the current total non-enforcement. Full persistence of the
in-flight countdown would require extending `EmberAfPluginDoorLockUserInfo` and every app's storage
callback; flagged as a larger, separate follow-up, not attempted here.

**Also known:** `UserStatus` transitions to `OccupiedDisabled` lazily, on the next access attempt after
`ExpiringUserTimeout` has elapsed, rather than via a proactive background timer the instant it elapses —
same approach the existing wrong-code lockout in this file already uses for its own timeout. The
access-denial behavior itself is correct either way; only the exact moment `GetUser` would report the
transition differs from an implementation using a background timer.

**Not included here:** `src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml`'s existing
`ExpiringUserTimeout` steps only read/write/range-check the attribute — no step actually waits out the
timeout and checks the resulting `UserStatus`, so certification doesn't catch this gap either. Happy to add
real behavior steps there (create an `ExpiringUser`, first use, `WaitForMs`, second use expecting
`FAILURE`, restore state) as a follow-up commit on this same PR if that's wanted — didn't want to touch the
certification suite unprompted in the same change as the implementation fix.

### Related issues

Fixes #73903

### Testing

Manually tested against a live commissioned device — not covered by an existing unit-test target (there is
no `src/app/clusters/door-lock-server/tests/`):

1. Built `examples/lock-app/linux` with this patch.
2. Commissioned it onto a real Matter controller (`ludovicboue/matterjs-server`'s WebSocket dashboard, which
   wraps `matter.js`).
3. Wrote `ExpiringUserTimeout = 1` (minute) — succeeds now (previously `UNSUPPORTED_ATTRIBUTE`, fixed by the
   `.zap` change).
4. `SetUser` (`userType = ExpiringUser`) + `SetCredential` (PIN).
5. `UnlockDoor` (first use) — granted, as expected.
6. Waited 75 real seconds (> the 1-minute timeout).
7. `UnlockDoor` again with the same PIN — **denied** (`Failure`), where before this patch it succeeded
   indefinitely.
8. `GetUser` afterward reports `userStatus = 3` (`OccupiedDisabled`), persisted.

Also re-verified no regression on the adjacent, already-correct `ScheduleRestrictedUser`/`WeekDaySchedule`
paths in `examples/lock-app/lock-common/src/LockEndpoint.cpp` (untouched by this patch, but sitting right
next to the edited code): zero-schedule user denied, a schedule window covering the current time granted, a
window that doesn't cover it denied — all still exactly as before this patch.

Full raw logs (commissioning, the fixed attribute write, the before/after unlock sequence, `chip-lock-app`'s
own log lines including `ExpiringUserTimeout elapsed, disabling user` and `modifyUser` persisting
`userStatus=3`): https://gist.github.com/lboue/c8b91c1f420df12e16589980ade6e88c
