### PR TITLE
[PAVST] Implement UpdateMotionZoneOptions command in PushAV server and camera-app

### DIFF
--- a/examples/camera-app/camera-common/camera-app.matter
+++ b/examples/camera-app/camera-common/camera-app.matter
@@ -3528,6 +3528,7 @@ endpoint 1 {
     handle command SetTransportStatus;
     handle command ManuallyTriggerTransport;
     handle command FindTransport;
+    handle command UpdateMotionZoneOptions;
   }
 
   server cluster Chime {

--- a/examples/camera-app/camera-common/camera-app.zap
+++ b/examples/camera-app/camera-common/camera-app.zap
@@ -6332,6 +6332,14 @@
               "source": "server",
               "isIncoming": 0,
               "isEnabled": 1
+            },
+            {
+              "name": "UpdateMotionZoneOptions",
+              "code": 8,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
             }
           ],
           "attributes": [

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -554,7 +554,7 @@ bool PushAvStreamTransportManager::ValidateMotionZoneListSize(size_t zoneListSiz
         return false;
     }
     auto maxZones = mCameraDevice->GetZoneManagementDelegate().GetZoneMgmtServer()->GetMaxZones();
-    if (zoneListSize >= maxZones)
+    if (zoneListSize > maxZones)
     {
         return false;
     }

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.cpp
@@ -42,7 +42,7 @@ namespace {
 using namespace chip::app::Clusters::PushAvStreamTransport::Commands;
 
 constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
-    AllocatePushTransport::kMetadataEntry,   DeallocatePushTransport::kMetadataEntry, ModifyPushTransport::kMetadataEntry,
+    AllocatePushTransport::kMetadataEntry,   DeallocatePushTransport::kMetadataEntry,  ModifyPushTransport::kMetadataEntry,
     SetTransportStatus::kMetadataEntry,      ManuallyTriggerTransport::kMetadataEntry, FindTransport::kMetadataEntry,
     UpdateMotionZoneOptions::kMetadataEntry,
 };

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.cpp
@@ -42,8 +42,9 @@ namespace {
 using namespace chip::app::Clusters::PushAvStreamTransport::Commands;
 
 constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
-    AllocatePushTransport::kMetadataEntry, DeallocatePushTransport::kMetadataEntry,  ModifyPushTransport::kMetadataEntry,
-    SetTransportStatus::kMetadataEntry,    ManuallyTriggerTransport::kMetadataEntry, FindTransport::kMetadataEntry,
+    AllocatePushTransport::kMetadataEntry,   DeallocatePushTransport::kMetadataEntry, ModifyPushTransport::kMetadataEntry,
+    SetTransportStatus::kMetadataEntry,      ManuallyTriggerTransport::kMetadataEntry, FindTransport::kMetadataEntry,
+    UpdateMotionZoneOptions::kMetadataEntry,
 };
 
 constexpr CommandId kGeneratedCommands[] = {
@@ -172,6 +173,11 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServer::Invoke
         FindTransport::DecodableType data;
         ReturnErrorOnFailure(data.Decode(input_arguments, fabricIndex));
         return mLogic.HandleFindTransport(*handler, request.path, data);
+    }
+    case UpdateMotionZoneOptions::Id: {
+        UpdateMotionZoneOptions::DecodableType data;
+        ReturnErrorOnFailure(data.Decode(input_arguments, fabricIndex));
+        return mLogic.HandleUpdateMotionZoneOptions(*handler, request.path, data);
     }
     }
 

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -1586,8 +1586,7 @@ PushAvStreamTransportServerLogic::HandleFindTransport(CommandHandler & handler, 
     return std::nullopt;
 }
 
-std::optional<DataModel::ActionReturnStatus>
-PushAvStreamTransportServerLogic::HandleUpdateMotionZoneOptions(
+std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::HandleUpdateMotionZoneOptions(
     CommandHandler & handler, const ConcreteCommandPath & commandPath,
     const PushAvStreamTransport::Commands::UpdateMotionZoneOptions::DecodableType & commandData)
 {
@@ -1697,9 +1696,9 @@ PushAvStreamTransportServerLogic::HandleUpdateMotionZoneOptions(
             {
                 if (!mFeatures.Has(Feature::kPerZoneSensitivity))
                 {
-                    ChipLogError(Zcl,
-                                 "HandleUpdateMotionZoneOptions[ep=%d]: Zone sensitivity provided without PerZoneSensitivity feature",
-                                 mEndpointId);
+                    ChipLogError(
+                        Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Zone sensitivity provided without PerZoneSensitivity feature",
+                        mEndpointId);
                     handler.AddStatus(commandPath, Status::InvalidCommand);
                     return std::nullopt;
                 }
@@ -1707,8 +1706,7 @@ PushAvStreamTransportServerLogic::HandleUpdateMotionZoneOptions(
                 uint8_t sens = zoneOpt.sensitivity.Value();
                 if (sens < 1 || sens > 10)
                 {
-                    ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Zone sensitivity out of range: %u", mEndpointId,
-                                 sens);
+                    ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Zone sensitivity out of range: %u", mEndpointId, sens);
                     handler.AddStatus(commandPath, Status::ConstraintError);
                     return std::nullopt;
                 }

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -1586,6 +1586,221 @@ PushAvStreamTransportServerLogic::HandleFindTransport(CommandHandler & handler, 
     return std::nullopt;
 }
 
+std::optional<DataModel::ActionReturnStatus>
+PushAvStreamTransportServerLogic::HandleUpdateMotionZoneOptions(
+    CommandHandler & handler, const ConcreteCommandPath & commandPath,
+    const PushAvStreamTransport::Commands::UpdateMotionZoneOptions::DecodableType & commandData)
+{
+    if (IsNullDelegateWithLogging(commandPath.mEndpointId))
+    {
+        handler.AddStatus(commandPath, Status::UnsupportedCommand);
+        return std::nullopt;
+    }
+
+    uint16_t connectionID   = commandData.connectionID;
+    FabricIndex fabricIndex = handler.GetAccessingFabricIndex();
+
+    TransportConfigurationStorage * transportConfiguration = FindStreamTransportConnectionWithinFabric(connectionID, fabricIndex);
+    if (transportConfiguration == nullptr)
+    {
+        ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: ConnectionID (%u) Not Found for fabric %u", mEndpointId,
+                     connectionID, fabricIndex);
+        handler.AddStatus(commandPath, Status::NotFound);
+        return std::nullopt;
+    }
+
+    if (mDelegate->GetTransportBusyStatus(connectionID) == PushAvStreamTransportStatusEnum::kBusy)
+    {
+        ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Connection is Busy", mEndpointId);
+        handler.AddStatus(commandPath, Status::Busy);
+        return std::nullopt;
+    }
+
+    auto transportOptionsPtr = transportConfiguration->GetTransportOptionsPtr();
+    if (transportOptionsPtr == nullptr)
+    {
+        ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Transport options missing for connection %u", mEndpointId,
+                     connectionID);
+        handler.AddStatus(commandPath, Status::NotFound);
+        return std::nullopt;
+    }
+
+    if (transportOptionsPtr->triggerOptions.triggerType != TransportTriggerTypeEnum::kMotion)
+    {
+        ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Transport trigger type is not Motion", mEndpointId);
+        handler.AddStatus(commandPath, Status::InvalidCommand);
+        return std::nullopt;
+    }
+
+    // Validate MotionSensitivity
+    if (commandData.motionSensitivity.HasValue())
+    {
+        if (mFeatures.Has(Feature::kPerZoneSensitivity))
+        {
+            ChipLogError(Zcl,
+                         "HandleUpdateMotionZoneOptions[ep=%d]: MotionSensitivity cannot be set when PerZoneSensitivity is enabled",
+                         mEndpointId);
+            handler.AddStatus(commandPath, Status::InvalidCommand);
+            return std::nullopt;
+        }
+
+        if (!commandData.motionSensitivity.Value().IsNull())
+        {
+            uint8_t sensitivity = commandData.motionSensitivity.Value().Value();
+            if (sensitivity < 1 || sensitivity > 10)
+            {
+                ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: MotionSensitivity out of range: %u", mEndpointId,
+                             sensitivity);
+                handler.AddStatus(commandPath, Status::ConstraintError);
+                return std::nullopt;
+            }
+        }
+    }
+
+    // Validate MotionZones
+    if (commandData.motionZones.HasValue() && !commandData.motionZones.Value().IsNull())
+    {
+        std::set<uint16_t> zoneIDsFound;
+        bool nullFound      = false;
+        size_t zoneListSize = 0;
+
+        auto iterDup = commandData.motionZones.Value().Value().begin();
+        while (iterDup.Next())
+        {
+            zoneListSize++;
+            auto & zoneOpt = iterDup.GetValue();
+
+            if (!zoneOpt.zone.IsNull())
+            {
+                uint16_t zoneID = zoneOpt.zone.Value();
+                if (zoneIDsFound.count(zoneID) != 0)
+                {
+                    ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Duplicate Zone ID (=%u) in Motion Zones", mEndpointId,
+                                 zoneID);
+                    handler.AddStatus(commandPath, Status::AlreadyExists);
+                    return std::nullopt;
+                }
+                zoneIDsFound.emplace(zoneID);
+            }
+            else
+            {
+                if (nullFound)
+                {
+                    ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Duplicate Null Zone ID in Motion Zones", mEndpointId);
+                    handler.AddStatus(commandPath, Status::AlreadyExists);
+                    return std::nullopt;
+                }
+                nullFound = true;
+            }
+
+            if (zoneOpt.sensitivity.HasValue())
+            {
+                if (!mFeatures.Has(Feature::kPerZoneSensitivity))
+                {
+                    ChipLogError(Zcl,
+                                 "HandleUpdateMotionZoneOptions[ep=%d]: Zone sensitivity provided without PerZoneSensitivity feature",
+                                 mEndpointId);
+                    handler.AddStatus(commandPath, Status::InvalidCommand);
+                    return std::nullopt;
+                }
+
+                uint8_t sens = zoneOpt.sensitivity.Value();
+                if (sens < 1 || sens > 10)
+                {
+                    ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Zone sensitivity out of range: %u", mEndpointId,
+                                 sens);
+                    handler.AddStatus(commandPath, Status::ConstraintError);
+                    return std::nullopt;
+                }
+            }
+        }
+
+        if (iterDup.GetStatus() != CHIP_NO_ERROR)
+        {
+            handler.AddStatus(commandPath, Status::InvalidCommand);
+            return std::nullopt;
+        }
+
+        bool isValidZoneSize = mDelegate->ValidateMotionZoneListSize(zoneListSize);
+        if (!isValidZoneSize)
+        {
+            ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Invalid Motion Zone Size (%u)", mEndpointId,
+                         static_cast<unsigned>(zoneListSize));
+            handler.AddStatus(commandPath, Status::DynamicConstraintError);
+            return std::nullopt;
+        }
+
+        auto iterZones = commandData.motionZones.Value().Value().begin();
+        while (iterZones.Next())
+        {
+            auto & zoneOpt = iterZones.GetValue();
+            if (!zoneOpt.zone.IsNull())
+            {
+                Status zoneIdStatus = mDelegate->ValidateZoneId(zoneOpt.zone.Value());
+                if (zoneIdStatus != Status::Success)
+                {
+                    auto status = to_underlying(StatusCodeEnum::kInvalidZone);
+                    ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Invalid ZoneId (%u)", mEndpointId,
+                                 zoneOpt.zone.Value());
+                    TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
+                    return std::nullopt;
+                }
+            }
+        }
+
+        if (iterZones.GetStatus() != CHIP_NO_ERROR)
+        {
+            handler.AddStatus(commandPath, Status::InvalidCommand);
+            return std::nullopt;
+        }
+    }
+
+    std::shared_ptr<TransportOptionsStorage> updatedTransportOptionsPtr{ new (std::nothrow)
+                                                                             TransportOptionsStorage(*transportOptionsPtr) };
+    if (updatedTransportOptionsPtr == nullptr)
+    {
+        ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Memory Allocation failed for transportOptions", mEndpointId);
+        handler.AddStatus(commandPath, Status::ResourceExhausted);
+        return std::nullopt;
+    }
+
+    if (commandData.motionSensitivity.HasValue())
+    {
+        updatedTransportOptionsPtr->UpdateMotionSensitivity(commandData.motionSensitivity);
+    }
+
+    if (commandData.motionZones.HasValue())
+    {
+        updatedTransportOptionsPtr->UpdateMotionZones(commandData.motionZones);
+    }
+
+    Status status = mDelegate->UpdateMotionZoneOptions(connectionID, *updatedTransportOptionsPtr);
+    if (status != Status::Success)
+    {
+        ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Delegate UpdateMotionZoneOptions failed: %u", mEndpointId,
+                     to_underlying(status));
+        handler.AddStatus(commandPath, status);
+        return std::nullopt;
+    }
+
+    transportConfiguration->SetTransportOptionsPtr(updatedTransportOptionsPtr);
+
+    CHIP_ERROR err = StoreCurrentConnections();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl,
+                     "HandleUpdateMotionZoneOptions[ep=%d]: Failed to store modified connection, reverting: %" CHIP_ERROR_FORMAT,
+                     mEndpointId, err.Format());
+        transportConfiguration->SetTransportOptionsPtr(transportOptionsPtr);
+        handler.AddStatus(commandPath, Status::Failure);
+        return std::nullopt;
+    }
+
+    mDelegate->OnAttributeChanged(PushAvStreamTransport::Attributes::CurrentConnections::Id);
+    handler.AddStatus(commandPath, Status::Success);
+    return std::nullopt;
+}
+
 Status PushAvStreamTransportServerLogic::CheckPrivacyModes(StreamUsageEnum streamUsage)
 {
     bool hardPrivacyModeActive = false;

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -1794,7 +1794,7 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::H
         return std::nullopt;
     }
 
-    mDelegate->OnAttributeChanged(PushAvStreamTransport::Attributes::CurrentConnections::Id);
+    mCluster->ReportAttributeChange(PushAvStreamTransport::Attributes::CurrentConnections::Id);
     handler.AddStatus(commandPath, Status::Success);
     return std::nullopt;
 }

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -1692,13 +1692,11 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::H
                 nullFound = true;
             }
 
-            if (zoneOpt.sensitivity.HasValue())
+            if (mFeatures.Has(Feature::kPerZoneSensitivity))
             {
-                if (!mFeatures.Has(Feature::kPerZoneSensitivity))
+                if (!zoneOpt.sensitivity.HasValue())
                 {
-                    ChipLogError(
-                        Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Zone sensitivity provided without PerZoneSensitivity feature",
-                        mEndpointId);
+                    ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Missing Zone Sensitivity", mEndpointId);
                     handler.AddStatus(commandPath, Status::InvalidCommand);
                     return std::nullopt;
                 }
@@ -1710,6 +1708,14 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::H
                     handler.AddStatus(commandPath, Status::ConstraintError);
                     return std::nullopt;
                 }
+            }
+            else if (zoneOpt.sensitivity.HasValue())
+            {
+                ChipLogError(Zcl,
+                             "HandleUpdateMotionZoneOptions[ep=%d]: Zone sensitivity provided without PerZoneSensitivity feature",
+                             mEndpointId);
+                handler.AddStatus(commandPath, Status::InvalidCommand);
+                return std::nullopt;
             }
         }
 

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -1659,14 +1659,34 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::H
     // Validate MotionZones
     if (commandData.motionZones.HasValue() && !commandData.motionZones.Value().IsNull())
     {
-        std::set<uint16_t> zoneIDsFound;
-        bool nullFound      = false;
         size_t zoneListSize = 0;
+        auto iterCount      = commandData.motionZones.Value().Value().begin();
+        while (iterCount.Next())
+        {
+            zoneListSize++;
+        }
+
+        if (iterCount.GetStatus() != CHIP_NO_ERROR)
+        {
+            handler.AddStatus(commandPath, Status::InvalidCommand);
+            return std::nullopt;
+        }
+
+        bool isValidZoneSize = mDelegate->ValidateMotionZoneListSize(zoneListSize);
+        if (!isValidZoneSize)
+        {
+            ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Invalid Motion Zone Size (%u)", mEndpointId,
+                         static_cast<unsigned>(zoneListSize));
+            handler.AddStatus(commandPath, Status::DynamicConstraintError);
+            return std::nullopt;
+        }
+
+        std::set<uint16_t> zoneIDsFound;
+        bool nullFound = false;
 
         auto iterDup = commandData.motionZones.Value().Value().begin();
         while (iterDup.Next())
         {
-            zoneListSize++;
             auto & zoneOpt = iterDup.GetValue();
 
             if (!zoneOpt.zone.IsNull())
@@ -1725,15 +1745,6 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::H
             return std::nullopt;
         }
 
-        bool isValidZoneSize = mDelegate->ValidateMotionZoneListSize(zoneListSize);
-        if (!isValidZoneSize)
-        {
-            ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Invalid Motion Zone Size (%u)", mEndpointId,
-                         static_cast<unsigned>(zoneListSize));
-            handler.AddStatus(commandPath, Status::DynamicConstraintError);
-            return std::nullopt;
-        }
-
         auto iterZones = commandData.motionZones.Value().Value().begin();
         while (iterZones.Next())
         {
@@ -1775,7 +1786,14 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::H
 
     if (commandData.motionZones.HasValue())
     {
-        updatedTransportOptionsPtr->UpdateMotionZones(commandData.motionZones);
+        CHIP_ERROR updateErr = updatedTransportOptionsPtr->UpdateMotionZones(commandData.motionZones);
+        if (updateErr != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Failed to update motion zones: %" CHIP_ERROR_FORMAT,
+                         mEndpointId, updateErr.Format());
+            handler.AddStatus(commandPath, Status::InvalidCommand);
+            return std::nullopt;
+        }
     }
 
     Status status = mDelegate->UpdateMotionZoneOptions(connectionID, *updatedTransportOptionsPtr);
@@ -1795,6 +1813,12 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::H
         ChipLogError(Zcl,
                      "HandleUpdateMotionZoneOptions[ep=%d]: Failed to store modified connection, reverting: %" CHIP_ERROR_FORMAT,
                      mEndpointId, err.Format());
+        Status rollbackStatus = mDelegate->UpdateMotionZoneOptions(connectionID, *transportOptionsPtr);
+        if (rollbackStatus != Status::Success)
+        {
+            ChipLogError(Zcl, "HandleUpdateMotionZoneOptions[ep=%d]: Delegate rollback failed: %u", mEndpointId,
+                         to_underlying(rollbackStatus));
+        }
         transportConfiguration->SetTransportOptionsPtr(transportOptionsPtr);
         handler.AddStatus(commandPath, Status::Failure);
         return std::nullopt;

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
@@ -136,6 +136,10 @@ public:
     HandleFindTransport(CommandHandler & handler, const ConcreteCommandPath & commandPath,
                         const PushAvStreamTransport::Commands::FindTransport::DecodableType & commandData);
 
+    std::optional<DataModel::ActionReturnStatus>
+    HandleUpdateMotionZoneOptions(CommandHandler & handler, const ConcreteCommandPath & commandPath,
+                                  const PushAvStreamTransport::Commands::UpdateMotionZoneOptions::DecodableType & commandData);
+
     // Send Push AV Stream Transport events
     Protocols::InteractionModel::Status
     GeneratePushTransportBeginEvent(const uint16_t connectionID, const PushAvStreamTransport::TransportTriggerTypeEnum triggerType,

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -91,6 +91,22 @@ public:
     ModifyPushTransport(const uint16_t connectionID, const PushAvStreamTransport::TransportOptionsStorage transportOptions) = 0;
 
     /**
+     * @brief Handles updating motion zone options for a push transport.
+     *
+     * @param connectionID The connectionID of the stream transport to update
+     * @param transportOptions The updated Transport Options
+     * @return Success if motion zone options update is successful;
+     *         Failure if modification fails
+     *
+     * Default implementation delegates to ModifyPushTransport.
+     */
+    virtual Protocols::InteractionModel::Status
+    UpdateMotionZoneOptions(const uint16_t connectionID, const PushAvStreamTransport::TransportOptionsStorage & transportOptions)
+    {
+        return ModifyPushTransport(connectionID, transportOptions);
+    }
+
+    /**
      * @brief Handles stream transport status modification.
      *
      * @param connectionIDList List of connectionIDs for which new transport status to apply

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
@@ -182,6 +182,47 @@ struct TransportTriggerOptionsStorage : public TransportTriggerOptionsStruct
         *this = triggerOptions;
     }
 
+    void UpdateMotionSensitivity(const Optional<DataModel::Nullable<uint8_t>> & newSensitivity)
+    {
+        if (newSensitivity.HasValue())
+        {
+            if (newSensitivity.Value().IsNull())
+            {
+                motionSensitivity.SetValue(DataModel::NullNullable);
+            }
+            else
+            {
+                motionSensitivity.SetValue(DataModel::MakeNullable(newSensitivity.Value().Value()));
+            }
+        }
+    }
+
+    void UpdateMotionZones(
+        const Optional<DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>>> & newMotionZones)
+    {
+        if (!newMotionZones.HasValue())
+        {
+            return;
+        }
+
+        mTransportZoneOptions.clear();
+
+        if (newMotionZones.Value().IsNull())
+        {
+            motionZones.SetValue(DataModel::NullNullable);
+        }
+        else
+        {
+            auto iter = newMotionZones.Value().Value().begin();
+            while (iter.Next())
+            {
+                mTransportZoneOptions.push_back(iter.GetValue());
+            }
+            motionZones.SetValue(DataModel::MakeNullable(
+                DataModel::List<const TransportZoneOptionsStruct>(mTransportZoneOptions.data(), mTransportZoneOptions.size())));
+        }
+    }
+
 private:
     std::vector<TransportZoneOptionsStruct> mTransportZoneOptions;
 };
@@ -508,6 +549,19 @@ struct TransportOptionsStorage : public TransportOptionsStruct
         {
             audioStreams.ClearValue();
         }
+    }
+
+    void UpdateMotionSensitivity(const Optional<DataModel::Nullable<uint8_t>> & newSensitivity)
+    {
+        mTriggerOptionsStorage.UpdateMotionSensitivity(newSensitivity);
+        triggerOptions = mTriggerOptionsStorage;
+    }
+
+    void UpdateMotionZones(
+        const Optional<DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>>> & newMotionZones)
+    {
+        mTriggerOptionsStorage.UpdateMotionZones(newMotionZones);
+        triggerOptions = mTriggerOptionsStorage;
     }
 
 private:

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
@@ -198,7 +198,8 @@ struct TransportTriggerOptionsStorage : public TransportTriggerOptionsStruct
     }
 
     void UpdateMotionZones(
-        const Optional<DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>>> & newMotionZones)
+        const Optional<DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>>> &
+            newMotionZones)
     {
         if (!newMotionZones.HasValue())
         {
@@ -558,7 +559,8 @@ struct TransportOptionsStorage : public TransportOptionsStruct
     }
 
     void UpdateMotionZones(
-        const Optional<DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>>> & newMotionZones)
+        const Optional<DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>>> &
+            newMotionZones)
     {
         mTriggerOptionsStorage.UpdateMotionZones(newMotionZones);
         triggerOptions = mTriggerOptionsStorage;

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h
@@ -197,31 +197,34 @@ struct TransportTriggerOptionsStorage : public TransportTriggerOptionsStruct
         }
     }
 
-    void UpdateMotionZones(
+    CHIP_ERROR UpdateMotionZones(
         const Optional<DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>>> &
             newMotionZones)
     {
         if (!newMotionZones.HasValue())
         {
-            return;
+            return CHIP_NO_ERROR;
         }
-
-        mTransportZoneOptions.clear();
 
         if (newMotionZones.Value().IsNull())
         {
+            mTransportZoneOptions.clear();
             motionZones.SetValue(DataModel::NullNullable);
+            return CHIP_NO_ERROR;
         }
-        else
+
+        std::vector<TransportZoneOptionsStruct> tempZones;
+        auto iter = newMotionZones.Value().Value().begin();
+        while (iter.Next())
         {
-            auto iter = newMotionZones.Value().Value().begin();
-            while (iter.Next())
-            {
-                mTransportZoneOptions.push_back(iter.GetValue());
-            }
-            motionZones.SetValue(DataModel::MakeNullable(
-                DataModel::List<const TransportZoneOptionsStruct>(mTransportZoneOptions.data(), mTransportZoneOptions.size())));
+            tempZones.push_back(iter.GetValue());
         }
+        ReturnErrorOnFailure(iter.GetStatus());
+
+        mTransportZoneOptions = std::move(tempZones);
+        motionZones.SetValue(DataModel::MakeNullable(
+            DataModel::List<const TransportZoneOptionsStruct>(mTransportZoneOptions.data(), mTransportZoneOptions.size())));
+        return CHIP_NO_ERROR;
     }
 
 private:
@@ -558,12 +561,13 @@ struct TransportOptionsStorage : public TransportOptionsStruct
         triggerOptions = mTriggerOptionsStorage;
     }
 
-    void UpdateMotionZones(
+    CHIP_ERROR UpdateMotionZones(
         const Optional<DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>>> &
             newMotionZones)
     {
-        mTriggerOptionsStorage.UpdateMotionZones(newMotionZones);
+        ReturnErrorOnFailure(mTriggerOptionsStorage.UpdateMotionZones(newMotionZones));
         triggerOptions = mTriggerOptionsStorage;
+        return CHIP_NO_ERROR;
     }
 
 private:

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -1646,6 +1646,149 @@ TEST_F(MockEventLogging, Test_AllocateTransport_SetTransportStatus_ManuallyTrigg
     mServer.GetLogic().HandleManuallyTriggerTransport(triggerCommandHandler, kTriggerCommandPath, triggerCommandData);
 }
 
+TEST_F(MockEventLogging, Test_AllocateTransport_UpdateMotionZoneOptions)
+{
+    CMAFContainerOptionsStruct cmafContainerOptions;
+    ContainerOptionsStruct containerOptions;
+    TransportMotionTriggerTimeControlDecodableStruct motionTimeControl;
+    TransportTriggerOptionsDecodableStruct triggerOptions;
+    TransportOptionsDecodableStruct transportOptions;
+
+    std::string url = "https://192.168.1.100:554/stream/";
+
+    cmafContainerOptions.segmentDuration = 1000;
+    cmafContainerOptions.chunkDuration   = 500;
+    std::string trackName                = "video";
+    cmafContainerOptions.trackName.SetValue(Span(trackName.data(), trackName.size()));
+    cmafContainerOptions.metadataEnabled.ClearValue();
+
+    containerOptions.containerType = ContainerFormatEnum::kCmaf;
+    containerOptions.CMAFContainerOptions.SetValue(cmafContainerOptions);
+
+    motionTimeControl.initialDuration      = 5000;
+    motionTimeControl.augmentationDuration = 2000;
+    motionTimeControl.maxDuration          = 30000;
+    motionTimeControl.blindDuration        = 1000;
+
+    triggerOptions.triggerType = TransportTriggerTypeEnum::kMotion;
+
+    uint8_t tlvBuffer[512];
+    Structs::TransportZoneOptionsStruct::Type zone1;
+    Structs::TransportZoneOptionsStruct::Type zone2;
+    DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> decodedList;
+
+    zone1.zone.SetNonNull(1);
+    zone1.sensitivity.SetValue(5);
+
+    zone2.zone.SetNonNull(2);
+    zone2.sensitivity.SetValue(10);
+
+    TLV::TLVWriter writer;
+    writer.Init(tlvBuffer, sizeof(tlvBuffer));
+
+    TLV::TLVWriter containerWriter;
+    CHIP_ERROR err = writer.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, containerWriter);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = DataModel::Encode(containerWriter, TLV::AnonymousTag(), zone1);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = DataModel::Encode(containerWriter, TLV::AnonymousTag(), zone2);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writer.CloseContainer(containerWriter);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    size_t encodedLen = writer.GetLengthWritten();
+
+    TLV::TLVReader motionZonesReader;
+    motionZonesReader.Init(tlvBuffer, static_cast<uint32_t>(encodedLen));
+    err = motionZonesReader.Next();
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = decodedList.Decode(motionZonesReader);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    triggerOptions.motionZones.SetValue(DataModel::MakeNullable(decodedList));
+    triggerOptions.motionSensitivity.ClearValue();
+    triggerOptions.motionTimeControl.SetValue(motionTimeControl);
+    triggerOptions.maxPreRollLen.SetValue(1000);
+
+    transportOptions.streamUsage = StreamUsageEnum::kAnalysis;
+    transportOptions.videoStreamID.SetValue(1);
+    transportOptions.audioStreamID.SetValue(2);
+    transportOptions.TLSEndpointID    = 1;
+    transportOptions.url              = Span(url.data(), url.size());
+    transportOptions.triggerOptions   = triggerOptions;
+    transportOptions.containerOptions = containerOptions;
+    transportOptions.expiryTime.ClearValue();
+
+    TestPushAVStreamTransportDelegateImpl mockDelegate;
+    TestTLSClientManagementDelegate tlsClientManagementDelegate;
+
+    Testing::MockCommandHandler commandHandler;
+    commandHandler.SetFabricIndex(1);
+    ConcreteCommandPath kCommandPath{ 1, Clusters::PushAvStreamTransport::Id, Commands::AllocatePushTransport::Id };
+    Commands::AllocatePushTransport::DecodableType commandData;
+    commandData.transportOptions = transportOptions;
+
+    EXPECT_EQ(mServer.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
+
+    mServer.GetLogic().SetDelegate(&mockDelegate);
+    mServer.GetLogic().SetTLSClientManagementDelegate(&tlsClientManagementDelegate);
+    EXPECT_EQ(mServer.Init(), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mServer.GetLogic().HandleAllocatePushTransport(commandHandler, kCommandPath, commandData), std::nullopt);
+    EXPECT_EQ(mServer.GetLogic().mCurrentConnections.size(), (size_t) 1);
+
+    uint16_t allocatedConnectionID = mServer.GetLogic().mCurrentConnections[0].connectionID;
+
+    /*
+     * Test UpdateMotionZoneOptions: NotFound for invalid connectionID
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = 9999;
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_EQ(updateHandler.GetLastStatus().status.GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: NotFound for different fabric
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(2);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_EQ(updateHandler.GetLastStatus().status.GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: Success with empty motion zones list
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> zonesList;
+        updateData.motionZones.SetValue(DataModel::MakeNullable(zonesList));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_TRUE(updateHandler.GetLastStatus().status.IsSuccess());
+    }
+}
+
 } // namespace PushAvStreamTransport
 } // namespace Clusters
 } // namespace app

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -1786,6 +1786,116 @@ TEST_F(MockEventLogging, Test_AllocateTransport_UpdateMotionZoneOptions)
         mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
         EXPECT_TRUE(updateHandler.HasStatus());
         EXPECT_TRUE(updateHandler.GetLastStatus().status.IsSuccess());
+
+        EXPECT_EQ(mServer.GetLogic().mCurrentConnections.size(), (size_t) 1);
+        auto currentConnection = mServer.GetLogic().mCurrentConnections[0];
+        EXPECT_EQ(currentConnection.connectionID, allocatedConnectionID);
+        EXPECT_TRUE(currentConnection.transportOptions.HasValue());
+        auto lTransportOptions = currentConnection.transportOptions.Value();
+        auto lTriggerOptions   = lTransportOptions.triggerOptions;
+        EXPECT_TRUE(lTriggerOptions.motionZones.HasValue());
+        EXPECT_FALSE(lTriggerOptions.motionZones.Value().IsNull());
+        EXPECT_EQ(lTriggerOptions.motionZones.Value().Value().size(), (size_t) 0);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: Success with updated non-empty motion zones list and sensitivity
+     */
+    {
+        uint8_t updateTlvBuffer[256];
+        Structs::TransportZoneOptionsStruct::Type updateZone;
+        DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> updateDecodedList;
+
+        updateZone.zone.SetNonNull(3);
+        updateZone.sensitivity.SetValue(8);
+
+        TLV::TLVWriter updateWriter;
+        updateWriter.Init(updateTlvBuffer, sizeof(updateTlvBuffer));
+
+        TLV::TLVWriter updateContainerWriter;
+        CHIP_ERROR errUpdate = updateWriter.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, updateContainerWriter);
+        EXPECT_EQ(errUpdate, CHIP_NO_ERROR);
+
+        errUpdate = DataModel::Encode(updateContainerWriter, TLV::AnonymousTag(), updateZone);
+        EXPECT_EQ(errUpdate, CHIP_NO_ERROR);
+
+        errUpdate = updateWriter.CloseContainer(updateContainerWriter);
+        EXPECT_EQ(errUpdate, CHIP_NO_ERROR);
+
+        TLV::TLVReader updateReader;
+        updateReader.Init(updateTlvBuffer, static_cast<uint32_t>(updateWriter.GetLengthWritten()));
+        errUpdate = updateReader.Next();
+        EXPECT_EQ(errUpdate, CHIP_NO_ERROR);
+
+        errUpdate = updateDecodedList.Decode(updateReader);
+        EXPECT_EQ(errUpdate, CHIP_NO_ERROR);
+
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionZones.SetValue(DataModel::MakeNullable(updateDecodedList));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_TRUE(updateHandler.GetLastStatus().status.IsSuccess());
+
+        auto currentConnection = mServer.GetLogic().mCurrentConnections[0];
+        EXPECT_EQ(currentConnection.connectionID, allocatedConnectionID);
+        EXPECT_TRUE(currentConnection.transportOptions.HasValue());
+        auto lTransportOptions = currentConnection.transportOptions.Value();
+        auto lTriggerOptions   = lTransportOptions.triggerOptions;
+
+        EXPECT_TRUE(lTriggerOptions.motionZones.HasValue());
+        EXPECT_FALSE(lTriggerOptions.motionZones.Value().IsNull());
+        const auto & updatedZonesList = lTriggerOptions.motionZones.Value().Value();
+        EXPECT_EQ(updatedZonesList.size(), (size_t) 1);
+        EXPECT_FALSE(updatedZonesList[0].zone.IsNull());
+        EXPECT_EQ(updatedZonesList[0].zone.Value(), 3);
+        EXPECT_TRUE(updatedZonesList[0].sensitivity.HasValue());
+        EXPECT_EQ(updatedZonesList[0].sensitivity.Value(), 8);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: InvalidCommand when motionSensitivity provided with PerZoneSensitivity feature
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionSensitivity.SetValue(DataModel::MakeNullable(static_cast<uint8_t>(7)));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_EQ(updateHandler.GetLastStatus().status.GetStatus(), Protocols::InteractionModel::Status::InvalidCommand);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: Success with null motion zones list
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionZones.SetValue(DataModel::NullNullable);
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_TRUE(updateHandler.GetLastStatus().status.IsSuccess());
+
+        auto currentConnection = mServer.GetLogic().mCurrentConnections[0];
+        EXPECT_EQ(currentConnection.connectionID, allocatedConnectionID);
+        EXPECT_TRUE(currentConnection.transportOptions.HasValue());
+        auto lTransportOptions = currentConnection.transportOptions.Value();
+        auto lTriggerOptions   = lTransportOptions.triggerOptions;
+
+        EXPECT_TRUE(lTriggerOptions.motionZones.HasValue());
+        EXPECT_TRUE(lTriggerOptions.motionZones.Value().IsNull());
     }
 }
 

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -90,6 +90,44 @@ protected:
     chip::Testing::ClusterTester mClusterTester;
 };
 
+class MockEventLoggingNoPerZoneSensitivity : public Testing::AppContext
+{
+public:
+    MockEventLoggingNoPerZoneSensitivity() : mClusterTester(mServer) {}
+
+    void SetUp() override
+    {
+        const LogStorageResources logStorageResources[] = {
+            { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), PriorityLevel::Debug },
+            { &gInfoEventBuffer[0], sizeof(gInfoEventBuffer), PriorityLevel::Info },
+            { &gCritEventBuffer[0], sizeof(gCritEventBuffer), PriorityLevel::Critical },
+        };
+
+        AppContext::SetUp();
+
+        ASSERT_EQ(mEventCounter.Init(0), CHIP_NO_ERROR);
+
+        EventManagement::CreateEventManagement(&GetExchangeManager(), std::size(logStorageResources), gCircularEventBuffer,
+                                               logStorageResources, &mEventCounter);
+
+        ASSERT_EQ(mPersistenceProvider.Init(&mClusterTester.GetServerClusterContext().storage), CHIP_NO_ERROR);
+        app::SetSafeAttributePersistenceProvider(&mPersistenceProvider);
+    }
+
+    void TearDown() override
+    {
+        app::SetSafeAttributePersistenceProvider(nullptr);
+        EventManagement::DestroyEventManagement();
+        AppContext::TearDown();
+    }
+
+protected:
+    MonotonicallyIncreasingCounter<EventNumber> mEventCounter;
+    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
+    Clusters::PushAvStreamTransportServer mServer{ 1, BitFlags<Clusters::PushAvStreamTransport::Feature>() };
+    chip::Testing::ClusterTester mClusterTester;
+};
+
 } // namespace app
 } // namespace chip
 
@@ -1775,12 +1813,31 @@ TEST_F(MockEventLogging, Test_AllocateTransport_UpdateMotionZoneOptions)
      * Test UpdateMotionZoneOptions: Success with empty motion zones list
      */
     {
+        uint8_t emptyTlvBuffer[32];
+        TLV::TLVWriter emptyWriter;
+        emptyWriter.Init(emptyTlvBuffer, sizeof(emptyTlvBuffer));
+
+        TLV::TLVWriter emptyContainerWriter;
+        CHIP_ERROR errEmpty = emptyWriter.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, emptyContainerWriter);
+        EXPECT_EQ(errEmpty, CHIP_NO_ERROR);
+
+        errEmpty = emptyWriter.CloseContainer(emptyContainerWriter);
+        EXPECT_EQ(errEmpty, CHIP_NO_ERROR);
+
+        TLV::TLVReader emptyReader;
+        emptyReader.Init(emptyTlvBuffer, static_cast<uint32_t>(emptyWriter.GetLengthWritten()));
+        errEmpty = emptyReader.Next();
+        EXPECT_EQ(errEmpty, CHIP_NO_ERROR);
+
+        DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> zonesList;
+        errEmpty = zonesList.Decode(emptyReader);
+        EXPECT_EQ(errEmpty, CHIP_NO_ERROR);
+
         Testing::MockCommandHandler updateHandler;
         updateHandler.SetFabricIndex(1);
         ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
         Commands::UpdateMotionZoneOptions::DecodableType updateData;
         updateData.connectionID = allocatedConnectionID;
-        DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> zonesList;
         updateData.motionZones.SetValue(DataModel::MakeNullable(zonesList));
 
         mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
@@ -1796,6 +1853,42 @@ TEST_F(MockEventLogging, Test_AllocateTransport_UpdateMotionZoneOptions)
         EXPECT_TRUE(lTriggerOptions.motionZones.HasValue());
         EXPECT_FALSE(lTriggerOptions.motionZones.Value().IsNull());
         EXPECT_EQ(lTriggerOptions.motionZones.Value().Value().size(), (size_t) 0);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: InvalidCommand when zone entry is missing sensitivity with PerZoneSensitivity feature
+     */
+    {
+        uint8_t noSensTlvBuffer[256];
+        Structs::TransportZoneOptionsStruct::Type noSensZone;
+        DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> noSensDecodedList;
+
+        noSensZone.zone.SetNonNull(4);
+        noSensZone.sensitivity.ClearValue();
+
+        TLV::TLVWriter noSensWriter;
+        noSensWriter.Init(noSensTlvBuffer, sizeof(noSensTlvBuffer));
+
+        TLV::TLVWriter noSensContainerWriter;
+        EXPECT_EQ(noSensWriter.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, noSensContainerWriter), CHIP_NO_ERROR);
+        EXPECT_EQ(DataModel::Encode(noSensContainerWriter, TLV::AnonymousTag(), noSensZone), CHIP_NO_ERROR);
+        EXPECT_EQ(noSensWriter.CloseContainer(noSensContainerWriter), CHIP_NO_ERROR);
+
+        TLV::TLVReader noSensReader;
+        noSensReader.Init(noSensTlvBuffer, static_cast<uint32_t>(noSensWriter.GetLengthWritten()));
+        EXPECT_EQ(noSensReader.Next(), CHIP_NO_ERROR);
+        EXPECT_EQ(noSensDecodedList.Decode(noSensReader), CHIP_NO_ERROR);
+
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionZones.SetValue(DataModel::MakeNullable(noSensDecodedList));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_EQ(updateHandler.GetLastStatus().status.GetStatus(), Protocols::InteractionModel::Status::InvalidCommand);
     }
 
     /*
@@ -1896,6 +1989,264 @@ TEST_F(MockEventLogging, Test_AllocateTransport_UpdateMotionZoneOptions)
 
         EXPECT_TRUE(lTriggerOptions.motionZones.HasValue());
         EXPECT_TRUE(lTriggerOptions.motionZones.Value().IsNull());
+    }
+}
+
+TEST_F(MockEventLoggingNoPerZoneSensitivity, Test_AllocateTransport_UpdateMotionZoneOptions_NoPerZoneSensitivity)
+{
+    CMAFContainerOptionsStruct cmafContainerOptions;
+    ContainerOptionsStruct containerOptions;
+    TransportMotionTriggerTimeControlDecodableStruct motionTimeControl;
+    TransportTriggerOptionsDecodableStruct triggerOptions;
+    TransportOptionsDecodableStruct transportOptions;
+
+    std::string url = "https://192.168.1.100:554/stream/";
+
+    cmafContainerOptions.segmentDuration = 1000;
+    cmafContainerOptions.chunkDuration   = 500;
+    std::string trackName                = "video";
+    cmafContainerOptions.trackName.SetValue(Span(trackName.data(), trackName.size()));
+    cmafContainerOptions.metadataEnabled.ClearValue();
+
+    containerOptions.containerType = ContainerFormatEnum::kCmaf;
+    containerOptions.CMAFContainerOptions.SetValue(cmafContainerOptions);
+
+    motionTimeControl.initialDuration      = 5000;
+    motionTimeControl.augmentationDuration = 2000;
+    motionTimeControl.maxDuration          = 30000;
+    motionTimeControl.blindDuration        = 1000;
+
+    triggerOptions.triggerType = TransportTriggerTypeEnum::kMotion;
+
+    uint8_t tlvBuffer[512];
+    Structs::TransportZoneOptionsStruct::Type zone1;
+    DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> decodedList;
+
+    zone1.zone.SetNonNull(1);
+    zone1.sensitivity.ClearValue();
+
+    TLV::TLVWriter writer;
+    writer.Init(tlvBuffer, sizeof(tlvBuffer));
+
+    TLV::TLVWriter containerWriter;
+    CHIP_ERROR err = writer.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, containerWriter);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = DataModel::Encode(containerWriter, TLV::AnonymousTag(), zone1);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writer.CloseContainer(containerWriter);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    TLV::TLVReader motionZonesReader;
+    motionZonesReader.Init(tlvBuffer, static_cast<uint32_t>(writer.GetLengthWritten()));
+    err = motionZonesReader.Next();
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = decodedList.Decode(motionZonesReader);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    triggerOptions.motionZones.SetValue(DataModel::MakeNullable(decodedList));
+    triggerOptions.motionSensitivity.SetValue(DataModel::MakeNullable(static_cast<uint8_t>(5)));
+    triggerOptions.motionTimeControl.SetValue(motionTimeControl);
+    triggerOptions.maxPreRollLen.SetValue(1000);
+
+    transportOptions.streamUsage = StreamUsageEnum::kAnalysis;
+    transportOptions.videoStreamID.SetValue(1);
+    transportOptions.audioStreamID.SetValue(2);
+    transportOptions.TLSEndpointID    = 1;
+    transportOptions.url              = Span(url.data(), url.size());
+    transportOptions.triggerOptions   = triggerOptions;
+    transportOptions.containerOptions = containerOptions;
+    transportOptions.expiryTime.ClearValue();
+
+    TestPushAVStreamTransportDelegateImpl mockDelegate;
+    TestTLSClientManagementDelegate tlsClientManagementDelegate;
+
+    Testing::MockCommandHandler commandHandler;
+    commandHandler.SetFabricIndex(1);
+    ConcreteCommandPath kCommandPath{ 1, Clusters::PushAvStreamTransport::Id, Commands::AllocatePushTransport::Id };
+    Commands::AllocatePushTransport::DecodableType commandData;
+    commandData.transportOptions = transportOptions;
+
+    EXPECT_EQ(mServer.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
+
+    mServer.GetLogic().SetDelegate(&mockDelegate);
+    mServer.GetLogic().SetTLSClientManagementDelegate(&tlsClientManagementDelegate);
+    EXPECT_EQ(mServer.Init(), CHIP_NO_ERROR);
+
+    EXPECT_EQ(mServer.GetLogic().HandleAllocatePushTransport(commandHandler, kCommandPath, commandData), std::nullopt);
+    EXPECT_EQ(mServer.GetLogic().mCurrentConnections.size(), (size_t) 1);
+
+    uint16_t allocatedConnectionID = mServer.GetLogic().mCurrentConnections[0].connectionID;
+
+    /*
+     * Test UpdateMotionZoneOptions: ConstraintError when motionSensitivity is 0 (out of range)
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionSensitivity.SetValue(DataModel::MakeNullable(static_cast<uint8_t>(0)));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_EQ(updateHandler.GetLastStatus().status.GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: ConstraintError when motionSensitivity is 11 (out of range)
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionSensitivity.SetValue(DataModel::MakeNullable(static_cast<uint8_t>(11)));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_EQ(updateHandler.GetLastStatus().status.GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: Success updating motionSensitivity to valid value (7)
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionSensitivity.SetValue(DataModel::MakeNullable(static_cast<uint8_t>(7)));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_TRUE(updateHandler.GetLastStatus().status.IsSuccess());
+
+        auto currentConnection = mServer.GetLogic().mCurrentConnections[0];
+        EXPECT_EQ(currentConnection.connectionID, allocatedConnectionID);
+        EXPECT_TRUE(currentConnection.transportOptions.HasValue());
+        auto lTransportOptions = currentConnection.transportOptions.Value();
+        auto lTriggerOptions   = lTransportOptions.triggerOptions;
+
+        EXPECT_TRUE(lTriggerOptions.motionSensitivity.HasValue());
+        EXPECT_FALSE(lTriggerOptions.motionSensitivity.Value().IsNull());
+        EXPECT_EQ(lTriggerOptions.motionSensitivity.Value().Value(), 7);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: Success updating motionSensitivity to Null
+     */
+    {
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionSensitivity.SetValue(DataModel::NullNullable);
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_TRUE(updateHandler.GetLastStatus().status.IsSuccess());
+
+        auto currentConnection = mServer.GetLogic().mCurrentConnections[0];
+        EXPECT_EQ(currentConnection.connectionID, allocatedConnectionID);
+        EXPECT_TRUE(currentConnection.transportOptions.HasValue());
+        auto lTransportOptions = currentConnection.transportOptions.Value();
+        auto lTriggerOptions   = lTransportOptions.triggerOptions;
+
+        EXPECT_TRUE(lTriggerOptions.motionSensitivity.HasValue());
+        EXPECT_TRUE(lTriggerOptions.motionSensitivity.Value().IsNull());
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: InvalidCommand when zone entry includes sensitivity without PerZoneSensitivity feature
+     */
+    {
+        uint8_t sensTlvBuffer[256];
+        Structs::TransportZoneOptionsStruct::Type sensZone;
+        DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> sensDecodedList;
+
+        sensZone.zone.SetNonNull(2);
+        sensZone.sensitivity.SetValue(5);
+
+        TLV::TLVWriter sensWriter;
+        sensWriter.Init(sensTlvBuffer, sizeof(sensTlvBuffer));
+
+        TLV::TLVWriter sensContainerWriter;
+        EXPECT_EQ(sensWriter.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, sensContainerWriter), CHIP_NO_ERROR);
+        EXPECT_EQ(DataModel::Encode(sensContainerWriter, TLV::AnonymousTag(), sensZone), CHIP_NO_ERROR);
+        EXPECT_EQ(sensWriter.CloseContainer(sensContainerWriter), CHIP_NO_ERROR);
+
+        TLV::TLVReader sensReader;
+        sensReader.Init(sensTlvBuffer, static_cast<uint32_t>(sensWriter.GetLengthWritten()));
+        EXPECT_EQ(sensReader.Next(), CHIP_NO_ERROR);
+        EXPECT_EQ(sensDecodedList.Decode(sensReader), CHIP_NO_ERROR);
+
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionZones.SetValue(DataModel::MakeNullable(sensDecodedList));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_EQ(updateHandler.GetLastStatus().status.GetStatus(), Protocols::InteractionModel::Status::InvalidCommand);
+    }
+
+    /*
+     * Test UpdateMotionZoneOptions: Success updating motionZones without sensitivity when PerZoneSensitivity is disabled
+     */
+    {
+        uint8_t updateTlvBuffer[256];
+        Structs::TransportZoneOptionsStruct::Type updateZone;
+        DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> updateDecodedList;
+
+        updateZone.zone.SetNonNull(2);
+        updateZone.sensitivity.ClearValue();
+
+        TLV::TLVWriter updateWriter;
+        updateWriter.Init(updateTlvBuffer, sizeof(updateTlvBuffer));
+
+        TLV::TLVWriter updateContainerWriter;
+        EXPECT_EQ(updateWriter.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, updateContainerWriter), CHIP_NO_ERROR);
+        EXPECT_EQ(DataModel::Encode(updateContainerWriter, TLV::AnonymousTag(), updateZone), CHIP_NO_ERROR);
+        EXPECT_EQ(updateWriter.CloseContainer(updateContainerWriter), CHIP_NO_ERROR);
+
+        TLV::TLVReader updateReader;
+        updateReader.Init(updateTlvBuffer, static_cast<uint32_t>(updateWriter.GetLengthWritten()));
+        EXPECT_EQ(updateReader.Next(), CHIP_NO_ERROR);
+        EXPECT_EQ(updateDecodedList.Decode(updateReader), CHIP_NO_ERROR);
+
+        Testing::MockCommandHandler updateHandler;
+        updateHandler.SetFabricIndex(1);
+        ConcreteCommandPath kUpdatePath{ 1, Clusters::PushAvStreamTransport::Id, Commands::UpdateMotionZoneOptions::Id };
+        Commands::UpdateMotionZoneOptions::DecodableType updateData;
+        updateData.connectionID = allocatedConnectionID;
+        updateData.motionZones.SetValue(DataModel::MakeNullable(updateDecodedList));
+
+        mServer.GetLogic().HandleUpdateMotionZoneOptions(updateHandler, kUpdatePath, updateData);
+        EXPECT_TRUE(updateHandler.HasStatus());
+        EXPECT_TRUE(updateHandler.GetLastStatus().status.IsSuccess());
+
+        auto currentConnection = mServer.GetLogic().mCurrentConnections[0];
+        EXPECT_EQ(currentConnection.connectionID, allocatedConnectionID);
+        EXPECT_TRUE(currentConnection.transportOptions.HasValue());
+        auto lTransportOptions = currentConnection.transportOptions.Value();
+        auto lTriggerOptions   = lTransportOptions.triggerOptions;
+
+        EXPECT_TRUE(lTriggerOptions.motionZones.HasValue());
+        EXPECT_FALSE(lTriggerOptions.motionZones.Value().IsNull());
+        const auto & updatedZonesList = lTriggerOptions.motionZones.Value().Value();
+        EXPECT_EQ(updatedZonesList.size(), (size_t) 1);
+        EXPECT_FALSE(updatedZonesList[0].zone.IsNull());
+        EXPECT_EQ(updatedZonesList[0].zone.Value(), 2);
+        EXPECT_FALSE(updatedZonesList[0].sensitivity.HasValue());
     }
 }
 

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportStorage.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportStorage.cpp
@@ -1119,6 +1119,81 @@ TEST_F(TestPushAVStreamTransportStorage, TestTransportOptionsStorage_DecodableTy
     }
 }
 
+TEST_F(TestPushAVStreamTransportStorage, TestUpdateMotionZonesAndSensitivity)
+{
+    TransportTriggerOptionsStorage triggerStorage;
+
+    // Test UpdateMotionSensitivity
+    triggerStorage.UpdateMotionSensitivity(MakeOptional(DataModel::MakeNullable(static_cast<uint8_t>(6))));
+    EXPECT_TRUE(triggerStorage.motionSensitivity.HasValue());
+    EXPECT_FALSE(triggerStorage.motionSensitivity.Value().IsNull());
+    EXPECT_EQ(triggerStorage.motionSensitivity.Value().Value(), 6);
+
+    // Update to Null
+    triggerStorage.UpdateMotionSensitivity(MakeOptional(DataModel::Nullable<uint8_t>()));
+    EXPECT_TRUE(triggerStorage.motionSensitivity.HasValue());
+    EXPECT_TRUE(triggerStorage.motionSensitivity.Value().IsNull());
+
+    // Update with empty optional (no-op)
+    triggerStorage.UpdateMotionSensitivity(Optional<DataModel::Nullable<uint8_t>>());
+    EXPECT_TRUE(triggerStorage.motionSensitivity.HasValue());
+    EXPECT_TRUE(triggerStorage.motionSensitivity.Value().IsNull());
+
+    // Test UpdateMotionZones with empty list
+    DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> emptyList;
+    triggerStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(emptyList)));
+    EXPECT_TRUE(triggerStorage.motionZones.HasValue());
+    EXPECT_FALSE(triggerStorage.motionZones.Value().IsNull());
+    EXPECT_EQ(triggerStorage.motionZones.Value().Value().size(), (size_t) 0);
+
+    // Test UpdateMotionZones with non-empty list
+    uint8_t tlvBuf[256];
+    Structs::TransportZoneOptionsStruct::Type z1;
+    z1.zone.SetNonNull(10);
+    z1.sensitivity.SetValue(3);
+
+    TLV::TLVWriter writer;
+    writer.Init(tlvBuf, sizeof(tlvBuf));
+    TLV::TLVWriter arrayWriter;
+    EXPECT_EQ(writer.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, arrayWriter), CHIP_NO_ERROR);
+    EXPECT_EQ(DataModel::Encode(arrayWriter, TLV::AnonymousTag(), z1), CHIP_NO_ERROR);
+    EXPECT_EQ(writer.CloseContainer(arrayWriter), CHIP_NO_ERROR);
+
+    TLV::TLVReader reader;
+    reader.Init(tlvBuf, static_cast<uint32_t>(writer.GetLengthWritten()));
+    EXPECT_EQ(reader.Next(), CHIP_NO_ERROR);
+
+    DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> decodedList;
+    EXPECT_EQ(decodedList.Decode(reader), CHIP_NO_ERROR);
+
+    triggerStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(decodedList)));
+    EXPECT_TRUE(triggerStorage.motionZones.HasValue());
+    EXPECT_FALSE(triggerStorage.motionZones.Value().IsNull());
+    EXPECT_EQ(triggerStorage.motionZones.Value().Value().size(), (size_t) 1);
+    EXPECT_EQ(triggerStorage.motionZones.Value().Value()[0].zone.Value(), 10);
+    EXPECT_EQ(triggerStorage.motionZones.Value().Value()[0].sensitivity.Value(), 3);
+
+    // Test UpdateMotionZones with null
+    DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>> nullZones;
+    triggerStorage.UpdateMotionZones(MakeOptional(nullZones));
+    EXPECT_TRUE(triggerStorage.motionZones.HasValue());
+    EXPECT_TRUE(triggerStorage.motionZones.Value().IsNull());
+
+    // Test TransportOptionsStorage wrapper
+    TransportOptionsStorage optionsStorage;
+    optionsStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(decodedList)));
+    optionsStorage.UpdateMotionSensitivity(MakeOptional(DataModel::MakeNullable(static_cast<uint8_t>(9))));
+
+    EXPECT_TRUE(optionsStorage.triggerOptions.motionZones.HasValue());
+    EXPECT_FALSE(optionsStorage.triggerOptions.motionZones.Value().IsNull());
+    EXPECT_EQ(optionsStorage.triggerOptions.motionZones.Value().Value().size(), (size_t) 1);
+    EXPECT_EQ(optionsStorage.triggerOptions.motionZones.Value().Value()[0].zone.Value(), 10);
+
+    EXPECT_TRUE(optionsStorage.triggerOptions.motionSensitivity.HasValue());
+    EXPECT_FALSE(optionsStorage.triggerOptions.motionSensitivity.Value().IsNull());
+    EXPECT_EQ(optionsStorage.triggerOptions.motionSensitivity.Value().Value(), 9);
+}
+
 } // namespace PushAvStreamTransport
 } // namespace Clusters
 } // namespace app

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportStorage.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportStorage.cpp
@@ -1140,8 +1140,19 @@ TEST_F(TestPushAVStreamTransportStorage, TestUpdateMotionZonesAndSensitivity)
     EXPECT_TRUE(triggerStorage.motionSensitivity.Value().IsNull());
 
     // Test UpdateMotionZones with empty list
+    uint8_t emptyTlvBuf[16];
+    TLV::TLVWriter emptyWriter;
+    emptyWriter.Init(emptyTlvBuf, sizeof(emptyTlvBuf));
+    TLV::TLVWriter emptyArrayWriter;
+    EXPECT_EQ(emptyWriter.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, emptyArrayWriter), CHIP_NO_ERROR);
+    EXPECT_EQ(emptyWriter.CloseContainer(emptyArrayWriter), CHIP_NO_ERROR);
+    TLV::TLVReader emptyReader;
+    emptyReader.Init(emptyTlvBuf, static_cast<uint32_t>(emptyWriter.GetLengthWritten()));
+    EXPECT_EQ(emptyReader.Next(), CHIP_NO_ERROR);
     DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> emptyList;
-    triggerStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(emptyList)));
+    EXPECT_EQ(emptyList.Decode(emptyReader), CHIP_NO_ERROR);
+
+    EXPECT_EQ(triggerStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(emptyList))), CHIP_NO_ERROR);
     EXPECT_TRUE(triggerStorage.motionZones.HasValue());
     EXPECT_FALSE(triggerStorage.motionZones.Value().IsNull());
     EXPECT_EQ(triggerStorage.motionZones.Value().Value().size(), (size_t) 0);
@@ -1166,7 +1177,7 @@ TEST_F(TestPushAVStreamTransportStorage, TestUpdateMotionZonesAndSensitivity)
     DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType> decodedList;
     EXPECT_EQ(decodedList.Decode(reader), CHIP_NO_ERROR);
 
-    triggerStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(decodedList)));
+    EXPECT_EQ(triggerStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(decodedList))), CHIP_NO_ERROR);
     EXPECT_TRUE(triggerStorage.motionZones.HasValue());
     EXPECT_FALSE(triggerStorage.motionZones.Value().IsNull());
     EXPECT_EQ(triggerStorage.motionZones.Value().Value().size(), (size_t) 1);
@@ -1175,13 +1186,13 @@ TEST_F(TestPushAVStreamTransportStorage, TestUpdateMotionZonesAndSensitivity)
 
     // Test UpdateMotionZones with null
     DataModel::Nullable<DataModel::DecodableList<Structs::TransportZoneOptionsStruct::DecodableType>> nullZones;
-    triggerStorage.UpdateMotionZones(MakeOptional(nullZones));
+    EXPECT_EQ(triggerStorage.UpdateMotionZones(MakeOptional(nullZones)), CHIP_NO_ERROR);
     EXPECT_TRUE(triggerStorage.motionZones.HasValue());
     EXPECT_TRUE(triggerStorage.motionZones.Value().IsNull());
 
     // Test TransportOptionsStorage wrapper
     TransportOptionsStorage optionsStorage;
-    optionsStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(decodedList)));
+    EXPECT_EQ(optionsStorage.UpdateMotionZones(MakeOptional(DataModel::MakeNullable(decodedList))), CHIP_NO_ERROR);
     optionsStorage.UpdateMotionSensitivity(MakeOptional(DataModel::MakeNullable(static_cast<uint8_t>(9))));
 
     EXPECT_TRUE(optionsStorage.triggerOptions.motionZones.HasValue());


### PR DESCRIPTION
### Summary
Implement UpdateMotionZoneOptions command:

- Add UpdateMotionZoneOptions command handling in PushAvStreamTransportServerLogic and dispatch in PushAvStreamTransportServer.
- Support updating motion sensitivity and motion zones in TransportTriggerOptionsStorage and TransportOptionsStorage.
- Add UpdateMotionZoneOptions method to PushAvStreamTransportDelegate defaulting to ModifyPushTransport.
- Enable UpdateMotionZoneOptions in camera-app.matter and camera-app.zap.
- Fix ValidateMotionZoneListSize in camera-app to allow lists up to MaxZones.
- Add unit test Test_AllocateTransport_UpdateMotionZoneOptions to TestPushAVStreamTransportCluster.

### Related issues

### Testing
Added unit test and verified with TC_PAVST_TC_2_15.py from https://github.com/project-chip/connectedhomeip/pull/73856 
