### PR TITLE
[Silabs]Fix build for refrigerator app

### DIFF
--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -32,6 +32,7 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::RefrigeratorAlarm;
+using chip::Protocols::InteractionModel::Status;
 using Shell::Engine;
 using Shell::shell_command_t;
 using Shell::streamer_get;


### PR DESCRIPTION
### Summary
Fix silabs refrigerator app after regression from 
https://github.com/project-chip/connectedhomeip/pull/73130

### Related issues
n/a

### Testing
Build the refrigerator app on brd4187c 
`./scripts/examples/gn_silabs_example.sh examples/refrigerator-app/silabs/ out/refrigerator-app BRD4187C`