### PR TITLE
[ULD] Parse DNS UPDATE responses for ULD

### DIFF
--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -212,7 +212,7 @@ private:
     void Report(const char * prefix, const chip::Dnssd::BytesRange & data)
     {
         MdnsExample::PacketReporter reporter(prefix, data);
-        if (!chip::Dnssd::ParsePacket(data, &reporter))
+        if (!chip::Dnssd::ParseMdnsPacket(data, &reporter))
         {
             printf("INVALID PACKET!!!!!!\n");
         }

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -137,7 +137,7 @@ public:
         Report("QUERY: ", data);
 
         mCurrentSource = info;
-        if (!chip::Dnssd::ParsePacket(data, this))
+        if (!chip::Dnssd::ParseMdnsPacket(data, this))
         {
             printf("Parsing failure may result in reply failure!\n");
         }
@@ -171,7 +171,7 @@ private:
     void Report(const char * prefix, const chip::Dnssd::BytesRange & data)
     {
         MdnsExample::PacketReporter reporter(prefix, data);
-        if (!chip::Dnssd::ParsePacket(data, &reporter))
+        if (!chip::Dnssd::ParseMdnsPacket(data, &reporter))
         {
             printf("INVALID PACKET!!!!!!\n");
         }

--- a/examples/minimal-mdns/tester.cpp
+++ b/examples/minimal-mdns/tester.cpp
@@ -164,7 +164,7 @@ private:
     void Report(const char * prefix, const chip::Dnssd::BytesRange & data)
     {
         MdnsExample::PacketReporter reporter(prefix, data);
-        if (!chip::Dnssd::ParsePacket(data, &reporter))
+        if (!chip::Dnssd::ParseMdnsPacket(data, &reporter))
         {
             printf("INVALID PACKET!!!!!!\n");
         }

--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -318,7 +318,7 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
     mNodeData.Set<Dnssd::CommissionNodeData>();
     mDnsPacket = chip::Dnssd::BytesRange(payload.data(), payload.data() + payload.size());
 
-    if (!chip::Dnssd::ParsePacket(mDnsPacket, this))
+    if (!chip::Dnssd::ParseMdnsPacket(mDnsPacket, this))
     {
         ChipLogError(Controller, "Failed to parse joiner mDNS announcement");
         return;

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -332,7 +332,7 @@ void AdvertiserMinMdns::OnMdnsPacketData(const BytesRange & data, const chip::In
 #endif
 
     mCurrentSource = info;
-    if (!ParsePacket(data, this))
+    if (!ParseMdnsPacket(data, this))
     {
         ChipLogError(Discovery, "Failed to parse mDNS query");
 #if CHIP_MINMDNS_HIGH_VERBOSITY

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -239,7 +239,7 @@ void PacketParser::ParseSrvRecords(const BytesRange & packet)
     mParsingState = RecordParsingState::kSrvInitialization;
     mPacketRange  = packet;
 
-    if (!ParsePacket(packet, this))
+    if (!ParseMdnsPacket(packet, this))
     {
         ChipLogError(Discovery, "DNSSD packet parsing failed (for SRV records)");
     }
@@ -255,7 +255,7 @@ void PacketParser::ParseNonSrvRecords(Inet::InterfaceId interface, const BytesRa
     mPacketRange  = packet;
     mInterfaceId  = interface;
 
-    if (!ParsePacket(packet, this))
+    if (!ParseMdnsPacket(packet, this))
     {
         ChipLogError(Discovery, "DNSSD packet parsing failed (for non-srv records)");
     }

--- a/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
+++ b/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
@@ -228,7 +228,7 @@ public:
                chip::Inet::InterfaceId interface) override
     {
         mPacketData = chip::Dnssd::BytesRange(data->Start(), data->Start() + data->TotalLength());
-        chip::Dnssd::ParsePacket(mPacketData, this);
+        chip::Dnssd::ParseMdnsPacket(mPacketData, this);
         if (mHeaderFound)
         {
             TestGotAllExpectedPackets();

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsing.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsing.cpp
@@ -59,7 +59,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
     BytesRange packet(data, data + len);
     FuzzDelegate delegate(packet);
 
-    chip::Dnssd::ParsePacket(packet, &delegate);
+    chip::Dnssd::ParseMdnsPacket(packet, &delegate);
 
     return 0;
 }

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsingPW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsingPW.cpp
@@ -61,7 +61,7 @@ void PacketParserFuzz(const std::vector<std::uint8_t> & bytes)
     BytesRange packet(bytes.data(), bytes.data() + bytes.size());
     FuzzDelegate delegate(packet);
 
-    chip::Dnssd::ParsePacket(packet, &delegate);
+    chip::Dnssd::ParseMdnsPacket(packet, &delegate);
 }
 
 FUZZ_TEST(MinimalmDNS, PacketParserFuzz).WithDomains(Arbitrary<std::vector<uint8_t>>());

--- a/src/lib/dnssd/minimal_mdns/tests/FuzzQueryResponderPW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzQueryResponderPW.cpp
@@ -137,7 +137,7 @@ private:
         // rejects would mean the builder emitted something it cannot itself read.
         NullParserDelegate delegate;
         const BytesRange reply(data->Start(), data->Start() + data->DataLength());
-        EXPECT_TRUE(ParsePacket(reply, &delegate));
+        EXPECT_TRUE(ParseMdnsPacket(reply, &delegate));
         return CHIP_NO_ERROR;
     }
 
@@ -329,7 +329,7 @@ void RespondToQueryNoCorruption(const std::vector<uint8_t> & queryPacket)
 
     const BytesRange packet(queryPacket.data(), queryPacket.data() + queryPacket.size());
     RespondingDelegate delegate(sender, source);
-    (void) ParsePacket(packet, &delegate);
+    (void) ParseMdnsPacket(packet, &delegate);
 }
 
 FUZZ_TEST(QueryResponderPW, RespondToQueryNoCorruption)

--- a/src/lib/dnssd/uld/BUILD.gn
+++ b/src/lib/dnssd/uld/BUILD.gn
@@ -23,11 +23,15 @@ source_set("uld") {
     "OptRecord.h",
     "Sig0Record.h",
     "UpdateBuilder.h",
+    "UpdateResponse.cpp",
+    "UpdateResponse.h",
   ]
 
   public_deps = [
+    "${chip_root}/src/crypto",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/dnssd/wire",
+    "${chip_root}/src/lib/dnssd/wire:reader",
     "${chip_root}/src/lib/dnssd/wire/records",
     "${chip_root}/src/lib/support",
   ]

--- a/src/lib/dnssd/uld/BUILD.gn
+++ b/src/lib/dnssd/uld/BUILD.gn
@@ -35,4 +35,6 @@ source_set("uld") {
     "${chip_root}/src/lib/dnssd/wire/records",
     "${chip_root}/src/lib/support",
   ]
+
+  cflags = [ "-Wconversion" ]
 }

--- a/src/lib/dnssd/uld/KeyRecord.cpp
+++ b/src/lib/dnssd/uld/KeyRecord.cpp
@@ -16,6 +16,11 @@
  */
 
 #include <lib/dnssd/uld/KeyRecord.h>
+
+#include <algorithm>
+#include <cstring>
+
+#include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
 
 namespace chip {
@@ -24,26 +29,33 @@ namespace Uld {
 
 bool KeyResourceRecord::WriteData(RecordWriter & out) const
 {
-    if (mPublicKey.size() != kP256RawPublicKeySize)
-    {
-        return false;
-    }
+    static_assert(Crypto::kP256_PublicKey_Length == kP256RawPublicKeySize + 1);
+    VerifyOrReturnValue(mPublicKey.IsUncompressed(), false);
 
     out.Put16(kKeyFlags).Put8(kKeyProtocolDnssec).Put8(kKeyAlgorithmEcdsaP256);
-    out.Writer().Put(mPublicKey.data(), mPublicKey.size());
+    out.Writer().Put(mPublicKey.ConstBytes() + 1, kP256RawPublicKeySize);
     return out.Fit();
 }
 
-CHIP_ERROR KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey)
+CHIP_ERROR KeyResourceRecord::Parse(ByteSpan rdata, Crypto::P256PublicKey & publicKey)
 {
-    constexpr uint8_t kUncompressedPointPrefix = 0x04;
-    constexpr size_t kUncompressedPointSize    = kP256RawPublicKeySize + 1;
+    static_assert(Crypto::kP256_PublicKey_Length == kP256RawPublicKeySize + 1);
+    // KEY RDATA prefix: flags (u16) | protocol (u8) | algorithm (u8).
+    constexpr size_t kKeyMetadataSize = sizeof(uint16_t) + sizeof(uint8_t) + sizeof(uint8_t);
 
-    VerifyOrReturnError(uncompressedPoint.size() == kUncompressedPointSize, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(uncompressedPoint[0] == kUncompressedPointPrefix, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(outRawKey.size() >= kP256RawPublicKeySize, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(rdata.size() == kKeyMetadataSize + kP256RawPublicKeySize, CHIP_ERROR_INVALID_ARGUMENT);
 
-    return CopySpanToMutableSpan(uncompressedPoint.SubSpan(1), outRawKey);
+    const uint8_t * cursor = rdata.data();
+    // Verify the validity of the Key metadata.
+    VerifyOrReturnError(Encoding::BigEndian::Read16(cursor) == kKeyFlags, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(*cursor++ == kKeyProtocolDnssec, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(*cursor++ == kKeyAlgorithmEcdsaP256, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(std::any_of(cursor, rdata.end(), [](uint8_t value) { return value != 0; }), CHIP_ERROR_INVALID_ARGUMENT);
+
+    constexpr uint8_t kUncompressedPointMarker = 0x04;
+    publicKey.Bytes()[0]                       = kUncompressedPointMarker;
+    memcpy(publicKey.Bytes() + 1, cursor, kP256RawPublicKeySize);
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Uld

--- a/src/lib/dnssd/uld/KeyRecord.cpp
+++ b/src/lib/dnssd/uld/KeyRecord.cpp
@@ -32,8 +32,12 @@ bool KeyResourceRecord::WriteData(RecordWriter & out) const
     static_assert(Crypto::kP256_PublicKey_Length == kP256RawPublicKeySize + 1);
     VerifyOrReturnValue(mPublicKey.IsUncompressed(), false);
 
+    const uint8_t * rawBegin = mPublicKey.ConstBytes() + 1;
+    const uint8_t * rawEnd   = rawBegin + kP256RawPublicKeySize;
+    VerifyOrReturnValue(std::any_of(rawBegin, rawEnd, [](uint8_t value) { return value != 0; }), false);
+
     out.Put16(kKeyFlags).Put8(kKeyProtocolDnssec).Put8(kKeyAlgorithmEcdsaP256);
-    out.Writer().Put(mPublicKey.ConstBytes() + 1, kP256RawPublicKeySize);
+    out.Writer().Put(rawBegin, kP256RawPublicKeySize);
     return out.Fit();
 }
 

--- a/src/lib/dnssd/uld/KeyRecord.cpp
+++ b/src/lib/dnssd/uld/KeyRecord.cpp
@@ -49,11 +49,14 @@ CHIP_ERROR KeyResourceRecord::Parse(ByteSpan rdata, Crypto::P256PublicKey & publ
 
     VerifyOrReturnError(rdata.size() == kKeyMetadataSize + kP256RawPublicKeySize, CHIP_ERROR_INVALID_ARGUMENT);
 
-    const uint8_t * cursor = rdata.data();
-    // Verify the validity of the Key metadata.
-    VerifyOrReturnError(Encoding::BigEndian::Read16(cursor) == kKeyFlags, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(*cursor++ == kKeyProtocolDnssec, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(*cursor++ == kKeyAlgorithmEcdsaP256, CHIP_ERROR_INVALID_ARGUMENT);
+    const uint8_t * cursor  = rdata.data();
+    const uint16_t flags    = Encoding::BigEndian::Read16(cursor);
+    const uint8_t protocol  = *cursor++;
+    const uint8_t algorithm = *cursor++;
+
+    VerifyOrReturnError(flags == kKeyFlags, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(protocol == kKeyProtocolDnssec, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(algorithm == kKeyAlgorithmEcdsaP256, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(std::any_of(cursor, rdata.end(), [](uint8_t value) { return value != 0; }), CHIP_ERROR_INVALID_ARGUMENT);
 
     constexpr uint8_t kUncompressedPointMarker = 0x04;

--- a/src/lib/dnssd/uld/KeyRecord.cpp
+++ b/src/lib/dnssd/uld/KeyRecord.cpp
@@ -29,7 +29,7 @@ namespace Uld {
 
 bool KeyResourceRecord::WriteData(RecordWriter & out) const
 {
-    // The PublicKeyLenght should match kP256RawPublicKeySize + 1 byte for the `Uncompressed Marker`
+    // The public key length should match kP256RawPublicKeySize + 1 byte for the uncompressed point marker.
     static_assert(Crypto::kP256_PublicKey_Length == kP256RawPublicKeySize + 1);
     VerifyOrReturnValue(mPublicKey.IsUncompressed(), false);
 

--- a/src/lib/dnssd/uld/KeyRecord.cpp
+++ b/src/lib/dnssd/uld/KeyRecord.cpp
@@ -29,9 +29,11 @@ namespace Uld {
 
 bool KeyResourceRecord::WriteData(RecordWriter & out) const
 {
+    // The PublicKeyLenght should match kP256RawPublicKeySize + 1 byte for the `Uncompressed Marker`
     static_assert(Crypto::kP256_PublicKey_Length == kP256RawPublicKeySize + 1);
     VerifyOrReturnValue(mPublicKey.IsUncompressed(), false);
 
+    // +1 to skip the kUncompressedPointMarker
     const uint8_t * rawBegin = mPublicKey.ConstBytes() + 1;
     const uint8_t * rawEnd   = rawBegin + kP256RawPublicKeySize;
     VerifyOrReturnValue(std::any_of(rawBegin, rawEnd, [](uint8_t value) { return value != 0; }), false);

--- a/src/lib/dnssd/uld/KeyRecord.h
+++ b/src/lib/dnssd/uld/KeyRecord.h
@@ -58,7 +58,7 @@ protected:
     bool WriteData(RecordWriter & out) const override;
 
 private:
-    const Crypto::P256PublicKey & mPublicKey;
+    Crypto::P256PublicKey mPublicKey;
 };
 
 } // namespace Uld

--- a/src/lib/dnssd/uld/KeyRecord.h
+++ b/src/lib/dnssd/uld/KeyRecord.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPError.h>
 #include <lib/dnssd/uld/Constants.h>
 #include <lib/dnssd/wire/records/ResourceRecord.h>
@@ -29,7 +30,8 @@ namespace Uld {
  * @brief DNS KEY resource record (RFC 2535 / RFC 6605).
  *
  * RDATA: flags(2) | protocol(1) | algorithm(1) | public_key(64).
- * @p publicKey is the 64-byte raw X||Y material (no 0x04 prefix).
+ * @p publicKey is an uncompressed P-256 public key. The 0x04 point prefix is
+ * omitted from the encoded RDATA.
  */
 class KeyResourceRecord : public ResourceRecord
 {
@@ -40,24 +42,23 @@ public:
     // DNSKEY RR protocol value for DNSSEC (RFC 4034).
     static constexpr uint8_t kKeyProtocolDnssec = 3;
 
-    KeyResourceRecord(const FullQName & name, ByteSpan publicKey) : ResourceRecord(QType::KEY, name), mPublicKey(publicKey) {}
+    KeyResourceRecord(const FullQName & name, const Crypto::P256PublicKey & publicKey) :
+        ResourceRecord(QType::KEY, name), mPublicKey(publicKey)
+    {}
 
-    ByteSpan GetPublicKey() const { return mPublicKey; }
+    const Crypto::P256PublicKey & GetPublicKey() const { return mPublicKey; }
 
     /**
-     * @brief Copies X||Y after checking uncompressed-point length (65) and 0x04 prefix.
-     * Does not validate coordinates or curve membership.
-     * @return CHIP_NO_ERROR on success; CHIP_ERROR_INVALID_ARGUMENT if length/prefix
-     *         checks fail; CHIP_ERROR_BUFFER_TOO_SMALL if @p outRawKey is smaller than
-     *         kP256RawPublicKeySize.
+     * Parses KEY RDATA (RFC 2535 / RFC 6605) and reconstructs an uncompressed
+     * P-256 public key.
      */
-    static CHIP_ERROR ExtractRawP256PublicKey(ByteSpan uncompressedPoint, MutableByteSpan outRawKey);
+    static CHIP_ERROR Parse(ByteSpan rdata, Crypto::P256PublicKey & publicKey);
 
 protected:
     bool WriteData(RecordWriter & out) const override;
 
 private:
-    ByteSpan mPublicKey;
+    const Crypto::P256PublicKey & mPublicKey;
 };
 
 } // namespace Uld

--- a/src/lib/dnssd/uld/KeyRecord.h
+++ b/src/lib/dnssd/uld/KeyRecord.h
@@ -50,7 +50,9 @@ public:
 
     /**
      * Parses KEY RDATA (RFC 2535 / RFC 6605) and reconstructs an uncompressed
-     * P-256 public key.
+     * P-256 public key. Only the RDATA length, metadata, and nonzero key
+     * material are checked; the X||Y coordinates are not validated as a point
+     * on the curve.
      */
     static CHIP_ERROR Parse(ByteSpan rdata, Crypto::P256PublicKey & publicKey);
 

--- a/src/lib/dnssd/uld/UpdateResponse.cpp
+++ b/src/lib/dnssd/uld/UpdateResponse.cpp
@@ -1,0 +1,99 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/dnssd/uld/UpdateResponse.h>
+
+#include <lib/dnssd/uld/KeyRecord.h>
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+CHIP_ERROR UpdateResponse::Parse(ByteSpan packet)
+{
+    mParseError   = CHIP_NO_ERROR;
+    mMessageId    = 0;
+    mResponseCode = 0;
+    mOptSeen      = false;
+    mKey.reset();
+
+    VerifyOrReturnError(packet.size() >= HeaderRef::kSizeBytes, CHIP_ERROR_INVALID_ARGUMENT);
+
+    const BytesRange packetData = BytesRange::BufferWithSize(packet.data(), packet.size());
+    VerifyOrReturnError(ParseDnsPacket(packetData, this), CHIP_ERROR_INVALID_ARGUMENT);
+    return mParseError;
+}
+
+void UpdateResponse::OnHeader(ConstHeaderRef & header)
+{
+    const BitPackedFlags flags = header.GetFlags();
+    if (!flags.IsResponse() || (flags.GetOpcode() != Opcode::kUpdate))
+    {
+        mParseError = CHIP_ERROR_INVALID_ARGUMENT;
+        return;
+    }
+
+    mMessageId    = header.GetMessageId();
+    mResponseCode = flags.GetResponseCodeBits();
+}
+
+void UpdateResponse::OnResource(ResourceType type, const ResourceData & data)
+{
+    VerifyOrReturn(mParseError == CHIP_NO_ERROR);
+
+    if (data.GetType() == QType::OPT)
+    {
+        if ((type != ResourceType::kAdditional) || mOptSeen)
+        {
+            mParseError = CHIP_ERROR_INVALID_ARGUMENT;
+            return;
+        }
+        mOptSeen = true;
+
+        // RFC 6891: OPT TTL = EXTENDED-RCODE (8) | VERSION (8) | flags (16).
+        // 12-bit RCODE = (EXTENDED-RCODE << headerRcodeBitWidth) | header RCODE (4).
+        constexpr uint8_t kOptTtlExtendedRcodeShift = 24;
+        constexpr uint8_t kOptTtlExtendedRcodeMask  = 0xFF;
+        constexpr uint8_t kHeaderRcodeBitWidth      = 4;
+
+        const uint16_t extendedResponseCode =
+            static_cast<uint16_t>((data.GetTtlSeconds() >> kOptTtlExtendedRcodeShift) & kOptTtlExtendedRcodeMask);
+        mResponseCode = static_cast<uint16_t>((extendedResponseCode << kHeaderRcodeBitWidth) | mResponseCode);
+        return;
+    }
+
+    if (data.GetType() == QType::KEY)
+    {
+        if ((type == ResourceType::kAnswer) || mKey.has_value())
+        {
+            mParseError = CHIP_ERROR_INVALID_ARGUMENT;
+            return;
+        }
+
+        Crypto::P256PublicKey publicKey;
+        mParseError = KeyResourceRecord::Parse(data.GetData().AsByteSpan(), publicKey);
+        if (mParseError == CHIP_NO_ERROR)
+        {
+            mKey = publicKey;
+        }
+    }
+}
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/UpdateResponse.cpp
+++ b/src/lib/dnssd/uld/UpdateResponse.cpp
@@ -35,7 +35,18 @@ CHIP_ERROR UpdateResponse::Parse(ByteSpan packet)
     VerifyOrReturnError(packet.size() >= HeaderRef::kSizeBytes, CHIP_ERROR_INVALID_ARGUMENT);
 
     const BytesRange packetData = BytesRange::BufferWithSize(packet.data(), packet.size());
-    VerifyOrReturnError(ParseDnsPacket(packetData, this), CHIP_ERROR_INVALID_ARGUMENT);
+    if (!ParseDnsPacket(packetData, this))
+    {
+        mParseError = CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (mParseError != CHIP_NO_ERROR)
+    {
+        mMessageId    = 0;
+        mResponseCode = 0;
+        mKey.reset();
+    }
+
     return mParseError;
 }
 
@@ -77,17 +88,12 @@ void UpdateResponse::OnResource(ResourceType type, const ResourceData & data)
         return;
     }
 
-    if (data.GetType() == QType::KEY)
+    // RFC 9665 section 3.3.5: an SRP requester must not validate the RRs a registrar copies
+    // into a response, so a KEY that does not parse is ignored rather than failing the parse.
+    if ((data.GetType() == QType::KEY) && !mKey.has_value())
     {
-        if ((type == ResourceType::kAnswer) || mKey.has_value())
-        {
-            mParseError = CHIP_ERROR_INVALID_ARGUMENT;
-            return;
-        }
-
         Crypto::P256PublicKey publicKey;
-        mParseError = KeyResourceRecord::Parse(data.GetData().AsByteSpan(), publicKey);
-        if (mParseError == CHIP_NO_ERROR)
+        if (KeyResourceRecord::Parse(data.GetData().AsByteSpan(), publicKey) == CHIP_NO_ERROR)
         {
             mKey = publicKey;
         }

--- a/src/lib/dnssd/uld/UpdateResponse.h
+++ b/src/lib/dnssd/uld/UpdateResponse.h
@@ -1,0 +1,63 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CHIPError.h>
+#include <lib/dnssd/wire/Parser.h>
+#include <lib/support/Span.h>
+
+namespace chip {
+namespace Dnssd {
+namespace Uld {
+
+/**
+ * Parses a DNS UPDATE response and exposes ULD-specific response data.
+ */
+class UpdateResponse : private ParserDelegate
+{
+public:
+    /**
+     * Parses a complete DNS UPDATE response.
+     *
+     * @return CHIP_NO_ERROR on success or CHIP_ERROR_INVALID_ARGUMENT if the
+     *         packet or a recognized ULD record is malformed.
+     */
+    CHIP_ERROR Parse(ByteSpan packet);
+
+    uint16_t GetMessageId() const { return mMessageId; }
+    uint16_t GetResponseCode() const { return mResponseCode; }
+    const std::optional<Crypto::P256PublicKey> & GetKey() const { return mKey; }
+
+private:
+    void OnHeader(ConstHeaderRef & header) override;
+    void OnQuery(const QueryData &) override {}
+    void OnResource(ResourceType type, const ResourceData & data) override;
+
+    CHIP_ERROR mParseError = CHIP_NO_ERROR;
+    uint16_t mMessageId    = 0;
+    uint16_t mResponseCode = 0;
+    bool mOptSeen          = false;
+    std::optional<Crypto::P256PublicKey> mKey;
+};
+
+} // namespace Uld
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/uld/UpdateResponse.h
+++ b/src/lib/dnssd/uld/UpdateResponse.h
@@ -38,12 +38,15 @@ public:
      * Parses a complete DNS UPDATE response.
      *
      * @return CHIP_NO_ERROR on success or CHIP_ERROR_INVALID_ARGUMENT if the
-     *         packet or a recognized ULD record is malformed.
+     *         DNS packet, UPDATE response header, or OPT record is malformed.
      */
     CHIP_ERROR Parse(ByteSpan packet);
 
     uint16_t GetMessageId() const { return mMessageId; }
     uint16_t GetResponseCode() const { return mResponseCode; }
+
+    // Returns the first KEY with decodable RDATA. Per RFC 9665 section 3.3.5,
+    // invalid KEY records in a response are ignored rather than failing Parse().
     const std::optional<Crypto::P256PublicKey> & GetKey() const { return mKey; }
 
 private:

--- a/src/lib/dnssd/uld/tests/BUILD.gn
+++ b/src/lib/dnssd/uld/tests/BUILD.gn
@@ -26,6 +26,7 @@ chip_test_suite("tests") {
     "TestOptRecord.cpp",
     "TestSig0Record.cpp",
     "TestUpdateBuilder.cpp",
+    "TestUpdateResponse.cpp",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/lib/dnssd/uld/tests/TestKeyRecord.cpp
+++ b/src/lib/dnssd/uld/tests/TestKeyRecord.cpp
@@ -35,12 +35,9 @@ TEST(TestKeyRecord, WritesFlagsProtocolAlgorithmAndRawKey)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[256];
-    uint8_t rawKey[kP256RawPublicKeySize];
 
-    for (size_t i = 0; i < sizeof(rawKey); i++)
-    {
-        rawKey[i] = static_cast<uint8_t>(i);
-    }
+    Crypto::P256Keypair keypair;
+    ASSERT_EQ(keypair.Initialize(Crypto::ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     HeaderRef header(headerBuffer);
     header.Clear();
@@ -48,7 +45,7 @@ TEST(TestKeyRecord, WritesFlagsProtocolAlgorithmAndRawKey)
     BufferWriter output(dataBuffer, sizeof(dataBuffer));
     RecordWriter writer(&output);
 
-    KeyResourceRecord record(kNames, ByteSpan(rawKey));
+    KeyResourceRecord record(kNames, keypair.Pubkey());
     record.SetTtl(120);
 
     EXPECT_TRUE(record.Append(header, ResourceType::kAuthority, writer));
@@ -70,14 +67,15 @@ TEST(TestKeyRecord, WritesFlagsProtocolAlgorithmAndRawKey)
     EXPECT_EQ(rdata[1], 0x00);
     EXPECT_EQ(rdata[2], KeyResourceRecord::kKeyProtocolDnssec);
     EXPECT_EQ(rdata[3], kKeyAlgorithmEcdsaP256);
-    EXPECT_EQ(memcmp(rdata + 4, rawKey, sizeof(rawKey)), 0);
+    EXPECT_EQ(memcmp(rdata + 4, keypair.Pubkey().ConstBytes() + 1, kP256RawPublicKeySize), 0);
 }
 
-TEST(TestKeyRecord, RejectsWrongKeyLength)
+TEST(TestKeyRecord, RejectsNonUncompressedKey)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
-    uint8_t shortKey[16] = {};
+    Crypto::P256PublicKey publicKey;
+    memset(publicKey.Bytes(), 0, publicKey.Length());
 
     HeaderRef header(headerBuffer);
     header.Clear();
@@ -85,34 +83,52 @@ TEST(TestKeyRecord, RejectsWrongKeyLength)
     BufferWriter output(dataBuffer, sizeof(dataBuffer));
     RecordWriter writer(&output);
 
-    KeyResourceRecord record(kNames, ByteSpan(shortKey));
+    KeyResourceRecord record(kNames, publicKey);
     EXPECT_FALSE(record.Append(header, ResourceType::kAuthority, writer));
     EXPECT_EQ(header.GetAuthorityCount(), 0);
 }
 
-TEST(TestKeyRecord, ExtractRawP256PublicKeyStripsPrefix)
+TEST(TestKeyRecord, ParseReconstructsUncompressedPublicKey)
 {
-    uint8_t point[kP256RawPublicKeySize + 1];
-    uint8_t raw[kP256RawPublicKeySize];
-
-    point[0] = 0x04;
-    for (size_t i = 0; i < kP256RawPublicKeySize; i++)
+    uint8_t rdata[4 + kP256RawPublicKeySize] = {};
+    rdata[2]                                 = KeyResourceRecord::kKeyProtocolDnssec;
+    rdata[3]                                 = kKeyAlgorithmEcdsaP256;
+    for (size_t i = 0; i < kP256RawPublicKeySize; ++i)
     {
-        point[i + 1] = static_cast<uint8_t>(0xA0 + i);
+        rdata[4 + i] = static_cast<uint8_t>(i + 1);
     }
 
-    MutableByteSpan out(raw);
-    EXPECT_EQ(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out), CHIP_NO_ERROR);
-    EXPECT_EQ(out.size(), kP256RawPublicKeySize);
-    EXPECT_EQ(memcmp(raw, point + 1, kP256RawPublicKeySize), 0);
+    Crypto::P256PublicKey publicKey;
+    EXPECT_EQ(KeyResourceRecord::Parse(ByteSpan(rdata), publicKey), CHIP_NO_ERROR);
+    EXPECT_EQ(publicKey.ConstBytes()[0], 0x04);
+    EXPECT_EQ(memcmp(publicKey.ConstBytes() + 1, rdata + 4, kP256RawPublicKeySize), 0);
+}
 
-    point[0] = 0x02; // compressed — reject
-    out      = MutableByteSpan(raw);
-    EXPECT_EQ(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out), CHIP_ERROR_INVALID_ARGUMENT);
+TEST(TestKeyRecord, ParseRejectsInvalidRdata)
+{
+    uint8_t rdata[4 + kP256RawPublicKeySize] = {};
+    rdata[2]                                 = KeyResourceRecord::kKeyProtocolDnssec;
+    rdata[3]                                 = kKeyAlgorithmEcdsaP256;
+    rdata[4]                                 = 1;
 
-    point[0] = 0x04;
-    out      = MutableByteSpan(raw, kP256RawPublicKeySize - 1);
-    EXPECT_EQ(KeyResourceRecord::ExtractRawP256PublicKey(ByteSpan(point), out), CHIP_ERROR_BUFFER_TOO_SMALL);
+    Crypto::P256PublicKey publicKey;
+
+    rdata[0] = 1;
+    EXPECT_EQ(KeyResourceRecord::Parse(ByteSpan(rdata), publicKey), CHIP_ERROR_INVALID_ARGUMENT);
+
+    rdata[0] = 0;
+    rdata[2] = 2;
+    EXPECT_EQ(KeyResourceRecord::Parse(ByteSpan(rdata), publicKey), CHIP_ERROR_INVALID_ARGUMENT);
+
+    rdata[2] = KeyResourceRecord::kKeyProtocolDnssec;
+    rdata[3] = 14;
+    EXPECT_EQ(KeyResourceRecord::Parse(ByteSpan(rdata), publicKey), CHIP_ERROR_INVALID_ARGUMENT);
+
+    rdata[3] = kKeyAlgorithmEcdsaP256;
+    rdata[4] = 0;
+    EXPECT_EQ(KeyResourceRecord::Parse(ByteSpan(rdata), publicKey), CHIP_ERROR_INVALID_ARGUMENT);
+
+    EXPECT_EQ(KeyResourceRecord::Parse(ByteSpan(rdata, sizeof(rdata) - 1), publicKey), CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 } // namespace

--- a/src/lib/dnssd/uld/tests/TestKeyRecord.cpp
+++ b/src/lib/dnssd/uld/tests/TestKeyRecord.cpp
@@ -88,6 +88,25 @@ TEST(TestKeyRecord, RejectsNonUncompressedKey)
     EXPECT_EQ(header.GetAuthorityCount(), 0);
 }
 
+TEST(TestKeyRecord, RejectsAllZeroRawPublicKey)
+{
+    uint8_t headerBuffer[HeaderRef::kSizeBytes];
+    uint8_t dataBuffer[128];
+    Crypto::P256PublicKey publicKey;
+    memset(publicKey.Bytes(), 0, publicKey.Length());
+    publicKey.Bytes()[0] = 0x04;
+
+    HeaderRef header(headerBuffer);
+    header.Clear();
+
+    BufferWriter output(dataBuffer, sizeof(dataBuffer));
+    RecordWriter writer(&output);
+
+    KeyResourceRecord record(kNames, publicKey);
+    EXPECT_FALSE(record.Append(header, ResourceType::kAuthority, writer));
+    EXPECT_EQ(header.GetAuthorityCount(), 0);
+}
+
 TEST(TestKeyRecord, ParseReconstructsUncompressedPublicKey)
 {
     uint8_t rdata[4 + kP256RawPublicKeySize] = {};

--- a/src/lib/dnssd/uld/tests/TestUpdateBuilder.cpp
+++ b/src/lib/dnssd/uld/tests/TestUpdateBuilder.cpp
@@ -58,13 +58,10 @@ TEST(TestUpdateBuilder, BeginSetsOpcodeUpdate)
 TEST(TestUpdateBuilder, MinimalUpdateWithZoneDeleteAddOptAndSig)
 {
     uint8_t buffer[512];
-    uint8_t rawKey[kP256RawPublicKeySize];
     uint8_t signature[kP256RawSignatureSize] = {};
 
-    for (size_t i = 0; i < sizeof(rawKey); i++)
-    {
-        rawKey[i] = static_cast<uint8_t>(i + 1);
-    }
+    Crypto::P256Keypair keypair;
+    ASSERT_EQ(keypair.Initialize(Crypto::ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     UpdateBuilder builder(buffer, sizeof(buffer));
     builder.Begin(0xABCD);
@@ -72,7 +69,7 @@ TEST(TestUpdateBuilder, MinimalUpdateWithZoneDeleteAddOptAndSig)
     DeleteRrsetRecord delAny(kHost, QType::ANY);
     PtrResourceRecord ptr(kService, kInstance);
     SrvResourceRecord srv(kInstance, kHost, 5540);
-    KeyResourceRecord key(kHost, ByteSpan(rawKey));
+    KeyResourceRecord key(kHost, keypair.Pubkey());
     OptLeaseRecord opt(/*udpPayloadSize=*/1232, /*leaseSeconds=*/7200, /*keyLeaseSeconds=*/86400);
     Sig0ResourceRecord sig(kHost, ByteSpan(signature));
 

--- a/src/lib/dnssd/uld/tests/TestUpdateResponse.cpp
+++ b/src/lib/dnssd/uld/tests/TestUpdateResponse.cpp
@@ -1,0 +1,167 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <array>
+#include <cstring>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/uld/KeyRecord.h>
+#include <lib/dnssd/uld/UpdateResponse.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Dnssd;
+using namespace chip::Dnssd::Uld;
+
+constexpr size_t kKeyFlagsOffset     = 34;
+constexpr size_t kKeyProtocolOffset  = 36;
+constexpr size_t kKeyAlgorithmOffset = 37;
+constexpr size_t kKeyBytesOffset     = 38;
+constexpr size_t kPacketSize         = 113;
+
+std::array<uint8_t, kPacketSize> MakeUpdateResponse()
+{
+    std::array<uint8_t, kPacketSize> packet = {};
+
+    packet[0]  = 0x12;
+    packet[1]  = 0x34; // message id
+    packet[2]  = 0xA8;
+    packet[3]  = 0x0B; // response, opcode UPDATE, header RCODE 11
+    packet[8]  = 0x00;
+    packet[9]  = 0x01; // one authority record
+    packet[10] = 0x00;
+    packet[11] = 0x01; // one additional record
+
+    size_t offset    = HeaderRef::kSizeBytes;
+    packet[offset++] = 4;
+    memcpy(packet.data() + offset, "host", 4);
+    offset += 4;
+    packet[offset++] = 5;
+    memcpy(packet.data() + offset, "local", 5);
+    offset += 5;
+    packet[offset++] = 0;
+    packet[offset++] = 0;
+    packet[offset++] = static_cast<uint8_t>(QType::KEY);
+    packet[offset++] = 0;
+    packet[offset++] = static_cast<uint8_t>(QClass::IN);
+    offset += 4; // TTL
+    packet[offset++] = 0;
+    packet[offset++] = 68; // RDLENGTH
+    packet[offset++] = 0;
+    packet[offset++] = 0; // flags
+    packet[offset++] = KeyResourceRecord::kKeyProtocolDnssec;
+    packet[offset++] = kKeyAlgorithmEcdsaP256;
+    for (size_t i = 0; i < kP256RawPublicKeySize; ++i)
+    {
+        packet[offset++] = static_cast<uint8_t>(i + 1);
+    }
+
+    packet[offset++] = 0; // root owner name
+    packet[offset++] = 0;
+    packet[offset++] = static_cast<uint8_t>(QType::OPT);
+    packet[offset++] = 0x04;
+    packet[offset++] = 0xD0; // UDP payload size 1232
+    packet[offset++] = 0x02;
+    packet[offset++] = 0;
+    packet[offset++] = 0;
+    packet[offset++] = 0; // extended RCODE 2
+    packet[offset++] = 0;
+    packet[offset++] = 0; // empty OPT RDATA
+
+    EXPECT_EQ(offset, packet.size());
+    return packet;
+}
+
+TEST(TestUpdateResponse, ParsesExtendedResponseCodeAndKey)
+{
+    const auto packet = MakeUpdateResponse();
+    UpdateResponse response;
+
+    ASSERT_EQ(response.Parse(ByteSpan(packet)), CHIP_NO_ERROR);
+    EXPECT_EQ(response.GetMessageId(), 0x1234);
+    EXPECT_EQ(response.GetResponseCode(), 0x2B);
+    ASSERT_TRUE(response.GetKey().has_value());
+
+    const Crypto::P256PublicKey & publicKey = response.GetKey().value();
+    EXPECT_EQ(publicKey.ConstBytes()[0], 0x04);
+    EXPECT_EQ(memcmp(publicKey.ConstBytes() + 1, packet.data() + kKeyBytesOffset, kP256RawPublicKeySize), 0);
+}
+
+TEST(TestUpdateResponse, RejectsUnsupportedKeyMetadata)
+{
+    auto packet = MakeUpdateResponse();
+    UpdateResponse response;
+
+    packet[kKeyFlagsOffset] = 1;
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+
+    packet                     = MakeUpdateResponse();
+    packet[kKeyProtocolOffset] = 2;
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+
+    packet                      = MakeUpdateResponse();
+    packet[kKeyAlgorithmOffset] = 14;
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+TEST(TestUpdateResponse, RejectsEmptyOrTruncatedKey)
+{
+    auto packet = MakeUpdateResponse();
+    UpdateResponse response;
+
+    memset(packet.data() + kKeyBytesOffset, 0, kP256RawPublicKeySize);
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+
+    packet = MakeUpdateResponse();
+    EXPECT_EQ(response.Parse(ByteSpan(packet.data(), packet.size() - 1)), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+TEST(TestUpdateResponse, ParsesHeaderOnlyResponse)
+{
+    const uint8_t packet[] = {
+        0x12, 0x34, // message id
+        0xA8, 0x00, // response, opcode UPDATE, RCODE 0
+        0,    0,    // no zone
+        0,    0,    // no prerequisites
+        0,    0,    // no updates
+        0,    0,    // no additional records
+    };
+    UpdateResponse response;
+
+    ASSERT_EQ(response.Parse(ByteSpan(packet)), CHIP_NO_ERROR);
+    EXPECT_EQ(response.GetMessageId(), 0x1234);
+    EXPECT_EQ(response.GetResponseCode(), 0);
+    EXPECT_FALSE(response.GetKey().has_value());
+}
+
+TEST(TestUpdateResponse, RejectsNonUpdateMessage)
+{
+    auto packet = MakeUpdateResponse();
+    UpdateResponse response;
+
+    packet[2] = 0x80; // response with QUERY opcode
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+
+    packet    = MakeUpdateResponse();
+    packet[2] = 0x28; // UPDATE query, not a response
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+} // namespace

--- a/src/lib/dnssd/uld/tests/TestUpdateResponse.cpp
+++ b/src/lib/dnssd/uld/tests/TestUpdateResponse.cpp
@@ -97,11 +97,13 @@ TEST(TestUpdateResponse, ParsesExtendedResponseCodeAndKey)
     ASSERT_EQ(response.Parse(ByteSpan(packet)), CHIP_NO_ERROR);
     EXPECT_EQ(response.GetMessageId(), 0x1234);
     EXPECT_EQ(response.GetResponseCode(), 0x2B);
-    ASSERT_TRUE(response.GetKey().has_value());
-
-    const Crypto::P256PublicKey & publicKey = response.GetKey().value();
-    EXPECT_EQ(publicKey.ConstBytes()[0], 0x04);
-    EXPECT_EQ(memcmp(publicKey.ConstBytes() + 1, packet.data() + kKeyBytesOffset, kP256RawPublicKeySize), 0);
+    const std::optional<Crypto::P256PublicKey> & key = response.GetKey();
+    ASSERT_TRUE(key.has_value());
+    if (key.has_value())
+    {
+        EXPECT_EQ(key->ConstBytes()[0], 0x04);
+        EXPECT_EQ(memcmp(key->ConstBytes() + 1, packet.data() + kKeyBytesOffset, kP256RawPublicKeySize), 0);
+    }
 }
 
 TEST(TestUpdateResponse, RejectsUnsupportedKeyMetadata)

--- a/src/lib/dnssd/uld/tests/TestUpdateResponse.cpp
+++ b/src/lib/dnssd/uld/tests/TestUpdateResponse.cpp
@@ -34,7 +34,10 @@ constexpr size_t kKeyFlagsOffset     = 34;
 constexpr size_t kKeyProtocolOffset  = 36;
 constexpr size_t kKeyAlgorithmOffset = 37;
 constexpr size_t kKeyBytesOffset     = 38;
+constexpr size_t kKeyRdlengthOffset  = kKeyFlagsOffset - 1;
+constexpr size_t kOptRecordOffset    = kKeyBytesOffset + kP256RawPublicKeySize;
 constexpr size_t kPacketSize         = 113;
+constexpr size_t kKeyRecordSize      = kOptRecordOffset - HeaderRef::kSizeBytes;
 
 std::array<uint8_t, kPacketSize> MakeUpdateResponse()
 {
@@ -106,33 +109,75 @@ TEST(TestUpdateResponse, ParsesExtendedResponseCodeAndKey)
     }
 }
 
-TEST(TestUpdateResponse, RejectsUnsupportedKeyMetadata)
+TEST(TestUpdateResponse, IgnoresUnsupportedKeyMetadata)
 {
     auto packet = MakeUpdateResponse();
     UpdateResponse response;
 
     packet[kKeyFlagsOffset] = 1;
-    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_NO_ERROR);
+    EXPECT_FALSE(response.GetKey().has_value());
 
     packet                     = MakeUpdateResponse();
     packet[kKeyProtocolOffset] = 2;
-    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_NO_ERROR);
+    EXPECT_FALSE(response.GetKey().has_value());
 
     packet                      = MakeUpdateResponse();
     packet[kKeyAlgorithmOffset] = 14;
-    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_NO_ERROR);
+    EXPECT_FALSE(response.GetKey().has_value());
 }
 
-TEST(TestUpdateResponse, RejectsEmptyOrTruncatedKey)
+TEST(TestUpdateResponse, IgnoresInvalidKeyData)
 {
     auto packet = MakeUpdateResponse();
     UpdateResponse response;
 
     memset(packet.data() + kKeyBytesOffset, 0, kP256RawPublicKeySize);
-    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(response.Parse(ByteSpan(packet)), CHIP_NO_ERROR);
+    EXPECT_FALSE(response.GetKey().has_value());
 
+    // Remove one byte from the KEY RDATA and move the complete OPT record after it.
     packet = MakeUpdateResponse();
+    std::array<uint8_t, kPacketSize - 1> shortKeyPacket;
+    memcpy(shortKeyPacket.data(), packet.data(), kOptRecordOffset - 1);
+    memcpy(shortKeyPacket.data() + kOptRecordOffset - 1, packet.data() + kOptRecordOffset, kPacketSize - kOptRecordOffset);
+    shortKeyPacket[kKeyRdlengthOffset] = static_cast<uint8_t>(4 + kP256RawPublicKeySize - 1);
+
+    EXPECT_EQ(response.Parse(ByteSpan(shortKeyPacket)), CHIP_NO_ERROR);
+    EXPECT_EQ(response.GetResponseCode(), 0x2B);
+    EXPECT_FALSE(response.GetKey().has_value());
+}
+
+TEST(TestUpdateResponse, AcceptsRepeatedKey)
+{
+    const auto packet = MakeUpdateResponse();
+    std::array<uint8_t, kPacketSize + kKeyRecordSize> packetWithRepeatedKey;
+
+    memcpy(packetWithRepeatedKey.data(), packet.data(), kOptRecordOffset);
+    memcpy(packetWithRepeatedKey.data() + kOptRecordOffset, packet.data() + HeaderRef::kSizeBytes, kKeyRecordSize);
+    memcpy(packetWithRepeatedKey.data() + kOptRecordOffset + kKeyRecordSize, packet.data() + kOptRecordOffset,
+           kPacketSize - kOptRecordOffset);
+    packetWithRepeatedKey[9] = 2; // two authority records
+
+    UpdateResponse response;
+    EXPECT_EQ(response.Parse(ByteSpan(packetWithRepeatedKey)), CHIP_NO_ERROR);
+    EXPECT_TRUE(response.GetKey().has_value());
+}
+
+TEST(TestUpdateResponse, RejectsTruncatedPacketAndClearsResults)
+{
+    const auto packet = MakeUpdateResponse();
+    UpdateResponse response;
+
+    ASSERT_EQ(response.Parse(ByteSpan(packet)), CHIP_NO_ERROR);
+    ASSERT_TRUE(response.GetKey().has_value());
+
     EXPECT_EQ(response.Parse(ByteSpan(packet.data(), packet.size() - 1)), CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(response.GetMessageId(), 0);
+    EXPECT_EQ(response.GetResponseCode(), 0);
+    EXPECT_FALSE(response.GetKey().has_value());
 }
 
 TEST(TestUpdateResponse, ParsesHeaderOnlyResponse)

--- a/src/lib/dnssd/wire/DnsHeader.h
+++ b/src/lib/dnssd/wire/DnsHeader.h
@@ -77,8 +77,6 @@ public:
 
     /// Validates that the message does not need to be ignored according to
     /// RFC 6762
-    // TODO: DNS Update carries an OpCode (5) and often non-zero return code. We will need to change this for ULD/SRP support.
-    // (RFC 2136)
     bool IsValidMdns() const { return (mValue & (kOpcodeMask | kResponseCodeMask)) == 0; }
 
 private:

--- a/src/lib/dnssd/wire/Parser.cpp
+++ b/src/lib/dnssd/wire/Parser.cpp
@@ -136,20 +136,12 @@ bool ResourceData::Parse(const BytesRange & validData, const uint8_t ** start)
     return true;
 }
 
-bool ParsePacket(const BytesRange & packetData, ParserDelegate * delegate)
+bool ParseDnsPacket(const BytesRange & packetData, ParserDelegate * delegate)
 {
-    if (packetData.Size() < static_cast<ptrdiff_t>(HeaderRef::kSizeBytes))
-    {
-        return false;
-    }
+    VerifyOrReturnValue(packetData.Size() >= static_cast<ptrdiff_t>(HeaderRef::kSizeBytes), false);
 
     // header is used as const, so cast is safe
     ConstHeaderRef header(packetData.Start());
-
-    if (!header.GetFlags().IsValidMdns())
-    {
-        return false;
-    }
 
     // Reject packets with unreasonable record counts to prevent CPU exhaustion.
     // An mDNS packet is at most ~9000 bytes; the smallest record is ~12 bytes,
@@ -213,6 +205,16 @@ bool ParsePacket(const BytesRange & packetData, ParserDelegate * delegate)
     }
 
     return true;
+}
+
+bool ParseMdnsPacket(const BytesRange & packetData, ParserDelegate * delegate)
+{
+    VerifyOrReturnValue(packetData.Size() >= static_cast<ptrdiff_t>(HeaderRef::kSizeBytes), false);
+
+    ConstHeaderRef header(packetData.Start());
+    VerifyOrReturnValue(header.GetFlags().IsValidMdns(), false);
+
+    return ParseDnsPacket(packetData, delegate);
 }
 
 } // namespace Dnssd

--- a/src/lib/dnssd/wire/Parser.cpp
+++ b/src/lib/dnssd/wire/Parser.cpp
@@ -16,9 +16,9 @@
  */
 
 #include "Parser.h"
-
 #include "Query.h"
 
+#include <lib/support/CodeUtils.h>
 #include <stdio.h>
 
 namespace chip {
@@ -144,8 +144,7 @@ bool ParseDnsPacket(const BytesRange & packetData, ParserDelegate * delegate)
     ConstHeaderRef header(packetData.Start());
 
     // Reject packets with unreasonable record counts to prevent CPU exhaustion.
-    // An mDNS packet is at most ~9000 bytes; the smallest record is ~12 bytes,
-    // so 256 is a generous upper bound for any single section.
+    // for DNS/mDNS packets, 256 records is a generous upper bound for any single section.
     static constexpr uint16_t kMaxRecordCount = 256;
 
     if (header.GetQueryCount() > kMaxRecordCount || header.GetAnswerCount() > kMaxRecordCount ||

--- a/src/lib/dnssd/wire/Parser.h
+++ b/src/lib/dnssd/wire/Parser.h
@@ -114,12 +114,18 @@ public:
     virtual void OnResource(ResourceType type, const ResourceData & data) = 0;
 };
 
-/// Parses a mMDNS packet.
+/// Parses a DNS packet.
 ///
-/// Calls appropriate delegate callbacks while parsing
+/// Calls appropriate delegate callbacks while parsing.
 ///
 /// returns true if packet was successfully parsed, false otherwise
-bool ParsePacket(const BytesRange & packetData, ParserDelegate * delegate);
+bool ParseDnsPacket(const BytesRange & packetData, ParserDelegate * delegate);
+
+/// Parses an mDNS packet, validating the header according to RFC 6762.
+/// (OPCODE and RCODE must be zero).
+/// It then parses using ParseDnsPacket().
+/// returns true if packet was successfully parsed, false otherwise
+bool ParseMdnsPacket(const BytesRange & packetData, ParserDelegate * delegate);
 
 } // namespace Dnssd
 } // namespace chip

--- a/src/lib/dnssd/wire/Parser.h
+++ b/src/lib/dnssd/wire/Parser.h
@@ -127,5 +127,11 @@ bool ParseDnsPacket(const BytesRange & packetData, ParserDelegate * delegate);
 /// returns true if packet was successfully parsed, false otherwise
 bool ParseMdnsPacket(const BytesRange & packetData, ParserDelegate * delegate);
 
+/// Backwards-compatible name for the original mDNS-only parser entry point.
+inline bool ParsePacket(const BytesRange & packetData, ParserDelegate * delegate)
+{
+    return ParseMdnsPacket(packetData, delegate);
+}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/lib/dnssd/wire/tests/TestParser.cpp
+++ b/src/lib/dnssd/wire/tests/TestParser.cpp
@@ -100,7 +100,7 @@ TEST(TestParser, ParsesQuestion)
     };
 
     PacketCapture capture;
-    ASSERT_TRUE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    ASSERT_TRUE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
 
     EXPECT_EQ(capture.mMessageId, 0x1234);
     EXPECT_TRUE(capture.mResources.empty());
@@ -130,7 +130,7 @@ TEST(TestParser, QuestionUnicastFlagIsSplitFromClass)
     };
 
     PacketCapture capture;
-    ASSERT_TRUE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    ASSERT_TRUE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
     ASSERT_EQ(capture.mQueries.size(), 1u);
 
     // The unicast bit is reported separately and must not leak into the class.
@@ -174,7 +174,7 @@ TEST(TestParser, ReportsEachSectionSeparately)
     };
 
     PacketCapture capture;
-    ASSERT_TRUE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    ASSERT_TRUE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
     ASSERT_EQ(capture.mResources.size(), 3u);
 
     EXPECT_EQ(capture.mResources[0].section, ResourceType::kAnswer);
@@ -249,7 +249,7 @@ TEST(TestParser, ResolvesCompressedRecordName)
     };
 
     PacketCapture capture;
-    ASSERT_TRUE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    ASSERT_TRUE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
     ASSERT_EQ(capture.mResources.size(), 1u);
 
     EXPECT_EQ(capture.mResources[0].name, (std::vector<std::string>{ "host", "local" }));
@@ -277,7 +277,7 @@ TEST(TestParser, UnknownRecordTypeKeepsDataOpaque)
     };
 
     PacketCapture capture;
-    ASSERT_TRUE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    ASSERT_TRUE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
 
     EXPECT_EQ(capture.mMessageId, 0x1234);
     EXPECT_TRUE(capture.mQueries.empty());
@@ -303,7 +303,7 @@ TEST(TestParser, AcceptsHeaderOnlyPacket)
     };
 
     PacketCapture capture;
-    EXPECT_TRUE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    EXPECT_TRUE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
     EXPECT_EQ(capture.mMessageId, 0x1234);
     EXPECT_TRUE(capture.mQueries.empty());
     EXPECT_TRUE(capture.mResources.empty());
@@ -312,11 +312,6 @@ TEST(TestParser, AcceptsHeaderOnlyPacket)
 TEST(TestParser, RejectsNonZeroOpcode)
 {
     // RFC 6762 section 18.3 requires mDNS receivers to ignore anything with a non-zero opcode.
-    // receivers to ignore anything with a non-zero opcode, so this entry point
-    // refuses to parse it.
-
-    // TODO: DNS Update carries an OpCode (5) and often non-zero return code.(RFC 2136)
-    // Update this test when we add ULD/SRP support.
     const uint8_t packet[] = {
         0x12, 0x34, // message id
         0x28, 0x00, // flags: opcode 5
@@ -327,7 +322,25 @@ TEST(TestParser, RejectsNonZeroOpcode)
     };
 
     PacketCapture capture;
-    EXPECT_FALSE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    EXPECT_FALSE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    EXPECT_TRUE(capture.mResources.empty());
+}
+
+TEST(TestParser, ParseDnsPacketAcceptsUpdateOpcode)
+{
+    const uint8_t packet[] = {
+        0x12, 0x34, // message id
+        0xA8, 0x05, // flags: response, opcode 5, rcode 5
+        0x00, 0x00, // no questions
+        0x00, 0x00, // no answers
+        0x00, 0x00, // no authority records
+        0x00, 0x00, // no additional records
+    };
+
+    PacketCapture capture;
+    ASSERT_TRUE(ParseDnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    EXPECT_EQ(capture.mMessageId, 0x1234);
+    EXPECT_TRUE(capture.mQueries.empty());
     EXPECT_TRUE(capture.mResources.empty());
 }
 
@@ -336,7 +349,7 @@ TEST(TestParser, RejectsTruncatedHeader)
     const uint8_t packet[] = { 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 };
 
     PacketCapture capture;
-    EXPECT_FALSE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    EXPECT_FALSE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
 }
 
 TEST(TestParser, RejectsRecordDataPastEndOfPacket)
@@ -359,7 +372,7 @@ TEST(TestParser, RejectsRecordDataPastEndOfPacket)
     };
 
     PacketCapture capture;
-    EXPECT_FALSE(ParsePacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
+    EXPECT_FALSE(ParseMdnsPacket(BytesRange::BufferWithSize(packet, sizeof(packet)), &capture));
 }
 
 } // namespace

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -58,7 +58,7 @@ public:
     void OnQuery(const chip::Dnssd::BytesRange & data, const chip::Inet::IPPacketInfo * info) override
     {
         mCurSrc = info;
-        chip::Dnssd::ParsePacket(data, this);
+        chip::Dnssd::ParseMdnsPacket(data, this);
         mCurSrc = nullptr;
     }
 


### PR DESCRIPTION
#### Summary

Adds a DNS UPDATE response parser for unicast DNS-SD (ULD) and splits mDNS header validation out of the generic packet parser so UPDATE opcode/RCODE values are not rejected.

##### Problem

- The wire parser (`ParsePacket`) applied RFC 6762 mDNS checks (OPCODE and RCODE must be zero) to every packet.
- DNS UPDATE responses (RFC 2136) use OPCODE 5 and often a non-zero RCODE, including EDNS EXTENDED-RCODE in the OPT TTL (RFC 6891).
- ULD had KEY record encoding but no way to parse an UPDATE response or KEY RDATA into a `Crypto::P256PublicKey`.

##### Solution

- Split parsing into `ParseDnsPacket` (generic DNS) and `ParseMdnsPacket` (RFC 6762 header checks, then `ParseDnsPacket`). Existing mDNS call sites use `ParseMdnsPacket`.
- Add `Uld::UpdateResponse` to parse an UPDATE response and expose message ID, 12-bit RCODE (header RCODE plus OPT EXTENDED-RCODE), and an optional KEY.
- Change `KeyResourceRecord` to take/return `Crypto::P256PublicKey`. Write omits the uncompressed-point `0x04` prefix; `Parse` restores it and rejects unsupported KEY flags/protocol/algorithm and an all-zero key.

#### Related issues
fixes #73652

#### Testing

- Added unit tests in `src/lib/dnssd/uld/tests/TestUpdateResponse.cpp` for header-only success, KEY + extended RCODE, invalid KEY metadata, empty/truncated KEY, and non-UPDATE messages.
- Updated `src/lib/dnssd/uld/tests/TestKeyRecord.cpp` for `P256PublicKey` write/parse and invalid RDATA.
- Updated `src/lib/dnssd/wire/tests/TestParser.cpp` so mDNS cases call `ParseMdnsPacket`, and added `ParseDnsPacketAcceptsUpdateOpcode`.