### PR TITLE
[HVAC] Fix failing telink thermostat example

### DIFF
--- a/examples/thermostat/telink/CMakeLists.txt
+++ b/examples/thermostat/telink/CMakeLists.txt
@@ -58,6 +58,8 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../thermostat-common/thermostat.zap
 )
 
+chip_add_thermostat_common(app)
+
 if(CONFIG_BOOTLOADER_MCUBOOT)
   target_sources(app PRIVATE ${TELINK_COMMON}/util/src/OTAUtil.cpp)
 endif()


### PR DESCRIPTION
### Summary

The merge of #73355 broke the thermostat example for telink, as it is not included in CI. This is because thermostat-common/thermostat-common.cmake changed to expose chip_add_thermostat_common which adds all the thermostat source files, rather than copy the list of files into all dependent cmake files. This was updated in the realtek example, but was missed in the telink example. 


### Related issues

### Testing

Successfully built telink example after fix applied.