### PR TITLE
Update compatible builds to docker version 211

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -192,7 +192,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -383,7 +383,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -451,7 +451,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -588,7 +588,7 @@ jobs:
         runs-on: namespace-profile-4x16
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -137,7 +137,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nrf-platform:211
+            image: ghcr.io/project-chip/chip-build-nrf-platform:210
             volumes:
                 - "/:/runner-root-volume"
             options: --user root

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -137,7 +137,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nrf-platform:210
+            image: ghcr.io/project-chip/chip-build-nrf-platform:200
             volumes:
                 - "/:/runner-root-volume"
             options: --user root

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/:/runner-root-volume"
             options: --user root
@@ -65,7 +65,7 @@ jobs:
         timeout-minutes: 90
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             options: >-
                 --privileged
                 --sysctl net.ipv6.conf.all.disable_ipv6=0
@@ -108,7 +108,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:200
+            image: ghcr.io/project-chip/chip-build-esp32:211
             volumes:
                 - "/:/runner-root-volume"
             options: --user root
@@ -137,7 +137,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nrf-platform:200
+            image: ghcr.io/project-chip/chip-build-nrf-platform:211
             volumes:
                 - "/:/runner-root-volume"
             options: --user root
@@ -165,7 +165,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:200
+            image: ghcr.io/project-chip/chip-build-telink:211
             volumes:
                 - "/:/runner-root-volume"
             options: --user root

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -84,7 +84,7 @@ jobs:
 
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build-doxygen:200
+            image: ghcr.io/project-chip/chip-build-doxygen:211
 
         if: github.actor != 'restyled-io[bot]'
 

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-ameba:200
+            image: ghcr.io/project-chip/chip-build-ameba:211
             options: --user root
 
         steps:

--- a/.github/workflows/examples-asr.yaml
+++ b/.github/workflows/examples-asr.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-asr:200
+            image: ghcr.io/project-chip/chip-build-asr:211
             options: --user root
             volumes:
                 - "/:/runner-root-volume"

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -38,7 +38,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-bouffalolab:200
+      image: ghcr.io/project-chip/chip-build-bouffalolab:211
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
         - "/:/runner-root-volume"

--- a/.github/workflows/examples-cc13xx_26xx.yaml
+++ b/.github/workflows/examples-cc13xx_26xx.yaml
@@ -42,7 +42,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-ti:200
+            image: ghcr.io/project-chip/chip-build-ti:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -41,7 +41,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-ti:200
+            image: ghcr.io/project-chip/chip-build-ti:211
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -41,7 +41,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-efr32:206
+      image: ghcr.io/project-chip/chip-build-efr32:211
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
         - "/:/runner-root-volume"

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:200
+            image: ghcr.io/project-chip/chip-build-esp32:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
@@ -197,7 +197,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]' &&  github.repository_owner == 'espressif'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:200
+            image: ghcr.io/project-chip/chip-build-esp32:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-infineon:211
+            image: ghcr.io/project-chip/chip-build-infineon:200
             env:
                # TODO: this should probably be part of the dockerfile itself
                CY_TOOLS_PATHS: /opt/Tools/ModusToolbox/tools_3.2

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-infineon:200
+            image: ghcr.io/project-chip/chip-build-infineon:211
             env:
                # TODO: this should probably be part of the dockerfile itself
                CY_TOOLS_PATHS: /opt/Tools/ModusToolbox/tools_3.2

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-crosscompile:200
+            image: ghcr.io/project-chip/chip-build-crosscompile:211
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-imx:200
+            image: ghcr.io/project-chip/chip-build-imx:211
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-linux-tv-casting-app.yaml
+++ b/.github/workflows/examples-linux-tv-casting-app.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nrf-platform:210
+            image: ghcr.io/project-chip/chip-build-nrf-platform:200
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nrf-platform:200
+            image: ghcr.io/project-chip/chip-build-nrf-platform:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nrf-platform:211
+            image: ghcr.io/project-chip/chip-build-nrf-platform:210
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-nuttx.yaml
+++ b/.github/workflows/examples-nuttx.yaml
@@ -47,7 +47,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-nuttx:200
+      image: ghcr.io/project-chip/chip-build-nuttx:211
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -43,7 +43,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp:200
+            image: ghcr.io/project-chip/chip-build-nxp:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
@@ -148,7 +148,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:203
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:211
             volumes:
                 - "/:/runner-root-volume"
 

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-realtek.yaml
+++ b/.github/workflows/examples-realtek.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-silabs-zephyr.yaml
+++ b/.github/workflows/examples-silabs-zephyr.yaml
@@ -37,7 +37,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-silabs-zephyr:202
+      image: ghcr.io/project-chip/chip-build-silabs-zephyr:211
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/examples-stm32.yaml
+++ b/.github/workflows/examples-stm32.yaml
@@ -41,7 +41,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/:/runner-root-volume"

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -39,7 +39,7 @@ jobs:
             BUILD_TYPE: telink
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
 
         steps:
             - name: Checkout
@@ -74,7 +74,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:200
+            image: ghcr.io/project-chip/chip-build-telink:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-tizen:200
+            image: ghcr.io/project-chip/chip-build-tizen:211
             options: --user root
             volumes:
                 - "/:/runner-root-volume"

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-tizen:211
+            image: ghcr.io/project-chip/chip-build-tizen:200
             options: --user root
             volumes:
                 - "/:/runner-root-volume"

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:200
+            image: ghcr.io/project-chip/chip-build-android:211
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -33,7 +33,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-java:200
+            image: ghcr.io/project-chip/chip-build-java:211
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
 
         steps:
             - name: Checkout

--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-minimal:200
+            image: ghcr.io/project-chip/chip-build-minimal:211
 
         steps:
             - name: Checkout
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-minimal:200
+            image: ghcr.io/project-chip/chip-build-minimal:211
 
         steps:
             - name: Checkout

--- a/.github/workflows/mypy-validation.yml
+++ b/.github/workflows/mypy-validation.yml
@@ -37,7 +37,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build:200
+      image: ghcr.io/project-chip/chip-build:211
       options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -59,7 +59,7 @@ jobs:
         runs-on: namespace-profile-4x16
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - /var/run/nsc/:/var/run/nsc/
             env:
@@ -231,7 +231,7 @@ jobs:
         runs-on: namespace-profile-1x2
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - /var/run/nsc/:/var/run/nsc/
             env:
@@ -411,7 +411,7 @@ jobs:
         runs-on: namespace-profile-4x16
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - /var/run/nsc/:/var/run/nsc/
             env:

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -85,7 +85,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-tizen-qemu:211
+            image: ghcr.io/project-chip/chip-build-tizen-qemu:200
             options: --user root
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -85,7 +85,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-tizen-qemu:200
+            image: ghcr.io/project-chip/chip-build-tizen-qemu:211
             options: --user root
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:200
+            image: ghcr.io/project-chip/chip-build-esp32:211
 
         steps:
             - name: Checkout
@@ -69,7 +69,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-efr32:206
+            image: ghcr.io/project-chip/chip-build-efr32:211
         steps:
             - name: Checkout
               uses: actions/checkout@v7

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:200
+            image: ghcr.io/project-chip/chip-build-android:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             options: >-
                 --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
@@ -794,7 +794,7 @@ jobs:
         runs-on: namespace-profile-16x32
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - /var/run/nsc/:/var/run/nsc/
             env:
@@ -1091,7 +1091,7 @@ jobs:
         runs-on: namespace-profile-1x2
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - /var/run/nsc/:/var/run/nsc/
             env:

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -40,7 +40,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -99,7 +99,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -30,7 +30,7 @@ jobs:
 
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
         defaults:
             run:
                 shell: sh

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -35,7 +35,7 @@ jobs:
 
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build:200
+            image: ghcr.io/project-chip/chip-build:211
         defaults:
             run:
                 shell: sh

--- a/examples/all-clusters-app/ameba/README.md
+++ b/examples/all-clusters-app/ameba/README.md
@@ -27,11 +27,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:200
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:211
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:200
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:211
 
 -   Setup build environment:
 

--- a/examples/all-clusters-minimal-app/ameba/README.md
+++ b/examples/all-clusters-minimal-app/ameba/README.md
@@ -27,13 +27,13 @@ The CHIP demo application is supported on
 -   Pull docker image:
 
           ```
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:200
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:211
           ```
 
 -   Run docker container:
 
           ```
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:200
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:211
           ```
 
 -   Setup build environment:

--- a/examples/camera-app/linux/README.md
+++ b/examples/camera-app/linux/README.md
@@ -78,7 +78,7 @@ environment to ensure all dependencies are correct.
 1. Pull the Cross-Compilation Docker Image
 
 ```
-docker pull ghcr.io/project-chip/chip-build-crosscompile:200
+docker pull ghcr.io/project-chip/chip-build-crosscompile:211
 ```
 
 2. Run the Docker Container This command starts an interactive shell inside the
@@ -86,7 +86,7 @@ docker pull ghcr.io/project-chip/chip-build-crosscompile:200
    container's /var/connectedhomeip directory.
 
 ```
-docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:200 /bin/bash
+docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:211 /bin/bash
 ```
 
 3. Build Inside the Container From within the Docker container's shell, execute

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -95,7 +95,7 @@ environment to ensure all dependencies are correct.
 1. Pull the Cross-Compilation Docker Image
 
 ```
-docker pull ghcr.io/project-chip/chip-build-crosscompile:200
+docker pull ghcr.io/project-chip/chip-build-crosscompile:211
 ```
 
 2. Run the Docker Container This command starts an interactive shell inside the
@@ -103,7 +103,7 @@ docker pull ghcr.io/project-chip/chip-build-crosscompile:200
    container's /var/connectedhomeip directory.
 
 ```
-docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:200 /bin/bash
+docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:211 /bin/bash
 ```
 
 3. Build Inside the Container From within the Docker container's shell, execute

--- a/examples/chef/tests/README.md
+++ b/examples/chef/tests/README.md
@@ -22,7 +22,7 @@ shows all chef tests run in CI.
    container.
 
 ```
-docker run -it --rm ghcr.io/project-chip/chip-build:200 /bin/bash
+docker run -it --rm ghcr.io/project-chip/chip-build:211 /bin/bash
 ```
 
 Run the remaining commands inside the container.

--- a/examples/fabric-admin/README.md
+++ b/examples/fabric-admin/README.md
@@ -23,13 +23,13 @@ For Raspberry Pi 4 example:
 ### Pull Docker Images
 
 ```
-docker pull ghcr.io/project-chip/chip-build-crosscompile:200
+docker pull ghcr.io/project-chip/chip-build-crosscompile:211
 ```
 
 ### Run docker
 
 ```
-docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:200 /bin/bash
+docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:211 /bin/bash
 ```
 
 ### Build

--- a/examples/fabric-bridge-app/linux/README.md
+++ b/examples/fabric-bridge-app/linux/README.md
@@ -100,13 +100,13 @@ defined:
     Pull Docker Images
 
     ```
-    docker pull ghcr.io/project-chip/chip-build-crosscompile:200
+    docker pull ghcr.io/project-chip/chip-build-crosscompile:211
     ```
 
     Run docker
 
     ```
-    docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:200 /bin/bash
+    docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:211 /bin/bash
     ```
 
     Build

--- a/examples/fabric-sync/README.md
+++ b/examples/fabric-sync/README.md
@@ -92,13 +92,13 @@ defined:
     Pull Docker Images
 
     ```sh
-    docker pull ghcr.io/project-chip/chip-build-crosscompile:200
+    docker pull ghcr.io/project-chip/chip-build-crosscompile:211
     ```
 
     Run docker
 
     ```sh
-    docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:200 /bin/bash
+    docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:211 /bin/bash
     ```
 
     Build

--- a/examples/light-switch-app/ameba/README.md
+++ b/examples/light-switch-app/ameba/README.md
@@ -26,11 +26,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:200
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:211
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:200
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:211
 
 -   Setup build environment:
 

--- a/examples/lighting-app/ameba/README.md
+++ b/examples/lighting-app/ameba/README.md
@@ -23,11 +23,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-            $ docker pull ghcr.io/project-chip/chip-build-ameba:200
+            $ docker pull ghcr.io/project-chip/chip-build-ameba:211
 
 -   Run docker container:
 
-            $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:200
+            $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:211
 
 -   Setup build environment:
 

--- a/examples/lighting-app/realtek/zephyr/README.md
+++ b/examples/lighting-app/realtek/zephyr/README.md
@@ -49,13 +49,13 @@ sudo apt-get install git gcc g++ pkg-config libssl-dev libdbus-1-dev libglib2.0-
 -   Step 1: Pull docker image
 
     ```bash
-    $ docker pull ghcr.io/project-chip/chip-build-realtek-zephyr:200
+    $ docker pull ghcr.io/project-chip/chip-build-realtek-zephyr:211
     ```
 
 -   Step 2: Run docker container:
 
     ```bash
-    $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-realtek-zephyr:200
+    $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-realtek-zephyr:211
     ```
 
 -   Step 3: Activate build environment

--- a/examples/ota-requestor-app/ameba/README.md
+++ b/examples/ota-requestor-app/ameba/README.md
@@ -6,11 +6,11 @@ A prototype application that demonstrates OTA Requestor capabilities.
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:200
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:211
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:200
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:211
 
 -   Setup build environment:
 

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -23,7 +23,7 @@ steps:
           - name: pwenv
             path: /pwenv
       timeout: 900s
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -39,7 +39,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       # ICD device is currently not supported for ESP32 and NRF targets. New rule to compile only ICD
       # linux binary.
       env:
@@ -54,7 +54,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -73,7 +73,7 @@ steps:
       waitFor:
           - CompileICD
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/examples.yaml
+++ b/integrations/cloudbuild/examples.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -24,7 +24,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       id: AllDevices
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -43,7 +43,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       id: Camera
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -24,7 +24,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -66,7 +66,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -86,7 +86,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -144,7 +144,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:206"
+    - name: "ghcr.io/project-chip/chip-build-vscode:211"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -542,7 +542,7 @@ class ChipDeviceControllerBase:
                 err = self._dmLib.pychip_GetCompletionError()
 
             if self._commissioning_context.future is None:
-                LOGGER.exception("HandleCommissioningComplete called unexpectedly")
+                LOGGER.error("HandleCommissioningComplete called unexpectedly")
                 return
 
             if err.is_success:
@@ -565,7 +565,7 @@ class ChipDeviceControllerBase:
                 LOGGER.warning("Failed to open commissioning window: %s", str(err))
 
             if self._open_window_context.future is None:
-                LOGGER.exception("HandleOpenWindowComplete called unexpectedly")
+                LOGGER.error("HandleOpenWindowComplete called unexpectedly")
                 return
 
             if err.is_success:
@@ -581,7 +581,7 @@ class ChipDeviceControllerBase:
                 LOGGER.warning("Failed to unpair device: %s", str(err))
 
             if self._unpair_device_context.future is None:
-                LOGGER.exception("HandleUnpairDeviceComplete called unexpectedly")
+                LOGGER.error("HandleUnpairDeviceComplete called unexpectedly")
                 return
 
             if err.is_success:
@@ -604,7 +604,7 @@ class ChipDeviceControllerBase:
                 return
 
             if self._pase_establishment_context.future is None:
-                LOGGER.exception("HandlePASEEstablishmentComplete called unexpectedly")
+                LOGGER.error("HandlePASEEstablishmentComplete called unexpectedly")
                 return
 
             if err.is_success:
@@ -3565,7 +3565,7 @@ class ChipDeviceController(ChipDeviceControllerBase):
             rcac_data = bytearray(rcac_buffer[:actual_rcac_size.value])
             rcac_bytes = bytes(rcac_data)
         else:
-            LOGGER.exception("RCAC returned from C++ did not contain any data")
+            LOGGER.error("RCAC returned from C++ did not contain any data")
             return None
         return rcac_bytes
 
@@ -3607,7 +3607,7 @@ class ChipDeviceController(ChipDeviceControllerBase):
             None
         '''
         if self._issue_node_chain_context.future is None:
-            LOGGER.exception("NOCChainCallback while not expecting a callback")
+            LOGGER.error("NOCChainCallback while not expecting a callback")
             return
         self._issue_node_chain_context.future.set_result(nocChain)
         return

--- a/src/controller/python/matter/clusters/Command.py
+++ b/src/controller/python/matter/clusters/Command.py
@@ -184,7 +184,7 @@ class AsyncBatchCommandsTransaction:
     def _handleError(self, imError: Status, chipError: PyChipError, exception: Exception | None):
         if self._future.done():
             # We need to eagerly stringify as specified in PyChipError docstring.
-            logger.exception("Received another error. Only expecting one error. imError:%s, chipError %s", imError, str(chipError))
+            logger.error("Received another error. Only expecting one error. imError:%s, chipError %s", imError, str(chipError))
             return
         if chipError != 0:
             exception = chipError.to_exception()

--- a/src/controller/python/tests/scripts/base.py
+++ b/src/controller/python/tests/scripts/base.py
@@ -1112,14 +1112,14 @@ class BaseTestHelper:
             while not addr:
                 addr = self.devCtrl.GetAddressAndPort(nodeId)
                 if time.time() - start > 10:
-                    self.logger.exception("Timeout waiting for address...")
+                    self.logger.error("Timeout waiting for address...")
                     break
 
                 if not addr:
                     time.sleep(0.2)
 
             if not addr:
-                self.logger.exception("Addr is missing...")
+                self.logger.error("Addr is missing...")
                 return False
             self.logger.info("Resolved address: %s:%s", addr[0], addr[1])
             return True
@@ -1169,7 +1169,7 @@ class BaseTestHelper:
             except Exception as ex:
                 failed_zcl[basic_attr] = str(ex)
         if failed_zcl:
-            self.logger.exception("Following attributes failed: %s", failed_zcl)
+            self.logger.error("Following attributes failed: %s", failed_zcl)
             return False
         return True
 
@@ -1208,7 +1208,7 @@ class BaseTestHelper:
             except Exception as ex:
                 failed_attribute_write.append(str(ex))
         if failed_attribute_write:
-            self.logger.exception("Following attributes failed: %s", failed_attribute_write)
+            self.logger.error("Following attributes failed: %s", failed_attribute_write)
             return False
         return True
 

--- a/src/test_driver/tizen/README.md
+++ b/src/test_driver/tizen/README.md
@@ -12,7 +12,7 @@ image from hub.docker.com or build it locally using the provided Dockerfile in
 
 ```sh
 # Pull the image from hub.docker.com
-docker pull ghcr.io/project-chip/chip-build-tizen-qemu:200
+docker pull ghcr.io/project-chip/chip-build-tizen-qemu:211
 ```
 
 ## Building and Running Tests on QEMU
@@ -21,7 +21,7 @@ All steps described below should be done inside the docker container.
 
 ```sh
 docker run -it --rm --name chip-tizen-qemu \
-    ghcr.io/project-chip/chip-build-tizen-qemu:200 /bin/bash
+    ghcr.io/project-chip/chip-build-tizen-qemu:211 /bin/bash
 ```
 
 ### Clone the connectedhomeip repository


### PR DESCRIPTION
#### Summary

- Update compatible builds to docker version 211 (from 200)
    - 201: https://github.com/project-chip/connectedhomeip/pull/72481
    - 202: https://github.com/project-chip/connectedhomeip/pull/72517
    - 203: https://github.com/project-chip/connectedhomeip/pull/72930
    - 204: https://github.com/project-chip/connectedhomeip/pull/72851
    - 205: https://github.com/project-chip/connectedhomeip/pull/72963
    - 206: https://github.com/project-chip/connectedhomeip/pull/73021
    - 207: https://github.com/project-chip/connectedhomeip/pull/73228
    - 208: https://github.com/project-chip/connectedhomeip/pull/73372
    - 209: https://github.com/project-chip/connectedhomeip/pull/73824
    - 210: https://github.com/project-chip/connectedhomeip/pull/73844
    - 211: https://github.com/project-chip/connectedhomeip/pull/73801
- Keep [nrfconnect], [Tizen], [Infineon] images on version 210.

#### Testing

- Update builds to docker version 211 verified by GitHub CI