### PR TITLE
Align pigweed project path with upstream move

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	platforms = esp32
 [submodule "pigweed"]
 	path = third_party/pigweed/repo
-	url = https://github.com/google/pigweed.git
+	url = https://github.com/pigweed-project/pigweed.git
 	branch  = main
 [submodule "openthread"]
 	path = third_party/openthread/repo


### PR DESCRIPTION
### Summary

Pigweed moved from google to pigweed-project, this results in a submodule_checkout.py failure on some setups.

### Related issues

N/A

### Testing

`python3 scripts/checkout_submodules.py --shallow --platform nrfconnect`
