### PR TITLE
[fuzz] Add FuzzTest harnesses for the crypto PAL primitives and X.509 helpers

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -78,6 +78,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/src/ble/tests:fuzz-btp-engine-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/credentials/tests:fuzz-attestation-elements-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/credentials/tests:fuzz-chip-cert-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/crypto/tests:fuzz-chip-crypto-pal-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/crypto/tests:fuzz-crypto-primitives-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/lib/asn1/tests:fuzz-asn1-reader-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/lib/core/tests:fuzz-ota-image-header-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/lib/core/tests:fuzz-tlv-reader-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -15,9 +15,9 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
+import("//build_overrides/mbedtls.gni")
 import("${chip_root}/build/chip/chip_test_suite.gni")
 import("${chip_root}/build/chip/fuzz_test.gni")
-import("//build_overrides/mbedtls.gni")
 import("${chip_root}/src/crypto/crypto.gni")
 
 chip_test_suite("tests") {

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/build/chip/fuzz_test.gni")
 import("${chip_root}/src/crypto/crypto.gni")
 
 chip_test_suite("tests") {
@@ -72,4 +73,28 @@ chip_test_suite("tests") {
     "${chip_root}/src/lib/support:testing",
     "${chip_root}/src/platform",
   ]
+}
+
+if (pw_enable_fuzz_test_targets) {
+  chip_pw_fuzz_target("fuzz-crypto-primitives-pw") {
+    test_source = [
+      "AES_CCM_128_test_vectors.h",
+      "FuzzCryptoPrimitivesPW.cpp",
+      "HKDF_SHA256_test_vectors.h",
+    ]
+    public_deps = [
+      "${chip_root}/src/crypto",
+      "${chip_root}/src/platform/logging:default",
+    ]
+  }
+
+  chip_pw_fuzz_target("fuzz-chip-crypto-pal-pw") {
+    test_source = [ "FuzzChipCryptoPalPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/credentials:test_paa_store",
+      "${chip_root}/src/credentials/tests:cert_test_vectors",
+      "${chip_root}/src/crypto",
+      "${chip_root}/src/platform/logging:default",
+    ]
+  }
 }

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 import("${chip_root}/build/chip/fuzz_test.gni")
+import("//build_overrides/mbedtls.gni")
 import("${chip_root}/src/crypto/crypto.gni")
 
 chip_test_suite("tests") {
@@ -87,6 +88,10 @@ if (pw_enable_fuzz_test_targets) {
       "${chip_root}/src/crypto",
       "${chip_root}/src/platform/logging:default",
     ]
+
+    if (chip_crypto == "psa") {
+      public_deps += [ "${mbedtls_root}:mbedtls" ]
+    }
   }
 
   chip_pw_fuzz_target("fuzz-chip-crypto-pal-pw") {

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -79,6 +79,7 @@ if (pw_enable_fuzz_test_targets) {
   chip_pw_fuzz_target("fuzz-crypto-primitives-pw") {
     test_source = [
       "AES_CCM_128_test_vectors.h",
+      "DerSigConversion_test_vectors.h",
       "FuzzCryptoPrimitivesPW.cpp",
       "HKDF_SHA256_test_vectors.h",
     ]

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -15,7 +15,6 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
-import("//build_overrides/mbedtls.gni")
 import("${chip_root}/build/chip/chip_test_suite.gni")
 import("${chip_root}/build/chip/fuzz_test.gni")
 import("${chip_root}/src/crypto/crypto.gni")
@@ -88,10 +87,6 @@ if (pw_enable_fuzz_test_targets) {
       "${chip_root}/src/crypto",
       "${chip_root}/src/platform/logging:default",
     ]
-
-    if (chip_crypto == "psa") {
-      public_deps += [ "${mbedtls_root}:mbedtls" ]
-    }
   }
 
   chip_pw_fuzz_target("fuzz-chip-crypto-pal-pw") {

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -92,7 +92,6 @@ if (pw_enable_fuzz_test_targets) {
   chip_pw_fuzz_target("fuzz-chip-crypto-pal-pw") {
     test_source = [ "FuzzChipCryptoPalPW.cpp" ]
     public_deps = [
-      "${chip_root}/src/credentials:test_paa_store",
       "${chip_root}/src/credentials/tests:cert_test_vectors",
       "${chip_root}/src/crypto",
       "${chip_root}/src/platform/logging:default",

--- a/src/crypto/tests/FuzzChipCryptoPalPW.cpp
+++ b/src/crypto/tests/FuzzChipCryptoPalPW.cpp
@@ -41,6 +41,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include <pw_fuzzer/fuzztest.h>
@@ -49,7 +50,13 @@
 #include <credentials/attestation_verifier/TestPAAStore.h>
 #include <credentials/tests/CHIPAttCert_test_vectors.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
+
+#if CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
 
 namespace {
 
@@ -60,10 +67,28 @@ using namespace fuzztest;
 
 using Bytes = std::vector<uint8_t>;
 
+// The mbedTLS and PSA certificate backends import keys through PSA, which
+// rejects every operation until the driver is initialized -- without this the
+// CSR case would pass without verifying anything.
+void EnsureInitialized()
+{
+    static const bool sInitialized = [] {
+        VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
+#endif
+        return true;
+    }();
+    (void) sInitialized;
+}
+
 Bytes ToBytes(const ByteSpan & span)
 {
     return Bytes(span.begin(), span.end());
 }
+
+// Matches the DER cap used by the other certificate harnesses.
+constexpr size_t kMaxDerCertLen = 8192;
 
 std::vector<Bytes> ToSeeds(const std::vector<ByteSpan> & spans)
 {
@@ -81,34 +106,38 @@ std::vector<Bytes> ToSeeds(const std::vector<ByteSpan> & spans)
 // edge case the test corpus provides.
 auto AnyDacCert()
 {
-    return Arbitrary<Bytes>().WithSeeds(ToSeeds({
-        sTestCert_DAC_FFF1_8000_0000_Cert,
-        sTestCert_DAC_FFF1_8000_0004_Cert,
-        sTestCert_DAC_FFF2_8001_0008_Cert,
-        sTestCert_DAC_FFF2_8002_0017_Cert,
-        sTestCert_DAC_FFF2_8003_0018_FB_Cert,
-        sTestCert_DAC_FFF2_8004_001C_FB_Cert,
-        sTestCert_DAC_FFF2_8004_0020_ValInPast_Cert,
-        sTestCert_DAC_FFF2_8004_0021_ValInFuture_Cert,
-        sTestCert_DAC_FFF2_8004_0030_Val1SecBefore_Cert,
-        sTestCert_DAC_FFF2_8006_0034_ValInFuture_Cert,
-    }));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxDerCertLen)
+        .WithSeeds(ToSeeds({
+            sTestCert_DAC_FFF1_8000_0000_Cert,
+            sTestCert_DAC_FFF1_8000_0004_Cert,
+            sTestCert_DAC_FFF2_8001_0008_Cert,
+            sTestCert_DAC_FFF2_8002_0017_Cert,
+            sTestCert_DAC_FFF2_8003_0018_FB_Cert,
+            sTestCert_DAC_FFF2_8004_001C_FB_Cert,
+            sTestCert_DAC_FFF2_8004_0020_ValInPast_Cert,
+            sTestCert_DAC_FFF2_8004_0021_ValInFuture_Cert,
+            sTestCert_DAC_FFF2_8004_0030_Val1SecBefore_Cert,
+            sTestCert_DAC_FFF2_8006_0034_ValInFuture_Cert,
+        }));
 }
 
 // Product attestation intermediates, leading with the FFF1 chain issuer.
 auto AnyPaiCert()
 {
-    return Arbitrary<Bytes>().WithSeeds(ToSeeds({
-        sTestCert_PAI_FFF1_8000_Cert,
-        sTestCert_PAI_FFF2_8001_Cert,
-        sTestCert_PAI_FFF2_8001_Resigned_Cert,
-        sTestCert_PAI_FFF2_8001_ResignedSKIDDiff_Cert,
-        sTestCert_PAI_FFF2_8001_ResignedSubjectDiff_Cert,
-        sTestCert_PAI_FFF2_8004_FB_Cert,
-        sTestCert_PAI_FFF2_8005_ValInPast_Cert,
-        sTestCert_PAI_FFF2_8006_ValInFuture_Cert,
-        sTestCert_PAI_FFF2_NoPID_Cert,
-    }));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxDerCertLen)
+        .WithSeeds(ToSeeds({
+            sTestCert_PAI_FFF1_8000_Cert,
+            sTestCert_PAI_FFF2_8001_Cert,
+            sTestCert_PAI_FFF2_8001_Resigned_Cert,
+            sTestCert_PAI_FFF2_8001_ResignedSKIDDiff_Cert,
+            sTestCert_PAI_FFF2_8001_ResignedSubjectDiff_Cert,
+            sTestCert_PAI_FFF2_8004_FB_Cert,
+            sTestCert_PAI_FFF2_8005_ValInPast_Cert,
+            sTestCert_PAI_FFF2_8006_ValInFuture_Cert,
+            sTestCert_PAI_FFF2_NoPID_Cert,
+        }));
 }
 
 // Certificates that actually carry a CRL distribution point, in every shape the
@@ -116,29 +145,33 @@ auto AnyPaiCert()
 // over-long URI, a wrong URI prefix, and one/two CRL issuers.
 auto AnyCdpCert()
 {
-    return Arbitrary<Bytes>().WithSeeds(ToSeeds({
-        sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAA_FFF1_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_2DPs_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_2URIs_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_HTTPS_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_Long_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_Wrong_Prefix_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_2CRLIssuers_PAA_FFF1_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_CRL_Issuer_PAA_FFF1_2DPs_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAA_NoVID_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAI_FFF2_8004_Cert,
-        sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAI_FFF2_8004_Long_Cert,
-        sTestCert_DAC_FFF1_8000_0000_2CDPs_Cert,
-        sTestCert_DAC_FFF1_8000_0000_2CDPs_Issuer_PAA_FFF1_Cert,
-        sTestCert_DAC_FFF1_8000_0000_2CDPs_Issuer_PAI_FFF2_8004_Cert,
-    }));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxDerCertLen)
+        .WithSeeds(ToSeeds({
+            sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAA_FFF1_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_2DPs_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_2URIs_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_HTTPS_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_Long_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_Wrong_Prefix_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_2CRLIssuers_PAA_FFF1_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_CRL_Issuer_PAA_FFF1_2DPs_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAA_NoVID_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAI_FFF2_8004_Cert,
+            sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAI_FFF2_8004_Long_Cert,
+            sTestCert_DAC_FFF1_8000_0000_2CDPs_Cert,
+            sTestCert_DAC_FFF1_8000_0000_2CDPs_Issuer_PAA_FFF1_Cert,
+            sTestCert_DAC_FFF1_8000_0000_2CDPs_Issuer_PAI_FFF2_8004_Cert,
+        }));
 }
 
 // IsCertificateValidAtCurrentTime reads the wall clock, so its result is not
 // reproducible across runs; only the absence of a crash is checked here.
 void IssuanceTimeComparison(const Bytes & candidate, const Bytes & issuer)
 {
+    EnsureInitialized();
+
     const ByteSpan candidateSpan(candidate.data(), candidate.size());
 
     RETURN_SAFELY_IGNORED IsCertificateValidAtIssuance(candidateSpan, ByteSpan(issuer.data(), issuer.size()));
@@ -149,6 +182,8 @@ FUZZ_TEST(ChipCryptoPal, IssuanceTimeComparison).WithDomains(AnyDacCert(), AnyPa
 
 void SerialNumberExtraction(const Bytes & cert)
 {
+    EnsureInitialized();
+
     uint8_t serialNumberBuf[kMaxCertificateSerialNumberLength] = { 0 };
     MutableByteSpan serialNumber(serialNumberBuf);
     RETURN_SAFELY_IGNORED ExtractSerialNumberFromX509Cert(ByteSpan(cert.data(), cert.size()), serialNumber);
@@ -158,6 +193,8 @@ FUZZ_TEST(ChipCryptoPal, SerialNumberExtraction).WithDomains(AnyDacCert());
 
 void KeyIdentifierExtraction(const Bytes & cert)
 {
+    EnsureInitialized();
+
     const ByteSpan certSpan(cert.data(), cert.size());
 
     uint8_t skidBuf[kSubjectKeyIdentifierLength];
@@ -173,6 +210,8 @@ FUZZ_TEST(ChipCryptoPal, KeyIdentifierExtraction).WithDomains(AnyDacCert());
 
 void CrlDistributionPointUriExtraction(const Bytes & cert)
 {
+    EnsureInitialized();
+
     char cdpBuf[kMaxCRLDistributionPointURLLength] = { '\0' };
     MutableCharSpan cdpUrl(cdpBuf);
     RETURN_SAFELY_IGNORED ExtractCRLDistributionPointURIFromX509Cert(ByteSpan(cert.data(), cert.size()), cdpUrl);
@@ -182,6 +221,8 @@ FUZZ_TEST(ChipCryptoPal, CrlDistributionPointUriExtraction).WithDomains(AnyCdpCe
 
 void CrlIssuerExtraction(const Bytes & cert)
 {
+    EnsureInitialized();
+
     uint8_t crlIssuerBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
     MutableByteSpan crlIssuer(crlIssuerBuf);
     RETURN_SAFELY_IGNORED ExtractCDPExtensionCRLIssuerFromX509Cert(ByteSpan(cert.data(), cert.size()), crlIssuer);
@@ -191,6 +232,8 @@ FUZZ_TEST(ChipCryptoPal, CrlIssuerExtraction).WithDomains(AnyCdpCert());
 
 void VidPidExtractionFromCert(const Bytes & cert)
 {
+    EnsureInitialized();
+
     AttestationCertVidPid vidPid;
     RETURN_SAFELY_IGNORED ExtractVIDPIDFromX509Cert(ByteSpan(cert.data(), cert.size()), vidPid);
 }
@@ -207,6 +250,8 @@ auto AnyDNAttrType()
 // seeded from certificates.
 void VidPidExtractionFromAttributeString(DNAttrType attrType, const std::string & attrString)
 {
+    EnsureInitialized();
+
     AttestationCertVidPid vidPid;
     AttestationCertVidPid vidPidFromCN;
 
@@ -221,6 +266,8 @@ FUZZ_TEST(ChipCryptoPal, VidPidExtractionFromAttributeString)
 
 void SubjectAndIssuerExtraction(const Bytes & cert)
 {
+    EnsureInitialized();
+
     const ByteSpan certSpan(cert.data(), cert.size());
 
     uint8_t subjectBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
@@ -246,6 +293,8 @@ const ByteSpan kResignedCandidates[] = {
 
 void ResignedCertificateLookup(const Bytes & cert, size_t candidateCount)
 {
+    EnsureInitialized();
+
     ByteSpan replacement;
     RETURN_SAFELY_IGNORED ReplaceCertIfResignedCertFound(ByteSpan(cert.data(), cert.size()), kResignedCandidates, candidateCount,
                                                          replacement);
@@ -254,15 +303,8 @@ void ResignedCertificateLookup(const Bytes & cert, size_t candidateCount)
 FUZZ_TEST(ChipCryptoPal, ResignedCertificateLookup)
     .WithDomains(AnyPaiCert(), InRange<size_t>(0, MATTER_ARRAY_SIZE(kResignedCandidates)));
 
-// A CSR whose signature verifies against this public key, used as the lead seed
-// so that mutations start from a structurally valid request.
-const uint8_t kGoodCsrSubjectPublicKey[] = {
-    0x04, 0xa3, 0xbe, 0xa1, 0xf5, 0x42, 0x01, 0x07, 0x3c, 0x4b, 0x75, 0x85, 0xd8, 0xe2, 0x98, 0xac, 0x2f,
-    0xf6, 0x98, 0xdb, 0xd9, 0x5b, 0xe0, 0x7e, 0xc1, 0x04, 0xd5, 0x73, 0xc5, 0xb0, 0x90, 0x77, 0x27, 0x00,
-    0x1e, 0x22, 0xc7, 0x89, 0x5e, 0x4d, 0x75, 0x07, 0x89, 0x82, 0x0f, 0x49, 0xb6, 0x59, 0xd5, 0xc5, 0x15,
-    0x7d, 0x93, 0xe6, 0x80, 0x5c, 0x70, 0x89, 0x0a, 0x43, 0x10, 0x3d, 0xeb, 0x3d, 0x4a,
-};
-
+// A well-formed CSR, used as the lead seed so that mutations start from a
+// structurally valid request.
 const uint8_t kGoodCsr[] = {
     0x30, 0x81, 0xca, 0x30, 0x70, 0x02, 0x01, 0x00, 0x30, 0x0e, 0x31, 0x0c, 0x30, 0x0a, 0x06, 0x03, 0x55, 0x04, 0x0a, 0x0c, 0x03,
     0x43, 0x53, 0x52, 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a, 0x86, 0x48,
@@ -278,8 +320,11 @@ const uint8_t kGoodCsr[] = {
 
 void CertificateSigningRequestVerification(const Bytes & csr)
 {
-    P256PublicKey expectedPublicKey(kGoodCsrSubjectPublicKey);
-    RETURN_SAFELY_IGNORED VerifyCertificateSigningRequest(csr.data(), csr.size(), expectedPublicKey);
+    EnsureInitialized();
+
+    // The key is an output: on success it is filled in from the CSR.
+    P256PublicKey csrPublicKey;
+    RETURN_SAFELY_IGNORED VerifyCertificateSigningRequest(csr.data(), csr.size(), csrPublicKey);
 }
 
 FUZZ_TEST(ChipCryptoPal, CertificateSigningRequestVerification)

--- a/src/crypto/tests/FuzzChipCryptoPalPW.cpp
+++ b/src/crypto/tests/FuzzChipCryptoPalPW.cpp
@@ -1,0 +1,273 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      FuzzTest harness for the X.509 helper surface of the crypto PAL
+ *      (`CHIPCryptoPAL.h`): key-identifier, distinguished-name, VID/PID and
+ *      CRL-distribution-point extraction, issuance-time comparison, resigned
+ *      certificate matching, and CSR verification.
+ *
+ *      These helpers each parse a DER certificate independently of the chain
+ *      validators, so they are covered here rather than in
+ *      `FuzzChipCertPW.cpp`, which already drives
+ *      `Crypto::ValidateCertificateChain` and
+ *      `Crypto::VerifyAttestationCertificateFormat`.
+ *
+ *      Seeds come from the compiled attestation-certificate test vectors, not
+ *      from a directory read, so they travel with the binary. They are attached
+ *      to the individual domains, because only domain-level seeds are injected
+ *      when the suite runs under the libFuzzer compatibility engine. Each pool
+ *      leads with the coherent FFF1 chain (PAA_FFF1 -> PAI_FFF1_8000 ->
+ *      DAC_FFF1_8000_0000): FuzzTest builds its pristine seed tuple from the
+ *      first seed of each domain, so a mismatched lead would fail the parse and
+ *      leave the helpers unreached.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <credentials/attestation_verifier/TestPAAStore.h>
+#include <credentials/tests/CHIPAttCert_test_vectors.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/Span.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Crypto;
+using namespace chip::TestCerts;
+using namespace fuzztest;
+
+using Bytes = std::vector<uint8_t>;
+
+Bytes ToBytes(const ByteSpan & span)
+{
+    return Bytes(span.begin(), span.end());
+}
+
+std::vector<Bytes> ToSeeds(const std::vector<ByteSpan> & spans)
+{
+    std::vector<Bytes> seeds;
+    seeds.reserve(spans.size());
+    for (const ByteSpan & span : spans)
+    {
+        seeds.push_back(ToBytes(span));
+    }
+    return seeds;
+}
+
+// Device attestation certificates, leading with the FFF1 chain leaf and
+// followed by variants covering other vendor/product ids and every validity
+// edge case the test corpus provides.
+auto AnyDacCert()
+{
+    return Arbitrary<Bytes>().WithSeeds(ToSeeds({
+        sTestCert_DAC_FFF1_8000_0000_Cert,
+        sTestCert_DAC_FFF1_8000_0004_Cert,
+        sTestCert_DAC_FFF2_8001_0008_Cert,
+        sTestCert_DAC_FFF2_8002_0017_Cert,
+        sTestCert_DAC_FFF2_8003_0018_FB_Cert,
+        sTestCert_DAC_FFF2_8004_001C_FB_Cert,
+        sTestCert_DAC_FFF2_8004_0020_ValInPast_Cert,
+        sTestCert_DAC_FFF2_8004_0021_ValInFuture_Cert,
+        sTestCert_DAC_FFF2_8004_0030_Val1SecBefore_Cert,
+        sTestCert_DAC_FFF2_8006_0034_ValInFuture_Cert,
+    }));
+}
+
+// Product attestation intermediates, leading with the FFF1 chain issuer.
+auto AnyPaiCert()
+{
+    return Arbitrary<Bytes>().WithSeeds(ToSeeds({
+        sTestCert_PAI_FFF1_8000_Cert,
+        sTestCert_PAI_FFF2_8001_Cert,
+        sTestCert_PAI_FFF2_8001_Resigned_Cert,
+        sTestCert_PAI_FFF2_8001_ResignedSKIDDiff_Cert,
+        sTestCert_PAI_FFF2_8001_ResignedSubjectDiff_Cert,
+        sTestCert_PAI_FFF2_8004_FB_Cert,
+        sTestCert_PAI_FFF2_8005_ValInPast_Cert,
+        sTestCert_PAI_FFF2_8006_ValInFuture_Cert,
+        sTestCert_PAI_FFF2_NoPID_Cert,
+    }));
+}
+
+// Certificates that actually carry a CRL distribution point, in every shape the
+// corpus provides: single/multiple DPs, multiple URIs, an HTTPS scheme, an
+// over-long URI, a wrong URI prefix, and one/two CRL issuers.
+auto AnyCdpCert()
+{
+    return Arbitrary<Bytes>().WithSeeds(ToSeeds({
+        sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAA_FFF1_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_2DPs_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_2URIs_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_HTTPS_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_Long_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_Wrong_Prefix_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_2CRLIssuers_PAA_FFF1_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_CRL_Issuer_PAA_FFF1_2DPs_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAA_NoVID_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAI_FFF2_8004_Cert,
+        sTestCert_DAC_FFF1_8000_0000_CDP_Issuer_PAI_FFF2_8004_Long_Cert,
+        sTestCert_DAC_FFF1_8000_0000_2CDPs_Cert,
+        sTestCert_DAC_FFF1_8000_0000_2CDPs_Issuer_PAA_FFF1_Cert,
+        sTestCert_DAC_FFF1_8000_0000_2CDPs_Issuer_PAI_FFF2_8004_Cert,
+    }));
+}
+
+void IssuanceTimeComparison(const Bytes & candidate, const Bytes & issuer)
+{
+    (void) IsCertificateValidAtIssuance(ByteSpan(candidate.data(), candidate.size()), ByteSpan(issuer.data(), issuer.size()));
+}
+
+FUZZ_TEST(ChipCryptoPal, IssuanceTimeComparison).WithDomains(AnyDacCert(), AnyPaiCert());
+
+void KeyIdentifierExtraction(const Bytes & cert)
+{
+    const ByteSpan certSpan(cert.data(), cert.size());
+
+    uint8_t skidBuf[kSubjectKeyIdentifierLength];
+    MutableByteSpan skid(skidBuf);
+    (void) ExtractSKIDFromX509Cert(certSpan, skid);
+
+    uint8_t akidBuf[kAuthorityKeyIdentifierLength];
+    MutableByteSpan akid(akidBuf);
+    (void) ExtractAKIDFromX509Cert(certSpan, akid);
+}
+
+FUZZ_TEST(ChipCryptoPal, KeyIdentifierExtraction).WithDomains(AnyDacCert());
+
+void CrlDistributionPointUriExtraction(const Bytes & cert)
+{
+    char cdpBuf[kMaxCRLDistributionPointURLLength] = { '\0' };
+    MutableCharSpan cdpUrl(cdpBuf);
+    (void) ExtractCRLDistributionPointURIFromX509Cert(ByteSpan(cert.data(), cert.size()), cdpUrl);
+}
+
+FUZZ_TEST(ChipCryptoPal, CrlDistributionPointUriExtraction).WithDomains(AnyCdpCert());
+
+void CrlIssuerExtraction(const Bytes & cert)
+{
+    uint8_t crlIssuerBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
+    MutableByteSpan crlIssuer(crlIssuerBuf);
+    (void) ExtractCDPExtensionCRLIssuerFromX509Cert(ByteSpan(cert.data(), cert.size()), crlIssuer);
+}
+
+FUZZ_TEST(ChipCryptoPal, CrlIssuerExtraction).WithDomains(AnyCdpCert());
+
+void VidPidExtractionFromCert(const Bytes & cert)
+{
+    AttestationCertVidPid vidPid;
+    (void) ExtractVIDPIDFromX509Cert(ByteSpan(cert.data(), cert.size()), vidPid);
+}
+
+FUZZ_TEST(ChipCryptoPal, VidPidExtractionFromCert).WithDomains(AnyDacCert());
+
+auto AnyDNAttrType()
+{
+    return ElementOf({ DNAttrType::kUnspecified, DNAttrType::kCommonName, DNAttrType::kMatterVID, DNAttrType::kMatterPID });
+}
+
+// The attribute string is parsed as text (including the "Mvid:"/"Mpid:" prefixes
+// embedded in a common name), so it is fuzzed as a free-form string rather than
+// seeded from certificates.
+void VidPidExtractionFromAttributeString(DNAttrType attrType, const std::string & attrString)
+{
+    AttestationCertVidPid vidPid;
+    AttestationCertVidPid vidPidFromCN;
+
+    const ByteSpan attrSpan(reinterpret_cast<const uint8_t *>(attrString.data()), attrString.size());
+    (void) ExtractVIDPIDFromAttributeString(attrType, attrSpan, vidPid, vidPidFromCN);
+}
+
+FUZZ_TEST(ChipCryptoPal, VidPidExtractionFromAttributeString)
+    .WithDomains(AnyDNAttrType(),
+                 Arbitrary<std::string>().WithSeeds({ "Mvid:FFF1", "Mpid:8000", "Mvid:FFF1 Mpid:8000", "Matter Test DAC 0000",
+                                                      "Mvid:", "Mvid:FFFF Mpid:FFFF" }));
+
+void SubjectAndIssuerExtraction(const Bytes & cert)
+{
+    const ByteSpan certSpan(cert.data(), cert.size());
+
+    uint8_t subjectBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
+    MutableByteSpan subject(subjectBuf);
+    (void) ExtractSubjectFromX509Cert(certSpan, subject);
+
+    uint8_t issuerBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
+    MutableByteSpan issuer(issuerBuf);
+    (void) ExtractIssuerFromX509Cert(certSpan, issuer);
+}
+
+FUZZ_TEST(ChipCryptoPal, SubjectAndIssuerExtraction).WithDomains(AnyDacCert());
+
+// The resigned-certificate lookup walks a caller-supplied candidate list, so the
+// list length is fuzzed alongside the reference certificate. The candidates are
+// the resigned PAI variants, which are what the helper exists to match.
+const ByteSpan kResignedCandidates[] = {
+    sTestCert_PAI_FFF2_8001_Resigned_Cert,
+    sTestCert_PAI_FFF2_8001_ResignedSKIDDiff_Cert,
+    sTestCert_PAI_FFF2_8001_ResignedSubjectDiff_Cert,
+    sTestCert_PAI_FFF2_NoPID_Resigned_Cert,
+};
+
+void ResignedCertificateLookup(const Bytes & cert, size_t candidateCount)
+{
+    ByteSpan replacement;
+    (void) ReplaceCertIfResignedCertFound(ByteSpan(cert.data(), cert.size()), kResignedCandidates, candidateCount, replacement);
+}
+
+FUZZ_TEST(ChipCryptoPal, ResignedCertificateLookup)
+    .WithDomains(AnyPaiCert(), InRange<size_t>(0, MATTER_ARRAY_SIZE(kResignedCandidates)));
+
+// A CSR whose signature verifies against this public key, used as the lead seed
+// so that mutations start from a structurally valid request.
+const uint8_t kGoodCsrSubjectPublicKey[] = {
+    0x04, 0xa3, 0xbe, 0xa1, 0xf5, 0x42, 0x01, 0x07, 0x3c, 0x4b, 0x75, 0x85, 0xd8, 0xe2, 0x98, 0xac, 0x2f,
+    0xf6, 0x98, 0xdb, 0xd9, 0x5b, 0xe0, 0x7e, 0xc1, 0x04, 0xd5, 0x73, 0xc5, 0xb0, 0x90, 0x77, 0x27, 0x00,
+    0x1e, 0x22, 0xc7, 0x89, 0x5e, 0x4d, 0x75, 0x07, 0x89, 0x82, 0x0f, 0x49, 0xb6, 0x59, 0xd5, 0xc5, 0x15,
+    0x7d, 0x93, 0xe6, 0x80, 0x5c, 0x70, 0x89, 0x0a, 0x43, 0x10, 0x3d, 0xeb, 0x3d, 0x4a,
+};
+
+const uint8_t kGoodCsr[] = {
+    0x30, 0x81, 0xca, 0x30, 0x70, 0x02, 0x01, 0x00, 0x30, 0x0e, 0x31, 0x0c, 0x30, 0x0a, 0x06, 0x03, 0x55, 0x04, 0x0a, 0x0c, 0x03,
+    0x43, 0x53, 0x52, 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a, 0x86, 0x48,
+    0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00, 0x04, 0xa3, 0xbe, 0xa1, 0xf5, 0x42, 0x01, 0x07, 0x3c, 0x4b, 0x75, 0x85, 0xd8,
+    0xe2, 0x98, 0xac, 0x2f, 0xf6, 0x98, 0xdb, 0xd9, 0x5b, 0xe0, 0x7e, 0xc1, 0x04, 0xd5, 0x73, 0xc5, 0xb0, 0x90, 0x77, 0x27, 0x00,
+    0x1e, 0x22, 0xc7, 0x89, 0x5e, 0x4d, 0x75, 0x07, 0x89, 0x82, 0x0f, 0x49, 0xb6, 0x59, 0xd5, 0xc5, 0x15, 0x7d, 0x93, 0xe6, 0x80,
+    0x5c, 0x70, 0x89, 0x0a, 0x43, 0x10, 0x3d, 0xeb, 0x3d, 0x4a, 0xa0, 0x00, 0x30, 0x0c, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d,
+    0x04, 0x03, 0x02, 0x05, 0x00, 0x03, 0x48, 0x00, 0x30, 0x45, 0x02, 0x20, 0x1d, 0x86, 0x21, 0xb4, 0xc2, 0xe1, 0xa9, 0xf3, 0xbc,
+    0xc8, 0x7c, 0xda, 0xb4, 0xb9, 0xc6, 0x8c, 0xd0, 0xe4, 0x9a, 0x9c, 0xef, 0x02, 0x93, 0x98, 0x27, 0x7e, 0x81, 0x21, 0x5d, 0x20,
+    0x9d, 0x32, 0x02, 0x21, 0x00, 0x8b, 0x6b, 0x49, 0xb6, 0x7d, 0x3e, 0x67, 0x9e, 0xb1, 0x22, 0xd3, 0x63, 0x82, 0x40, 0x4f, 0x49,
+    0xa4, 0xdc, 0x17, 0x35, 0xac, 0x4b, 0x7a, 0xbf, 0x52, 0x05, 0x58, 0x68, 0xe0, 0xaa, 0xd2, 0x8e,
+};
+
+void CertificateSigningRequestVerification(const Bytes & csr)
+{
+    P256PublicKey expectedPublicKey(kGoodCsrSubjectPublicKey);
+    (void) VerifyCertificateSigningRequest(csr.data(), csr.size(), expectedPublicKey);
+}
+
+FUZZ_TEST(ChipCryptoPal, CertificateSigningRequestVerification)
+    .WithDomains(Arbitrary<Bytes>().WithSeeds({ Bytes(kGoodCsr, kGoodCsr + sizeof(kGoodCsr)) }));
+
+} // namespace

--- a/src/crypto/tests/FuzzChipCryptoPalPW.cpp
+++ b/src/crypto/tests/FuzzChipCryptoPalPW.cpp
@@ -135,12 +135,26 @@ auto AnyCdpCert()
     }));
 }
 
+// IsCertificateValidAtCurrentTime reads the wall clock, so its result is not
+// reproducible across runs; only the absence of a crash is checked here.
 void IssuanceTimeComparison(const Bytes & candidate, const Bytes & issuer)
 {
-    (void) IsCertificateValidAtIssuance(ByteSpan(candidate.data(), candidate.size()), ByteSpan(issuer.data(), issuer.size()));
+    const ByteSpan candidateSpan(candidate.data(), candidate.size());
+
+    RETURN_SAFELY_IGNORED IsCertificateValidAtIssuance(candidateSpan, ByteSpan(issuer.data(), issuer.size()));
+    RETURN_SAFELY_IGNORED IsCertificateValidAtCurrentTime(candidateSpan);
 }
 
 FUZZ_TEST(ChipCryptoPal, IssuanceTimeComparison).WithDomains(AnyDacCert(), AnyPaiCert());
+
+void SerialNumberExtraction(const Bytes & cert)
+{
+    uint8_t serialNumberBuf[kMaxCertificateSerialNumberLength] = { 0 };
+    MutableByteSpan serialNumber(serialNumberBuf);
+    RETURN_SAFELY_IGNORED ExtractSerialNumberFromX509Cert(ByteSpan(cert.data(), cert.size()), serialNumber);
+}
+
+FUZZ_TEST(ChipCryptoPal, SerialNumberExtraction).WithDomains(AnyDacCert());
 
 void KeyIdentifierExtraction(const Bytes & cert)
 {
@@ -148,11 +162,11 @@ void KeyIdentifierExtraction(const Bytes & cert)
 
     uint8_t skidBuf[kSubjectKeyIdentifierLength];
     MutableByteSpan skid(skidBuf);
-    (void) ExtractSKIDFromX509Cert(certSpan, skid);
+    RETURN_SAFELY_IGNORED ExtractSKIDFromX509Cert(certSpan, skid);
 
     uint8_t akidBuf[kAuthorityKeyIdentifierLength];
     MutableByteSpan akid(akidBuf);
-    (void) ExtractAKIDFromX509Cert(certSpan, akid);
+    RETURN_SAFELY_IGNORED ExtractAKIDFromX509Cert(certSpan, akid);
 }
 
 FUZZ_TEST(ChipCryptoPal, KeyIdentifierExtraction).WithDomains(AnyDacCert());
@@ -161,7 +175,7 @@ void CrlDistributionPointUriExtraction(const Bytes & cert)
 {
     char cdpBuf[kMaxCRLDistributionPointURLLength] = { '\0' };
     MutableCharSpan cdpUrl(cdpBuf);
-    (void) ExtractCRLDistributionPointURIFromX509Cert(ByteSpan(cert.data(), cert.size()), cdpUrl);
+    RETURN_SAFELY_IGNORED ExtractCRLDistributionPointURIFromX509Cert(ByteSpan(cert.data(), cert.size()), cdpUrl);
 }
 
 FUZZ_TEST(ChipCryptoPal, CrlDistributionPointUriExtraction).WithDomains(AnyCdpCert());
@@ -170,7 +184,7 @@ void CrlIssuerExtraction(const Bytes & cert)
 {
     uint8_t crlIssuerBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
     MutableByteSpan crlIssuer(crlIssuerBuf);
-    (void) ExtractCDPExtensionCRLIssuerFromX509Cert(ByteSpan(cert.data(), cert.size()), crlIssuer);
+    RETURN_SAFELY_IGNORED ExtractCDPExtensionCRLIssuerFromX509Cert(ByteSpan(cert.data(), cert.size()), crlIssuer);
 }
 
 FUZZ_TEST(ChipCryptoPal, CrlIssuerExtraction).WithDomains(AnyCdpCert());
@@ -178,7 +192,7 @@ FUZZ_TEST(ChipCryptoPal, CrlIssuerExtraction).WithDomains(AnyCdpCert());
 void VidPidExtractionFromCert(const Bytes & cert)
 {
     AttestationCertVidPid vidPid;
-    (void) ExtractVIDPIDFromX509Cert(ByteSpan(cert.data(), cert.size()), vidPid);
+    RETURN_SAFELY_IGNORED ExtractVIDPIDFromX509Cert(ByteSpan(cert.data(), cert.size()), vidPid);
 }
 
 FUZZ_TEST(ChipCryptoPal, VidPidExtractionFromCert).WithDomains(AnyDacCert());
@@ -197,7 +211,7 @@ void VidPidExtractionFromAttributeString(DNAttrType attrType, const std::string 
     AttestationCertVidPid vidPidFromCN;
 
     const ByteSpan attrSpan(reinterpret_cast<const uint8_t *>(attrString.data()), attrString.size());
-    (void) ExtractVIDPIDFromAttributeString(attrType, attrSpan, vidPid, vidPidFromCN);
+    RETURN_SAFELY_IGNORED ExtractVIDPIDFromAttributeString(attrType, attrSpan, vidPid, vidPidFromCN);
 }
 
 FUZZ_TEST(ChipCryptoPal, VidPidExtractionFromAttributeString)
@@ -211,11 +225,11 @@ void SubjectAndIssuerExtraction(const Bytes & cert)
 
     uint8_t subjectBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
     MutableByteSpan subject(subjectBuf);
-    (void) ExtractSubjectFromX509Cert(certSpan, subject);
+    RETURN_SAFELY_IGNORED ExtractSubjectFromX509Cert(certSpan, subject);
 
     uint8_t issuerBuf[kMaxCertificateDistinguishedNameLength] = { 0 };
     MutableByteSpan issuer(issuerBuf);
-    (void) ExtractIssuerFromX509Cert(certSpan, issuer);
+    RETURN_SAFELY_IGNORED ExtractIssuerFromX509Cert(certSpan, issuer);
 }
 
 FUZZ_TEST(ChipCryptoPal, SubjectAndIssuerExtraction).WithDomains(AnyDacCert());
@@ -233,7 +247,8 @@ const ByteSpan kResignedCandidates[] = {
 void ResignedCertificateLookup(const Bytes & cert, size_t candidateCount)
 {
     ByteSpan replacement;
-    (void) ReplaceCertIfResignedCertFound(ByteSpan(cert.data(), cert.size()), kResignedCandidates, candidateCount, replacement);
+    RETURN_SAFELY_IGNORED ReplaceCertIfResignedCertFound(ByteSpan(cert.data(), cert.size()), kResignedCandidates, candidateCount,
+                                                         replacement);
 }
 
 FUZZ_TEST(ChipCryptoPal, ResignedCertificateLookup)
@@ -264,7 +279,7 @@ const uint8_t kGoodCsr[] = {
 void CertificateSigningRequestVerification(const Bytes & csr)
 {
     P256PublicKey expectedPublicKey(kGoodCsrSubjectPublicKey);
-    (void) VerifyCertificateSigningRequest(csr.data(), csr.size(), expectedPublicKey);
+    RETURN_SAFELY_IGNORED VerifyCertificateSigningRequest(csr.data(), csr.size(), expectedPublicKey);
 }
 
 FUZZ_TEST(ChipCryptoPal, CertificateSigningRequestVerification)

--- a/src/crypto/tests/FuzzChipCryptoPalPW.cpp
+++ b/src/crypto/tests/FuzzChipCryptoPalPW.cpp
@@ -47,7 +47,6 @@
 #include <pw_fuzzer/fuzztest.h>
 #include <pw_unit_test/framework.h>
 
-#include <credentials/attestation_verifier/TestPAAStore.h>
 #include <credentials/tests/CHIPAttCert_test_vectors.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/CHIPMem.h>

--- a/src/crypto/tests/FuzzChipCryptoPalPW.cpp
+++ b/src/crypto/tests/FuzzChipCryptoPalPW.cpp
@@ -90,6 +90,10 @@ Bytes ToBytes(const ByteSpan & span)
 // Matches the DER cap used by the other certificate harnesses.
 constexpr size_t kMaxDerCertLen = 8192;
 
+// Distinguished-name attributes are bounded by kMaxCertificateDistinguishedNameLength;
+// allow twice that so over-long values are still exercised.
+constexpr size_t kMaxAttributeStringLen = 2 * kMaxCertificateDistinguishedNameLength;
+
 std::vector<Bytes> ToSeeds(const std::vector<ByteSpan> & spans)
 {
     std::vector<Bytes> seeds;
@@ -261,8 +265,10 @@ void VidPidExtractionFromAttributeString(DNAttrType attrType, const std::string 
 
 FUZZ_TEST(ChipCryptoPal, VidPidExtractionFromAttributeString)
     .WithDomains(AnyDNAttrType(),
-                 Arbitrary<std::string>().WithSeeds({ "Mvid:FFF1", "Mpid:8000", "Mvid:FFF1 Mpid:8000", "Matter Test DAC 0000",
-                                                      "Mvid:", "Mvid:FFFF Mpid:FFFF" }));
+                 Arbitrary<std::string>()
+                     .WithMaxSize(kMaxAttributeStringLen)
+                     .WithSeeds({ "Mvid:FFF1", "Mpid:8000", "Mvid:FFF1 Mpid:8000", "Matter Test DAC 0000",
+                                  "Mvid:", "Mvid:FFFF Mpid:FFFF" }));
 
 void SubjectAndIssuerExtraction(const Bytes & cert)
 {

--- a/src/crypto/tests/FuzzChipCryptoPalPW.cpp
+++ b/src/crypto/tests/FuzzChipCryptoPalPW.cpp
@@ -328,6 +328,6 @@ void CertificateSigningRequestVerification(const Bytes & csr)
 }
 
 FUZZ_TEST(ChipCryptoPal, CertificateSigningRequestVerification)
-    .WithDomains(Arbitrary<Bytes>().WithSeeds({ Bytes(kGoodCsr, kGoodCsr + sizeof(kGoodCsr)) }));
+    .WithDomains(Arbitrary<Bytes>().WithMaxSize(kMaxDerCertLen).WithSeeds({ Bytes(kGoodCsr, kGoodCsr + sizeof(kGoodCsr)) }));
 
 } // namespace

--- a/src/crypto/tests/FuzzCryptoPrimitivesPW.cpp
+++ b/src/crypto/tests/FuzzCryptoPrimitivesPW.cpp
@@ -1,0 +1,314 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      FuzzTest harness for the AEAD and KDF primitives that sit underneath
+ *      every encrypted Matter session: CASE and PASE derive keys with
+ *      HKDF-SHA256, and every secured message is AES-CCM.
+ *
+ *      Each parameter has its own typed domain, seeded from this directory's
+ *      AES-CCM and HKDF test vectors, so the checks are functional invariants
+ *      rather than only "does not crash":
+ *
+ *        - AES-CCM round-trip: decrypt(encrypt(pt)) recovers pt.
+ *        - AES-CCM authenticity: a tampered tag or ciphertext must not decrypt.
+ *        - HKDF determinism: identical inputs produce identical output.
+ *
+ *      Seeds are attached to the individual domains rather than to the
+ *      FUZZ_TEST registration, because only domain-level seeds are injected
+ *      when the suite runs under the libFuzzer compatibility engine.
+ */
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <crypto/CHIPCryptoPAL.h>
+#include <crypto/RawKeySessionKeystore.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+
+#include "AES_CCM_128_test_vectors.h"
+#include "HKDF_SHA256_test_vectors.h"
+
+namespace {
+
+using namespace chip;
+using namespace chip::Crypto;
+using namespace fuzztest;
+
+using KeyArray = std::array<uint8_t, kAES_CCM128_Key_Length>;
+using Bytes    = std::vector<uint8_t>;
+
+// The test vectors carry nonces of 8 and 12 bytes; Matter itself mandates 13.
+// Allow a little headroom either side so nonce-length handling is exercised.
+constexpr size_t kMaxNonceLen = kAES_CCM128_Nonce_Length + 3;
+constexpr size_t kMaxAadLen   = 1024;
+constexpr size_t kMaxTextLen  = 2048;
+
+void EnsureInitialized()
+{
+    static const bool sInitialized = [] {
+        VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+        return true;
+    }();
+    (void) sInitialized;
+}
+
+Bytes ToBytes(const uint8_t * data, size_t len)
+{
+    return (data == nullptr) ? Bytes{} : Bytes(data, data + len);
+}
+
+// Pull one field out of every AES-CCM test vector to use as domain seeds.
+template <typename Selector>
+std::vector<Bytes> CcmSeeds(Selector select, size_t maxLen)
+{
+    std::vector<Bytes> seeds;
+    for (const auto * vector : ccm_128_test_vectors)
+    {
+        Bytes value = select(vector);
+        if (value.size() <= maxLen)
+        {
+            seeds.push_back(std::move(value));
+        }
+    }
+    return seeds;
+}
+
+std::vector<KeyArray> CcmKeySeeds()
+{
+    std::vector<KeyArray> seeds;
+    for (const auto * vector : ccm_128_test_vectors)
+    {
+        if (vector->key_len != kAES_CCM128_Key_Length)
+        {
+            continue;
+        }
+        KeyArray key{};
+        memcpy(key.data(), vector->key, key.size());
+        seeds.push_back(key);
+    }
+    return seeds;
+}
+
+auto AnyKey()
+{
+    return Arbitrary<KeyArray>().WithSeeds(CcmKeySeeds());
+}
+
+auto AnyNonce()
+{
+    return Arbitrary<Bytes>().WithMaxSize(kMaxNonceLen).WithSeeds(
+        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->nonce, v->nonce_len); }, kMaxNonceLen));
+}
+
+auto AnyAad()
+{
+    return Arbitrary<Bytes>().WithMaxSize(kMaxAadLen).WithSeeds(
+        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->aad, v->aad_len); }, kMaxAadLen));
+}
+
+auto AnyPlaintext()
+{
+    return Arbitrary<Bytes>().WithMaxSize(kMaxTextLen).WithSeeds(
+        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->pt, v->pt_len); }, kMaxTextLen));
+}
+
+auto AnyCiphertext()
+{
+    return Arbitrary<Bytes>().WithMaxSize(kMaxTextLen).WithSeeds(
+        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->ct, v->ct_len); }, kMaxTextLen));
+}
+
+auto AnyTag()
+{
+    return Arbitrary<Bytes>().WithMaxSize(kAES_CCM128_Tag_Length).WithSeeds(
+        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->tag, v->tag_len); }, kAES_CCM128_Tag_Length));
+}
+
+// AES-CCM permits these MIC/tag lengths.
+auto AnyTagLen()
+{
+    return ElementOf<size_t>({ 4, 6, 8, 10, 12, 14, 16 });
+}
+
+bool MakeKey(const KeyArray & raw, RawKeySessionKeystore & keystore, Aes128KeyHandle & out)
+{
+    Symmetric128BitsKeyByteArray material;
+    memcpy(material, raw.data(), raw.size());
+    return keystore.CreateKey(material, out) == CHIP_NO_ERROR;
+}
+
+// Drive the decryptor with fully fuzzer-controlled inputs. The authenticity
+// check is expected to reject them; the contract under test is that it does so
+// without reading or writing out of bounds.
+void AesCcmDecryptNoCrash(const KeyArray & key, const Bytes & nonce, const Bytes & aad, const Bytes & ciphertext,
+                          const Bytes & tagBytes, size_t tagLen)
+{
+    EnsureInitialized();
+
+    RawKeySessionKeystore keystore;
+    Aes128KeyHandle handle;
+    if (!MakeKey(key, keystore, handle))
+    {
+        return;
+    }
+
+    Bytes tag(tagLen, 0);
+    for (size_t i = 0; i < tagLen && i < tagBytes.size(); ++i)
+    {
+        tag[i] = tagBytes[i];
+    }
+
+    Bytes plaintext(ciphertext.size());
+    (void) AES_CCM_decrypt(ciphertext.data(), ciphertext.size(), aad.data(), aad.size(), tag.data(), tagLen, handle, nonce.data(),
+                           nonce.size(), plaintext.data());
+    keystore.DestroyKey(handle);
+}
+
+FUZZ_TEST(CryptoPrimitives, AesCcmDecryptNoCrash)
+    .WithDomains(AnyKey(), AnyNonce(), AnyAad(), AnyCiphertext(), AnyTag(), AnyTagLen());
+
+// Round-trip plus authenticity: an honest decrypt must recover the plaintext,
+// and any single-bit change to the tag or the ciphertext must be rejected.
+void AesCcmRoundtrip(const KeyArray & key, const Bytes & nonce, const Bytes & aad, const Bytes & plaintext, size_t tagLen)
+{
+    EnsureInitialized();
+
+    RawKeySessionKeystore keystore;
+    Aes128KeyHandle handle;
+    if (!MakeKey(key, keystore, handle))
+    {
+        return;
+    }
+
+    Bytes ciphertext(plaintext.size());
+    Bytes tag(tagLen);
+    CHIP_ERROR encryptError = AES_CCM_encrypt(plaintext.data(), plaintext.size(), aad.data(), aad.size(), handle, nonce.data(),
+                                              nonce.size(), ciphertext.data(), tag.data(), tagLen);
+    if (encryptError != CHIP_NO_ERROR)
+    {
+        keystore.DestroyKey(handle);
+        return;
+    }
+
+    Bytes recovered(plaintext.size());
+    ASSERT_EQ(AES_CCM_decrypt(ciphertext.data(), ciphertext.size(), aad.data(), aad.size(), tag.data(), tagLen, handle,
+                              nonce.data(), nonce.size(), recovered.data()),
+              CHIP_NO_ERROR);
+    ASSERT_EQ(recovered, plaintext);
+
+    Bytes sink(plaintext.size());
+
+    Bytes tamperedTag = tag;
+    tamperedTag[0] ^= 0x01;
+    ASSERT_NE(AES_CCM_decrypt(ciphertext.data(), ciphertext.size(), aad.data(), aad.size(), tamperedTag.data(), tagLen, handle,
+                              nonce.data(), nonce.size(), sink.data()),
+              CHIP_NO_ERROR);
+
+    if (!ciphertext.empty())
+    {
+        Bytes tamperedCiphertext = ciphertext;
+        tamperedCiphertext[0] ^= 0x01;
+        ASSERT_NE(AES_CCM_decrypt(tamperedCiphertext.data(), tamperedCiphertext.size(), aad.data(), aad.size(), tag.data(),
+                                  tagLen, handle, nonce.data(), nonce.size(), sink.data()),
+                  CHIP_NO_ERROR);
+    }
+
+    keystore.DestroyKey(handle);
+}
+
+FUZZ_TEST(CryptoPrimitives, AesCcmRoundtrip).WithDomains(AnyKey(), AnyNonce(), AnyAad(), AnyPlaintext(), AnyTagLen());
+
+template <typename Selector>
+std::vector<Bytes> HkdfSeeds(Selector select, size_t maxLen)
+{
+    std::vector<Bytes> seeds;
+    for (const auto & vector : hkdf_sha256_test_vectors)
+    {
+        Bytes value = select(vector);
+        if (value.size() <= maxLen)
+        {
+            seeds.push_back(std::move(value));
+        }
+    }
+    return seeds;
+}
+
+constexpr size_t kMaxHkdfInputLen = 512;
+
+auto AnyHkdfSecret()
+{
+    return Arbitrary<Bytes>().WithMaxSize(kMaxHkdfInputLen).WithSeeds(HkdfSeeds(
+        [](const hkdf_sha256_vector & v) { return ToBytes(v.initial_key_material, v.initial_key_material_length); },
+        kMaxHkdfInputLen));
+}
+
+auto AnyHkdfSalt()
+{
+    return Arbitrary<Bytes>().WithMaxSize(kMaxHkdfInputLen).WithSeeds(
+        HkdfSeeds([](const hkdf_sha256_vector & v) { return ToBytes(v.salt, v.salt_length); }, kMaxHkdfInputLen));
+}
+
+auto AnyHkdfInfo()
+{
+    return Arbitrary<Bytes>().WithMaxSize(kMaxHkdfInputLen).WithSeeds(
+        HkdfSeeds([](const hkdf_sha256_vector & v) { return ToBytes(v.info, v.info_length); }, kMaxHkdfInputLen));
+}
+
+void HkdfSha256NoCrash(const Bytes & secret, const Bytes & salt, const Bytes & info, size_t outLen)
+{
+    EnsureInitialized();
+
+    Bytes out(outLen);
+    HKDF_sha hkdf;
+    (void) hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(), out.data(), outLen);
+}
+
+FUZZ_TEST(CryptoPrimitives, HkdfSha256NoCrash)
+    .WithDomains(AnyHkdfSecret(), AnyHkdfSalt(), AnyHkdfInfo(), InRange<size_t>(1, 4096));
+
+// HKDF is a pure function: the same inputs must always produce the same output.
+void HkdfSha256Deterministic(const Bytes & secret, const Bytes & salt, const Bytes & info, size_t outLen)
+{
+    EnsureInitialized();
+
+    HKDF_sha hkdf;
+    Bytes first(outLen);
+    Bytes second(outLen);
+    CHIP_ERROR firstError = hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(),
+                                             first.data(), outLen);
+    CHIP_ERROR secondError = hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(),
+                                              second.data(), outLen);
+    ASSERT_EQ(firstError, secondError);
+    if (firstError == CHIP_NO_ERROR)
+    {
+        ASSERT_EQ(first, second);
+    }
+}
+
+FUZZ_TEST(CryptoPrimitives, HkdfSha256Deterministic)
+    .WithDomains(AnyHkdfSecret(), AnyHkdfSalt(), AnyHkdfInfo(), InRange<size_t>(1, 1024));
+
+} // namespace

--- a/src/crypto/tests/FuzzCryptoPrimitivesPW.cpp
+++ b/src/crypto/tests/FuzzCryptoPrimitivesPW.cpp
@@ -45,7 +45,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <crypto/CHIPCryptoPAL.h>
-#include <crypto/RawKeySessionKeystore.h>
+#include <crypto/DefaultSessionKeystore.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 
@@ -72,6 +72,12 @@ void EnsureInitialized()
 {
     static const bool sInitialized = [] {
         VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        // The PSA backend rejects every key operation until the driver is
+        // initialized, which would otherwise turn each property below into a
+        // vacuous pass.
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
+#endif
         return true;
     }();
     (void) sInitialized;
@@ -160,7 +166,7 @@ auto AnyTagLen()
     return ElementOf<size_t>({ 4, 6, 8, 10, 12, 14, 16 });
 }
 
-bool MakeKey(const KeyArray & raw, RawKeySessionKeystore & keystore, Aes128KeyHandle & out)
+bool MakeKey(const KeyArray & raw, DefaultSessionKeystore & keystore, Aes128KeyHandle & out)
 {
     Symmetric128BitsKeyByteArray material;
     memcpy(material, raw.data(), raw.size());
@@ -175,7 +181,7 @@ void AesCcmDecryptNoCrash(const KeyArray & key, const Bytes & nonce, const Bytes
 {
     EnsureInitialized();
 
-    RawKeySessionKeystore keystore;
+    DefaultSessionKeystore keystore;
     Aes128KeyHandle handle;
     if (!MakeKey(key, keystore, handle))
     {
@@ -203,7 +209,7 @@ void AesCcmRoundtrip(const KeyArray & key, const Bytes & nonce, const Bytes & aa
 {
     EnsureInitialized();
 
-    RawKeySessionKeystore keystore;
+    DefaultSessionKeystore keystore;
     Aes128KeyHandle handle;
     if (!MakeKey(key, keystore, handle))
     {
@@ -255,7 +261,7 @@ void AesCtrCryptNoCrash(const KeyArray & key, const Bytes & nonce, const Bytes &
 {
     EnsureInitialized();
 
-    RawKeySessionKeystore keystore;
+    DefaultSessionKeystore keystore;
     Aes128KeyHandle handle;
     if (!MakeKey(key, keystore, handle))
     {
@@ -274,7 +280,7 @@ void AesCtrRoundtrip(const KeyArray & key, const Bytes & nonce, const Bytes & pl
 {
     EnsureInitialized();
 
-    RawKeySessionKeystore keystore;
+    DefaultSessionKeystore keystore;
     Aes128KeyHandle handle;
     if (!MakeKey(key, keystore, handle))
     {

--- a/src/crypto/tests/FuzzCryptoPrimitivesPW.cpp
+++ b/src/crypto/tests/FuzzCryptoPrimitivesPW.cpp
@@ -38,6 +38,7 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 #include <vector>
 
 #include <pw_fuzzer/fuzztest.h>
@@ -49,6 +50,7 @@
 #include <lib/support/CodeUtils.h>
 
 #include "AES_CCM_128_test_vectors.h"
+#include "DerSigConversion_test_vectors.h"
 #include "HKDF_SHA256_test_vectors.h"
 
 namespace {
@@ -119,32 +121,37 @@ auto AnyKey()
 
 auto AnyNonce()
 {
-    return Arbitrary<Bytes>().WithMaxSize(kMaxNonceLen).WithSeeds(
-        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->nonce, v->nonce_len); }, kMaxNonceLen));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxNonceLen)
+        .WithSeeds(CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->nonce, v->nonce_len); }, kMaxNonceLen));
 }
 
 auto AnyAad()
 {
-    return Arbitrary<Bytes>().WithMaxSize(kMaxAadLen).WithSeeds(
-        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->aad, v->aad_len); }, kMaxAadLen));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxAadLen)
+        .WithSeeds(CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->aad, v->aad_len); }, kMaxAadLen));
 }
 
 auto AnyPlaintext()
 {
-    return Arbitrary<Bytes>().WithMaxSize(kMaxTextLen).WithSeeds(
-        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->pt, v->pt_len); }, kMaxTextLen));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxTextLen)
+        .WithSeeds(CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->pt, v->pt_len); }, kMaxTextLen));
 }
 
 auto AnyCiphertext()
 {
-    return Arbitrary<Bytes>().WithMaxSize(kMaxTextLen).WithSeeds(
-        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->ct, v->ct_len); }, kMaxTextLen));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxTextLen)
+        .WithSeeds(CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->ct, v->ct_len); }, kMaxTextLen));
 }
 
 auto AnyTag()
 {
-    return Arbitrary<Bytes>().WithMaxSize(kAES_CCM128_Tag_Length).WithSeeds(
-        CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->tag, v->tag_len); }, kAES_CCM128_Tag_Length));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kAES_CCM128_Tag_Length)
+        .WithSeeds(CcmSeeds([](const ccm_128_test_vector * v) { return ToBytes(v->tag, v->tag_len); }, kAES_CCM128_Tag_Length));
 }
 
 // AES-CCM permits these MIC/tag lengths.
@@ -182,8 +189,8 @@ void AesCcmDecryptNoCrash(const KeyArray & key, const Bytes & nonce, const Bytes
     }
 
     Bytes plaintext(ciphertext.size());
-    (void) AES_CCM_decrypt(ciphertext.data(), ciphertext.size(), aad.data(), aad.size(), tag.data(), tagLen, handle, nonce.data(),
-                           nonce.size(), plaintext.data());
+    RETURN_SAFELY_IGNORED AES_CCM_decrypt(ciphertext.data(), ciphertext.size(), aad.data(), aad.size(), tag.data(), tagLen, handle,
+                                          nonce.data(), nonce.size(), plaintext.data());
     keystore.DestroyKey(handle);
 }
 
@@ -231,8 +238,8 @@ void AesCcmRoundtrip(const KeyArray & key, const Bytes & nonce, const Bytes & aa
     {
         Bytes tamperedCiphertext = ciphertext;
         tamperedCiphertext[0] ^= 0x01;
-        ASSERT_NE(AES_CCM_decrypt(tamperedCiphertext.data(), tamperedCiphertext.size(), aad.data(), aad.size(), tag.data(),
-                                  tagLen, handle, nonce.data(), nonce.size(), sink.data()),
+        ASSERT_NE(AES_CCM_decrypt(tamperedCiphertext.data(), tamperedCiphertext.size(), aad.data(), aad.size(), tag.data(), tagLen,
+                                  handle, nonce.data(), nonce.size(), sink.data()),
                   CHIP_NO_ERROR);
     }
 
@@ -240,6 +247,221 @@ void AesCcmRoundtrip(const KeyArray & key, const Bytes & nonce, const Bytes & aa
 }
 
 FUZZ_TEST(CryptoPrimitives, AesCcmRoundtrip).WithDomains(AnyKey(), AnyNonce(), AnyAad(), AnyPlaintext(), AnyTagLen());
+
+// AES-CTR carries no authentication tag: it is the keystream XOR used to
+// obfuscate the privacy header of a group message, and on receive it runs over
+// the datagram before the AES-CCM tag is checked.
+void AesCtrCryptNoCrash(const KeyArray & key, const Bytes & nonce, const Bytes & input)
+{
+    EnsureInitialized();
+
+    RawKeySessionKeystore keystore;
+    Aes128KeyHandle handle;
+    if (!MakeKey(key, keystore, handle))
+    {
+        return;
+    }
+
+    Bytes output(input.size());
+    RETURN_SAFELY_IGNORED AES_CTR_crypt(input.data(), input.size(), handle, nonce.data(), nonce.size(), output.data());
+    keystore.DestroyKey(handle);
+}
+
+FUZZ_TEST(CryptoPrimitives, AesCtrCryptNoCrash).WithDomains(AnyKey(), AnyNonce(), AnyCiphertext());
+
+// CTR mode is its own inverse, so applying it twice must return the input.
+void AesCtrRoundtrip(const KeyArray & key, const Bytes & nonce, const Bytes & plaintext)
+{
+    EnsureInitialized();
+
+    RawKeySessionKeystore keystore;
+    Aes128KeyHandle handle;
+    if (!MakeKey(key, keystore, handle))
+    {
+        return;
+    }
+
+    Bytes ciphertext(plaintext.size());
+    if (AES_CTR_crypt(plaintext.data(), plaintext.size(), handle, nonce.data(), nonce.size(), ciphertext.data()) == CHIP_NO_ERROR)
+    {
+        Bytes recovered(plaintext.size());
+        ASSERT_EQ(AES_CTR_crypt(ciphertext.data(), ciphertext.size(), handle, nonce.data(), nonce.size(), recovered.data()),
+                  CHIP_NO_ERROR);
+        ASSERT_EQ(recovered, plaintext);
+    }
+    keystore.DestroyKey(handle);
+}
+
+FUZZ_TEST(CryptoPrimitives, AesCtrRoundtrip).WithDomains(AnyKey(), AnyNonce(), AnyPlaintext());
+
+// Epoch keys and compressed fabric ids from the group key derivation vectors in
+// TestChipCryptoPAL.cpp.
+const uint8_t kEpochKey1[] = { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf };
+const uint8_t kEpochKey2[] = { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf };
+const uint8_t kEpochKey3[] = { 0x23, 0x5b, 0xf7, 0xe6, 0x28, 0x23, 0xd3, 0x58, 0xdc, 0xa4, 0xba, 0x50, 0xb1, 0x53, 0x5f, 0x4b };
+const uint8_t kCompressedFabricId1[] = { 0x29, 0x06, 0xc9, 0x08, 0xd1, 0x15, 0xd3, 0x62 };
+const uint8_t kCompressedFabricId2[] = { 0x87, 0xe1, 0xb0, 0x04, 0xe2, 0x35, 0xa1, 0x30 };
+
+auto AnyEpochKey()
+{
+    return Arbitrary<Bytes>()
+        .WithMaxSize(CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES * 2)
+        .WithSeeds({ Bytes(std::begin(kEpochKey1), std::end(kEpochKey1)), Bytes(std::begin(kEpochKey2), std::end(kEpochKey2)),
+                     Bytes(std::begin(kEpochKey3), std::end(kEpochKey3)) });
+}
+
+auto AnyCompressedFabricId()
+{
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kCompressedFabricIdentifierSize * 2)
+        .WithSeeds({ Bytes(std::begin(kCompressedFabricId1), std::end(kCompressedFabricId1)),
+                     Bytes(std::begin(kCompressedFabricId2), std::end(kCompressedFabricId2)) });
+}
+
+// The group key schedule: an epoch key plus the compressed fabric id yield the
+// encryption key, the privacy key and the session id used for group messaging.
+void GroupKeyDerivation(const Bytes & epochKey, const Bytes & compressedFabricId)
+{
+    EnsureInitialized();
+
+    const ByteSpan epochKeySpan(epochKey.data(), epochKey.size());
+    const ByteSpan fabricIdSpan(compressedFabricId.data(), compressedFabricId.size());
+
+    uint8_t operationalKeyBuf[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES] = { 0 };
+    MutableByteSpan operationalKey(operationalKeyBuf);
+    if (DeriveGroupOperationalKey(epochKeySpan, fabricIdSpan, operationalKey) == CHIP_NO_ERROR)
+    {
+        // The session id is derived from the operational key, so it is only
+        // meaningful once that derivation has succeeded.
+        uint16_t sessionId = 0;
+        RETURN_SAFELY_IGNORED DeriveGroupSessionId(ByteSpan(operationalKey.data(), operationalKey.size()), sessionId);
+    }
+
+    // Fed the raw fuzzer bytes rather than the derived operational key that
+    // production uses, so that the length-rejection path is exercised too.
+    uint8_t privacyKeyBuf[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES] = { 0 };
+    MutableByteSpan privacyKey(privacyKeyBuf);
+    RETURN_SAFELY_IGNORED DeriveGroupPrivacyKey(epochKeySpan, privacyKey);
+
+    GroupOperationalCredentials credentials;
+    RETURN_SAFELY_IGNORED DeriveGroupOperationalCredentials(epochKeySpan, fabricIdSpan, credentials);
+}
+
+FUZZ_TEST(CryptoPrimitives, GroupKeyDerivation).WithDomains(AnyEpochKey(), AnyCompressedFabricId());
+
+// The combined credentials call must agree with running the same schedule by
+// hand. Note the chaining: the privacy key is derived from the *operational*
+// key, not from the epoch key -- DeriveGroupPrivacyKey names its parameter
+// encryption_key, and both keys are 16 bytes, so feeding it the epoch key is
+// accepted and silently yields a different key.
+void GroupKeyDerivationAgrees(const Bytes & epochKey, const Bytes & compressedFabricId)
+{
+    EnsureInitialized();
+
+    const ByteSpan epochKeySpan(epochKey.data(), epochKey.size());
+    const ByteSpan fabricIdSpan(compressedFabricId.data(), compressedFabricId.size());
+
+    GroupOperationalCredentials credentials;
+    if (DeriveGroupOperationalCredentials(epochKeySpan, fabricIdSpan, credentials) != CHIP_NO_ERROR)
+    {
+        return;
+    }
+
+    uint8_t operationalKeyBuf[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES] = { 0 };
+    MutableByteSpan operationalKey(operationalKeyBuf);
+    ASSERT_EQ(DeriveGroupOperationalKey(epochKeySpan, fabricIdSpan, operationalKey), CHIP_NO_ERROR);
+    ASSERT_EQ(memcmp(credentials.encryption_key, operationalKey.data(), operationalKey.size()), 0);
+
+    uint8_t privacyKeyBuf[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES] = { 0 };
+    MutableByteSpan privacyKey(privacyKeyBuf);
+    ASSERT_EQ(DeriveGroupPrivacyKey(ByteSpan(operationalKey.data(), operationalKey.size()), privacyKey), CHIP_NO_ERROR);
+    ASSERT_EQ(memcmp(credentials.privacy_key, privacyKey.data(), privacyKey.size()), 0);
+
+    uint16_t sessionId = 0;
+    ASSERT_EQ(DeriveGroupSessionId(ByteSpan(operationalKey.data(), operationalKey.size()), sessionId), CHIP_NO_ERROR);
+    ASSERT_EQ(sessionId, credentials.hash);
+}
+
+FUZZ_TEST(CryptoPrimitives, GroupKeyDerivationAgrees).WithDomains(AnyEpochKey(), AnyCompressedFabricId());
+
+// ECDSA signatures cross this boundary in both directions: raw fixed-width r||s
+// on the Matter wire, X9.62 DER inside certificates.
+std::vector<Bytes> DerSigSeeds(bool wantDer)
+{
+    std::vector<Bytes> seeds;
+    for (const auto & vector : kDerSigConvTestVectors)
+    {
+        seeds.push_back(wantDer ? ToBytes(vector.der_version, vector.der_version_length)
+                                : ToBytes(vector.raw_version, vector.raw_version_length));
+    }
+    return seeds;
+}
+
+// The vectors use 32- and 64-byte field elements, so the buffers here are sized
+// past P-256's kMax_ECDSA_Signature_Length rather than from it. Fuzzing the
+// width a little beyond the largest vector exercises the length validation.
+constexpr size_t kMaxFeLen     = 80;
+constexpr size_t kMaxRawSigLen = 2 * kMaxFeLen;
+constexpr size_t kMaxDerSigLen = kMaxRawSigLen + kMax_ECDSA_X9Dot62_Asn1_Overhead;
+
+auto AnyFeLength()
+{
+    return InRange<size_t>(0, kMaxFeLen);
+}
+
+void EcdsaSignatureRawToDer(size_t feLengthBytes, const Bytes & rawSig)
+{
+    EnsureInitialized();
+
+    uint8_t derBuf[kMaxDerSigLen];
+    MutableByteSpan derSig(derBuf);
+    RETURN_SAFELY_IGNORED EcdsaRawSignatureToAsn1(feLengthBytes, ByteSpan(rawSig.data(), rawSig.size()), derSig);
+}
+
+FUZZ_TEST(CryptoPrimitives, EcdsaSignatureRawToDer)
+    .WithDomains(AnyFeLength(), Arbitrary<Bytes>().WithMaxSize(kMaxRawSigLen).WithSeeds(DerSigSeeds(false)));
+
+void EcdsaSignatureDerToRaw(size_t feLengthBytes, const Bytes & derSig)
+{
+    EnsureInitialized();
+
+    uint8_t rawBuf[kMaxRawSigLen];
+    MutableByteSpan rawSig(rawBuf);
+    RETURN_SAFELY_IGNORED EcdsaAsn1SignatureToRaw(feLengthBytes, ByteSpan(derSig.data(), derSig.size()), rawSig);
+}
+
+FUZZ_TEST(CryptoPrimitives, EcdsaSignatureDerToRaw)
+    .WithDomains(AnyFeLength(), Arbitrary<Bytes>().WithMaxSize(kMaxDerSigLen).WithSeeds(DerSigSeeds(true)));
+
+// The two converters are inverses for a well-formed raw signature, so a
+// successful round-trip must reproduce the input exactly.
+void EcdsaSignatureConversionRoundtrip(const Bytes & rawSig)
+{
+    EnsureInitialized();
+
+    // Both directions take the field-element width, which is half of r||s.
+    if (rawSig.empty() || (rawSig.size() % 2) != 0)
+    {
+        return;
+    }
+    const size_t feLengthBytes = rawSig.size() / 2;
+
+    uint8_t derBuf[kMaxDerSigLen];
+    MutableByteSpan derSig(derBuf);
+    if (EcdsaRawSignatureToAsn1(feLengthBytes, ByteSpan(rawSig.data(), rawSig.size()), derSig) != CHIP_NO_ERROR)
+    {
+        return;
+    }
+
+    uint8_t rawBuf[kMaxRawSigLen];
+    MutableByteSpan recovered(rawBuf);
+    ASSERT_EQ(EcdsaAsn1SignatureToRaw(feLengthBytes, ByteSpan(derSig.data(), derSig.size()), recovered), CHIP_NO_ERROR);
+    ASSERT_EQ(recovered.size(), rawSig.size());
+    ASSERT_EQ(memcmp(recovered.data(), rawSig.data(), rawSig.size()), 0);
+}
+
+FUZZ_TEST(CryptoPrimitives, EcdsaSignatureConversionRoundtrip)
+    .WithDomains(Arbitrary<Bytes>().WithMaxSize(kMaxRawSigLen).WithSeeds(DerSigSeeds(false)));
 
 template <typename Selector>
 std::vector<Bytes> HkdfSeeds(Selector select, size_t maxLen)
@@ -260,21 +482,25 @@ constexpr size_t kMaxHkdfInputLen = 512;
 
 auto AnyHkdfSecret()
 {
-    return Arbitrary<Bytes>().WithMaxSize(kMaxHkdfInputLen).WithSeeds(HkdfSeeds(
-        [](const hkdf_sha256_vector & v) { return ToBytes(v.initial_key_material, v.initial_key_material_length); },
-        kMaxHkdfInputLen));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxHkdfInputLen)
+        .WithSeeds(
+            HkdfSeeds([](const hkdf_sha256_vector & v) { return ToBytes(v.initial_key_material, v.initial_key_material_length); },
+                      kMaxHkdfInputLen));
 }
 
 auto AnyHkdfSalt()
 {
-    return Arbitrary<Bytes>().WithMaxSize(kMaxHkdfInputLen).WithSeeds(
-        HkdfSeeds([](const hkdf_sha256_vector & v) { return ToBytes(v.salt, v.salt_length); }, kMaxHkdfInputLen));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxHkdfInputLen)
+        .WithSeeds(HkdfSeeds([](const hkdf_sha256_vector & v) { return ToBytes(v.salt, v.salt_length); }, kMaxHkdfInputLen));
 }
 
 auto AnyHkdfInfo()
 {
-    return Arbitrary<Bytes>().WithMaxSize(kMaxHkdfInputLen).WithSeeds(
-        HkdfSeeds([](const hkdf_sha256_vector & v) { return ToBytes(v.info, v.info_length); }, kMaxHkdfInputLen));
+    return Arbitrary<Bytes>()
+        .WithMaxSize(kMaxHkdfInputLen)
+        .WithSeeds(HkdfSeeds([](const hkdf_sha256_vector & v) { return ToBytes(v.info, v.info_length); }, kMaxHkdfInputLen));
 }
 
 void HkdfSha256NoCrash(const Bytes & secret, const Bytes & salt, const Bytes & info, size_t outLen)
@@ -283,11 +509,11 @@ void HkdfSha256NoCrash(const Bytes & secret, const Bytes & salt, const Bytes & i
 
     Bytes out(outLen);
     HKDF_sha hkdf;
-    (void) hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(), out.data(), outLen);
+    RETURN_SAFELY_IGNORED hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(),
+                                           out.data(), outLen);
 }
 
-FUZZ_TEST(CryptoPrimitives, HkdfSha256NoCrash)
-    .WithDomains(AnyHkdfSecret(), AnyHkdfSalt(), AnyHkdfInfo(), InRange<size_t>(1, 4096));
+FUZZ_TEST(CryptoPrimitives, HkdfSha256NoCrash).WithDomains(AnyHkdfSecret(), AnyHkdfSalt(), AnyHkdfInfo(), InRange<size_t>(1, 4096));
 
 // HKDF is a pure function: the same inputs must always produce the same output.
 void HkdfSha256Deterministic(const Bytes & secret, const Bytes & salt, const Bytes & info, size_t outLen)
@@ -297,10 +523,10 @@ void HkdfSha256Deterministic(const Bytes & secret, const Bytes & salt, const Byt
     HKDF_sha hkdf;
     Bytes first(outLen);
     Bytes second(outLen);
-    CHIP_ERROR firstError = hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(),
-                                             first.data(), outLen);
-    CHIP_ERROR secondError = hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(),
-                                              second.data(), outLen);
+    CHIP_ERROR firstError =
+        hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(), first.data(), outLen);
+    CHIP_ERROR secondError =
+        hkdf.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info.data(), info.size(), second.data(), outLen);
     ASSERT_EQ(firstError, secondError);
     if (firstError == CHIP_NO_ERROR)
     {

--- a/src/crypto/tests/FuzzCryptoPrimitivesPW.cpp
+++ b/src/crypto/tests/FuzzCryptoPrimitivesPW.cpp
@@ -49,6 +49,10 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 
+#if CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
+
 #include "AES_CCM_128_test_vectors.h"
 #include "DerSigConversion_test_vectors.h"
 #include "HKDF_SHA256_test_vectors.h"


### PR DESCRIPTION
#### Summary

Adds two pw_fuzztest harnesses covering crypto PAL functions that no existing fuzz target reaches.

##### Problem

Per the OSS-Fuzz coverage report (2026-09-02), these are all at 0% line coverage: `VerifyCertificateSigningRequest`, the SKID/AKID/subject/issuer/VID-PID/CDP extractors, `ExtractSerialNumberFromX509Cert`, `AES_CTR_crypt`, the group key schedule, and the ECDSA raw/DER signature converters.

##### Solution

-   `fuzz-crypto-primitives-pw` (11 cases) — AES-CCM, AES-CTR, HKDF, the group key schedule, and the ECDSA raw/DER signature converters.
-   `fuzz-chip-crypto-pal-pw` (10 cases) — the X.509 helper surface: key identifiers, subject/issuer, VID/PID, CRL distribution point, issuance time, resigned-certificate lookup, and CSR verification.

Both assert functional properties rather than only absence of crashes: AEAD round-trip and authenticity, HKDF and group-key determinism, and CTR / ECDSA-conversion round-trips.

Seeds come from the in-tree test vectors (`AES_CCM_128_`, `HKDF_SHA256_`, `DerSigConversion_`, `CHIPAttCert_`). They are attached to the domains rather than to the FUZZ_TEST registration, because only domain-level seeds are injected under the libFuzzer compatibility engine.

##### Caveats

`Crypto::ValidateCertificateChain` and `Crypto::VerifyAttestationCertificateFormat` are left to `FuzzChipCertPW`, which already drives both with coherent chain seeds.

#### Testing

Built and run under `linux-x64-tests-clang-pw-fuzztest-ossfuzz`: 21 cases pass in unit mode; 200k runs per case under the libFuzzer compatibility engine, 0 crashes.

Region/branch coverage of the targeted functions, measured with `linux-x64-tests-clang-pw-fuzztest-ossfuzz-coverage`:

| Function | Region | Branch |
| --- | --- | --- |
| `EcdsaAsn1SignatureToRaw` | 96.8% | 92.6% |
| `VerifyCertificateSigningRequest` | 96.6% | 92.6% |
| `ExtractCRLDistributionPointURIFromX509Cert` | 96.6% | 82.5% |
| `ExtractKIDFromX509Cert` | 96.1% | 86.4% |
| `ExtractCDPExtensionCRLIssuerFromX509Cert` | 94.6% | 82.8% |
| `ExtractRawDNFromX509Cert` | 94.6% | 81.3% |
| `DeriveGroupOperationalKey` / `DeriveGroupPrivacyKey` | 93.3% | 83.3% |
| `ExtractVIDPIDFromX509Cert` | 91.5% | 80.0% |
| `ReplaceCertIfResignedCertFound` | 91.3% | 77.8% |
| `DeriveGroupOperationalCredentials` | 90.5% | 77.8% |
| `EcdsaRawSignatureToAsn1` | 89.6% | 75.9% |
| `DeriveGroupSessionId` | 87.5% | 66.7% |

Also built and run with `chip_crypto="mbedtls"`: both targets pass all 21 cases. `chip_crypto="psa"` does not link on a Linux host, but that is pre-existing and unrelated to this change — the untouched `src/crypto/tests:tests` suite fails there identically with undefined `psa_aead_*`.
