### PR TITLE
[python-testing] Use assert_greater for subscription window check in TC_IDM_1_5

### DIFF
--- a/src/python_testing/TC_IDM_1_5.py
+++ b/src/python_testing/TC_IDM_1_5.py
@@ -159,10 +159,10 @@ class TC_IDM_1_5(IDMBaseTest):
             sub_elapsed_sec = time.monotonic() - t_prime
             remaining_sub_window_sec = float(negotiated_max_interval_sec) - sub_elapsed_sec
 
-            log.info("Time elapsed since priming report: %.2f s; remaining window: %.2f s (required >= %.2f s)",
+            log.info("Time elapsed since priming report: %.2f s; remaining window: %.2f s (required > %.2f s)",
                      sub_elapsed_sec, remaining_sub_window_sec, min_required_sub_window_sec)
 
-            asserts.assert_greater_equal(
+            asserts.assert_greater(
                 remaining_sub_window_sec, min_required_sub_window_sec,
                 f"Subscription setup took too long ({sub_elapsed_sec:.2f} s); not enough time remaining "
                 f"({remaining_sub_window_sec:.2f} s) before scheduled periodic report"


### PR DESCRIPTION

- Replace assert_greater_equal with assert_greater for remaining_sub_window_sec
- Update log message to reflect strictly greater condition

### Related issues
https://github.com/project-chip/connectedhomeip/issues/73823

### Testing

local tests
