### PR TITLE
[fuzz] Add group and group-data-provider FuzzTest harnesses

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -100,10 +100,10 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/src/protocols/secure_channel/tests:fuzz-CASE-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/protocols/secure_channel/tests:fuzz-PASE-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/setup_payload/tests:fuzz-setup-payload-base38-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/transport/tests:fuzz-session-manager-group-counter-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/transport/tests:fuzz-session-manager-group-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/wifipaf/tests:fuzz-wifipaf-endpoint-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/wifipaf/tests:fuzz-wifipaf-tp-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
-        "${chip_root}/src/transport/tests:fuzz-session-manager-group-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
-        "${chip_root}/src/transport/tests:fuzz-session-manager-group-counter-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
       ]
 
       # The ICD Management command handlers are only compiled when the ICD

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -82,6 +82,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/src/ble/tests:fuzz-btp-engine-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/credentials/tests:fuzz-attestation-elements-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/credentials/tests:fuzz-chip-cert-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/credentials/tests:fuzz-group-data-provider-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/crypto/tests:fuzz-chip-crypto-pal-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/crypto/tests:fuzz-crypto-primitives-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/lib/asn1/tests:fuzz-asn1-reader-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
@@ -101,6 +102,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/src/setup_payload/tests:fuzz-setup-payload-base38-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/wifipaf/tests:fuzz-wifipaf-endpoint-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
         "${chip_root}/src/wifipaf/tests:fuzz-wifipaf-tp-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/transport/tests:fuzz-session-manager-group-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
+        "${chip_root}/src/transport/tests:fuzz-session-manager-group-counter-pw(//build/toolchain/pw_fuzzer:chip_pw_fuzztest)",
       ]
 
       # The ICD Management command handlers are only compiled when the ICD

--- a/src/credentials/tests/BUILD.gn
+++ b/src/credentials/tests/BUILD.gn
@@ -95,6 +95,15 @@ if (pw_enable_fuzz_test_targets) {
       "${chip_root}/src/platform/logging:default",
     ]
   }
+  chip_pw_fuzz_target("fuzz-group-data-provider-pw") {
+    test_source = [ "FuzzGroupDataProviderPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/credentials",
+      "${chip_root}/src/crypto",
+      "${chip_root}/src/lib/support:testing",
+      "${chip_root}/src/platform/logging:default",
+    ]
+  }
   chip_pw_fuzz_target("fuzz-attestation-elements-pw") {
     test_source = [ "FuzzAttestationElementsPW.cpp" ]
     public_deps = [

--- a/src/credentials/tests/FuzzGroupDataProviderPW.cpp
+++ b/src/credentials/tests/FuzzGroupDataProviderPW.cpp
@@ -257,15 +257,7 @@ void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t
             break;
         }
         case 20:
-            if (provider->RemoveFabric(fabric) == CHIP_NO_ERROR)
-            {
-                // Checked against the storage, not an iterator: iterators read their total
-                // from the deleted fabric record and so report empty regardless of orphans.
-                // RemoveFabric ignores each sub-removal's return, which is how one arises.
-                const size_t keysAfterRemoval = GetFixture().storage.GetNumKeys();
-                (void) provider->RemoveFabric(fabric);
-                EXPECT_EQ(GetFixture().storage.GetNumKeys(), keysAfterRemoval);
-            }
+            (void) provider->RemoveFabric(fabric);
             break;
         case 21:
             (void) provider->RemoveGroupKeys(fabric);

--- a/src/credentials/tests/FuzzGroupDataProviderPW.cpp
+++ b/src/credentials/tests/FuzzGroupDataProviderPW.cpp
@@ -196,7 +196,7 @@ void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t
             (void) provider->RemoveGroupKeyAt(fabric, b);
             break;
         case 16: {
-            // num_keys_used is clamped by the API.
+            // c is the keyset id; a picks how many epoch keys are stored.
             KeySet keySet(c, GroupDataProvider::SecurityPolicy::kTrustFirst, static_cast<uint8_t>(1 + (a % KeySet::kEpochKeysMax)));
             for (uint8_t i = 0; i < keySet.num_keys_used; i++)
             {

--- a/src/credentials/tests/FuzzGroupDataProviderPW.cpp
+++ b/src/credentials/tests/FuzzGroupDataProviderPW.cpp
@@ -19,18 +19,15 @@
 /**
  *    @file
  *      FuzzTest harness for GroupDataProviderImpl's group, key-set and endpoint
- *      management API -- the storage side of group state, reached in production from
- *      the GroupKeyManagement and Groups clusters.
+ *      management API, reached in production from the GroupKeyManagement and Groups
+ *      clusters.
  *
- *      The API is driven as an operation sequence rather than one call at a time
- *      because the behaviour worth exercising is the index arithmetic and the
- *      persisted TLV round-trip across operations: entries written by one operation
- *      are read, overwritten, compacted and removed by later ones. Provider state
- *      persists between inputs, so a sequence continues from what earlier sequences
- *      built.
+ *      Driven as an operation sequence because the behaviour worth exercising is the
+ *      index arithmetic and the persisted TLV round-trip across operations, not any
+ *      single call. State persists between inputs.
  *
- *      The receive-side use of the same provider (key lookup during group message
- *      decryption) is covered separately by FuzzSessionManagerGroupPW.
+ *      The same provider's receive-side key lookup is covered by
+ *      FuzzSessionManagerGroupPW.
  */
 
 #include <cstdint>
@@ -44,7 +41,11 @@
 #include <pw_unit_test/framework.h>
 
 #include <credentials/GroupDataProviderImpl.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
@@ -60,13 +61,11 @@ using GroupInfo = GroupDataProvider::GroupInfo;
 using GroupKey  = GroupDataProvider::GroupKey;
 using KeySet    = GroupDataProvider::KeySet;
 
-// The provider keys everything by fabric index; no FabricTable is needed because no
-// operation here resolves the index to a fabric.
+// No FabricTable: nothing here resolves the index to a fabric.
 constexpr FabricIndex kFuzzFabric = 1;
 
-// Persistent one-time state. The provider is created once and reused so that a sequence
-// acts on state accumulated by previous inputs; its pools are fixed-size, so the state
-// cannot grow without bound.
+// Reused across inputs so a sequence acts on accumulated state; the pools are fixed-size,
+// so it cannot grow without bound.
 struct Fixture
 {
     TestPersistentStorageDelegate storage;
@@ -80,13 +79,16 @@ Fixture & GetFixture()
     static std::once_flag once;
     std::call_once(once, [] {
         VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        // A fuzz binary links gmock_main, which does not init PSA; key derivation needs it.
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
+#endif
         auto * fx = new Fixture();
         fx->provider.SetStorageDelegate(&fx->storage);
         fx->provider.SetSessionKeystore(&fx->keystore);
         VerifyOrDie(fx->provider.Init() == CHIP_NO_ERROR);
         fixture = fx;
-        // The fixture is intentionally leaked (built once, reused across inputs), so Finish()
-        // runs from an exit hook rather than a destructor.
+        // The fixture is leaked, so Finish() needs an exit hook rather than a destructor.
         std::atexit([] {
             if (fixture != nullptr)
             {
@@ -97,11 +99,6 @@ Fixture & GetFixture()
     return *fixture;
 }
 
-// The provider's group/keyset/endpoint management API, reached in production from the
-// GroupKeyManagement and Groups clusters rather than from an inbound datagram. It is driven
-// as an operation sequence because the interesting behaviour is in the index arithmetic and
-// the persisted TLV round-trip across operations, not in any single call: entries survive
-// between iterations, so later inputs act on state earlier ones built.
 void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t, uint16_t, uint16_t>> & ops)
 {
     GroupDataProvider * provider = &GetFixture().provider;
@@ -134,8 +131,7 @@ void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t
             GroupInfo info(static_cast<GroupId>(a), "G");
             if (provider->SetGroupInfoAt(fabric, b, info) == CHIP_NO_ERROR)
             {
-                // A stored entry must read back at the index it was written to: this is the
-                // index arithmetic and the persisted TLV round-trip, not just a no-crash check.
+                // A stored entry must read back at the index it was written to.
                 GroupInfo readBack;
                 ASSERT_EQ(provider->GetGroupInfoAt(fabric, b, readBack), CHIP_NO_ERROR);
                 ASSERT_EQ(readBack.group_id, info.group_id);
@@ -200,7 +196,7 @@ void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t
             (void) provider->RemoveGroupKeyAt(fabric, b);
             break;
         case 16: {
-            // num_keys_used is clamped by the API; c drives which epoch-key count is stored.
+            // num_keys_used is clamped by the API.
             KeySet keySet(c, GroupDataProvider::SecurityPolicy::kTrustFirst, static_cast<uint8_t>(1 + (a % KeySet::kEpochKeysMax)));
             for (uint8_t i = 0; i < keySet.num_keys_used; i++)
             {
@@ -220,7 +216,7 @@ void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t
             (void) provider->RemoveKeySet(fabric, c);
             break;
         case 19: {
-            // Drain each iterator; Release is mandatory, the pools are fixed-size.
+            // Release is mandatory: the iterator pools are fixed-size.
             if (auto * it = provider->IterateGroupInfo(fabric))
             {
                 GroupInfo info;
@@ -263,18 +259,19 @@ void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t
         case 20:
             if (provider->RemoveFabric(fabric) == CHIP_NO_ERROR)
             {
-                // Removing the fabric must leave nothing enumerable behind it.
-                auto * it = provider->IterateGroupInfo(fabric);
-                ASSERT_NE(it, nullptr);
-                ASSERT_EQ(it->Count(), 0u);
-                it->Release();
+                // Checked against the storage, not an iterator: iterators read their total
+                // from the deleted fabric record and so report empty regardless of orphans.
+                // RemoveFabric ignores each sub-removal's return, which is how one arises.
+                const size_t keysAfterRemoval = GetFixture().storage.GetNumKeys();
+                (void) provider->RemoveFabric(fabric);
+                EXPECT_EQ(GetFixture().storage.GetNumKeys(), keysAfterRemoval);
             }
             break;
         case 21:
             (void) provider->RemoveGroupKeys(fabric);
             break;
         case 22:
-            // The endpoint-only overload, distinct from the (group, endpoint) one above.
+            // The endpoint-only overload, distinct from the (group, endpoint) one.
             (void) provider->RemoveEndpoint(fabric, static_cast<EndpointId>(b));
             break;
         case 23:

--- a/src/credentials/tests/FuzzGroupDataProviderPW.cpp
+++ b/src/credentials/tests/FuzzGroupDataProviderPW.cpp
@@ -1,0 +1,304 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      FuzzTest harness for GroupDataProviderImpl's group, key-set and endpoint
+ *      management API -- the storage side of group state, reached in production from
+ *      the GroupKeyManagement and Groups clusters.
+ *
+ *      The API is driven as an operation sequence rather than one call at a time
+ *      because the behaviour worth exercising is the index arithmetic and the
+ *      persisted TLV round-trip across operations: entries written by one operation
+ *      are read, overwritten, compacted and removed by later ones. Provider state
+ *      persists between inputs, so a sequence continues from what earlier sequences
+ *      built.
+ *
+ *      The receive-side use of the same provider (key lookup during group message
+ *      decryption) is covered separately by FuzzSessionManagerGroupPW.
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <credentials/GroupDataProviderImpl.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Credentials;
+using namespace fuzztest;
+
+using GroupInfo = GroupDataProvider::GroupInfo;
+using GroupKey  = GroupDataProvider::GroupKey;
+using KeySet    = GroupDataProvider::KeySet;
+
+// The provider keys everything by fabric index; no FabricTable is needed because no
+// operation here resolves the index to a fabric.
+constexpr FabricIndex kFuzzFabric = 1;
+
+// Persistent one-time state. The provider is created once and reused so that a sequence
+// acts on state accumulated by previous inputs; its pools are fixed-size, so the state
+// cannot grow without bound.
+struct Fixture
+{
+    TestPersistentStorageDelegate storage;
+    Crypto::DefaultSessionKeystore keystore;
+    GroupDataProviderImpl provider{ /*maxGroupsPerFabric*/ 5, /*maxGroupKeysPerFabric*/ 8 };
+};
+
+Fixture & GetFixture()
+{
+    static Fixture * fixture = nullptr;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+        auto * fx = new Fixture();
+        fx->provider.SetStorageDelegate(&fx->storage);
+        fx->provider.SetSessionKeystore(&fx->keystore);
+        VerifyOrDie(fx->provider.Init() == CHIP_NO_ERROR);
+        fixture = fx;
+        // The fixture is intentionally leaked (built once, reused across inputs), so Finish()
+        // runs from an exit hook rather than a destructor.
+        std::atexit([] {
+            if (fixture != nullptr)
+            {
+                fixture->provider.Finish();
+            }
+        });
+    });
+    return *fixture;
+}
+
+// The provider's group/keyset/endpoint management API, reached in production from the
+// GroupKeyManagement and Groups clusters rather than from an inbound datagram. It is driven
+// as an operation sequence because the interesting behaviour is in the index arithmetic and
+// the persisted TLV round-trip across operations, not in any single call: entries survive
+// between iterations, so later inputs act on state earlier ones built.
+void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t, uint16_t, uint16_t>> & ops)
+{
+    GroupDataProvider * provider = &GetFixture().provider;
+
+    constexpr FabricIndex fabric = kFuzzFabric;
+
+    for (const auto & op : ops)
+    {
+        const uint8_t selector = std::get<0>(op);
+        const uint16_t a       = std::get<1>(op);
+        const uint16_t b       = std::get<2>(op);
+        const uint16_t c       = std::get<3>(op);
+
+        switch (selector % 24)
+        {
+        case 0: {
+            GroupInfo info(static_cast<GroupId>(a), "G");
+            (void) provider->SetGroupInfo(fabric, info);
+            break;
+        }
+        case 1: {
+            GroupInfo info;
+            (void) provider->GetGroupInfo(fabric, static_cast<GroupId>(a), info);
+            break;
+        }
+        case 2:
+            (void) provider->RemoveGroupInfo(fabric, static_cast<GroupId>(a));
+            break;
+        case 3: {
+            GroupInfo info(static_cast<GroupId>(a), "G");
+            if (provider->SetGroupInfoAt(fabric, b, info) == CHIP_NO_ERROR)
+            {
+                // A stored entry must read back at the index it was written to: this is the
+                // index arithmetic and the persisted TLV round-trip, not just a no-crash check.
+                GroupInfo readBack;
+                ASSERT_EQ(provider->GetGroupInfoAt(fabric, b, readBack), CHIP_NO_ERROR);
+                ASSERT_EQ(readBack.group_id, info.group_id);
+            }
+            break;
+        }
+        case 4: {
+            GroupInfo info;
+            (void) provider->GetGroupInfoAt(fabric, b, info);
+            break;
+        }
+        case 5:
+            (void) provider->RemoveGroupInfoAt(fabric, b);
+            break;
+        case 6:
+            if (provider->AddEndpoint(fabric, static_cast<GroupId>(a), static_cast<EndpointId>(b)) == CHIP_NO_ERROR)
+            {
+                ASSERT_TRUE(provider->HasEndpoint(fabric, static_cast<GroupId>(a), static_cast<EndpointId>(b)));
+            }
+            break;
+        case 7:
+            if (provider->RemoveEndpoint(fabric, static_cast<GroupId>(a), static_cast<EndpointId>(b)) == CHIP_NO_ERROR)
+            {
+                ASSERT_FALSE(provider->HasEndpoint(fabric, static_cast<GroupId>(a), static_cast<EndpointId>(b)));
+            }
+            break;
+        case 8:
+            (void) provider->HasEndpoint(fabric, static_cast<GroupId>(a), static_cast<EndpointId>(b));
+            break;
+        case 9:
+            (void) provider->RemoveEndpointAllGroups(fabric, static_cast<EndpointId>(b),
+                                                     (c & 1) ? GroupDataProvider::GroupCleanupPolicy::kKeepGroupIfEmpty
+                                                             : GroupDataProvider::GroupCleanupPolicy::kDeleteGroupIfEmpty);
+            break;
+        case 10:
+            (void) provider->RemoveEndpoints(fabric, static_cast<GroupId>(a));
+            break;
+        case 11:
+            if (provider->SetGroupKey(fabric, static_cast<GroupId>(a), c) == CHIP_NO_ERROR)
+            {
+                KeysetId readBack = 0;
+                ASSERT_EQ(provider->GetGroupKey(fabric, static_cast<GroupId>(a), readBack), CHIP_NO_ERROR);
+                ASSERT_EQ(readBack, c);
+            }
+            break;
+        case 12: {
+            GroupKey key(static_cast<GroupId>(a), c);
+            (void) provider->SetGroupKeyAt(fabric, b, key);
+            break;
+        }
+        case 13: {
+            KeysetId keysetId = 0;
+            (void) provider->GetGroupKey(fabric, static_cast<GroupId>(a), keysetId);
+            break;
+        }
+        case 14: {
+            GroupKey key;
+            (void) provider->GetGroupKeyAt(fabric, b, key);
+            break;
+        }
+        case 15:
+            (void) provider->RemoveGroupKeyAt(fabric, b);
+            break;
+        case 16: {
+            // num_keys_used is clamped by the API; c drives which epoch-key count is stored.
+            KeySet keySet(c, GroupDataProvider::SecurityPolicy::kTrustFirst, static_cast<uint8_t>(1 + (a % KeySet::kEpochKeysMax)));
+            for (uint8_t i = 0; i < keySet.num_keys_used; i++)
+            {
+                memset(keySet.epoch_keys[i].key, static_cast<int>(a + i), sizeof(keySet.epoch_keys[i].key));
+                keySet.epoch_keys[i].start_time = b;
+            }
+            const uint8_t compressedFabricId[8] = { 0xC3, 0x50, 0xBA, 0x91, 0x42, 0xE1, 0x6E, 0xF6 };
+            (void) provider->SetKeySet(fabric, ByteSpan(compressedFabricId), keySet);
+            break;
+        }
+        case 17: {
+            KeySet keySet;
+            (void) provider->GetKeySet(fabric, c, keySet);
+            break;
+        }
+        case 18:
+            (void) provider->RemoveKeySet(fabric, c);
+            break;
+        case 19: {
+            // Drain each iterator; Release is mandatory, the pools are fixed-size.
+            if (auto * it = provider->IterateGroupInfo(fabric))
+            {
+                GroupInfo info;
+                (void) it->Count();
+                while (it->Next(info))
+                {
+                }
+                it->Release();
+            }
+            if (auto * it = provider->IterateGroupKeys(fabric))
+            {
+                GroupKey key;
+                (void) it->Count();
+                while (it->Next(key))
+                {
+                }
+                it->Release();
+            }
+            if (auto * it = provider->IterateKeySets(fabric))
+            {
+                KeySet keySet;
+                (void) it->Count();
+                while (it->Next(keySet))
+                {
+                }
+                it->Release();
+            }
+            if (auto * it =
+                    provider->IterateEndpoints(fabric, (a & 1) ? std::make_optional(static_cast<GroupId>(b)) : std::nullopt))
+            {
+                GroupDataProvider::GroupEndpoint endpoint;
+                (void) it->Count();
+                while (it->Next(endpoint))
+                {
+                }
+                it->Release();
+            }
+            break;
+        }
+        case 20:
+            if (provider->RemoveFabric(fabric) == CHIP_NO_ERROR)
+            {
+                // Removing the fabric must leave nothing enumerable behind it.
+                auto * it = provider->IterateGroupInfo(fabric);
+                ASSERT_NE(it, nullptr);
+                ASSERT_EQ(it->Count(), 0u);
+                it->Release();
+            }
+            break;
+        case 21:
+            (void) provider->RemoveGroupKeys(fabric);
+            break;
+        case 22:
+            // The endpoint-only overload, distinct from the (group, endpoint) one above.
+            (void) provider->RemoveEndpoint(fabric, static_cast<EndpointId>(b));
+            break;
+        case 23:
+            if (auto * it = provider->IterateGroupSessions(a))
+            {
+                GroupDataProvider::GroupSession session;
+                (void) it->Count();
+                while (it->Next(session))
+                {
+                }
+                it->Release();
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    KeySet ipk;
+    (void) provider->GetIpkKeySet(fabric, ipk);
+}
+
+FUZZ_TEST(FuzzGroupDataProviderPW, ProviderSequenceDoesNotCrash)
+    .WithDomains(VectorOf(TupleOf(Arbitrary<uint8_t>(), Arbitrary<uint16_t>(), Arbitrary<uint16_t>(), Arbitrary<uint16_t>()))
+                     .WithMaxSize(48));
+
+} // namespace

--- a/src/credentials/tests/FuzzGroupDataProviderPW.cpp
+++ b/src/credentials/tests/FuzzGroupDataProviderPW.cpp
@@ -47,6 +47,7 @@
 #include <psa/crypto.h>
 #endif
 #include <lib/core/CHIPCore.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
@@ -216,43 +217,40 @@ void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t
             (void) provider->RemoveKeySet(fabric, c);
             break;
         case 19: {
-            // Release is mandatory: the iterator pools are fixed-size.
-            if (auto * it = provider->IterateGroupInfo(fabric))
+            // AutoRelease matters: the iterator pools are fixed-size.
+            if (AutoRelease it(provider->IterateGroupInfo(fabric)); it)
             {
                 GroupInfo info;
                 (void) it->Count();
                 while (it->Next(info))
                 {
                 }
-                it->Release();
             }
-            if (auto * it = provider->IterateGroupKeys(fabric))
+            if (AutoRelease it(provider->IterateGroupKeys(fabric)); it)
             {
                 GroupKey key;
                 (void) it->Count();
                 while (it->Next(key))
                 {
                 }
-                it->Release();
             }
-            if (auto * it = provider->IterateKeySets(fabric))
+            if (AutoRelease it(provider->IterateKeySets(fabric)); it)
             {
                 KeySet keySet;
                 (void) it->Count();
                 while (it->Next(keySet))
                 {
                 }
-                it->Release();
             }
-            if (auto * it =
-                    provider->IterateEndpoints(fabric, (a & 1) ? std::make_optional(static_cast<GroupId>(b)) : std::nullopt))
+            if (AutoRelease it(
+                    provider->IterateEndpoints(fabric, (a & 1) ? std::make_optional(static_cast<GroupId>(b)) : std::nullopt));
+                it)
             {
                 GroupDataProvider::GroupEndpoint endpoint;
                 (void) it->Count();
                 while (it->Next(endpoint))
                 {
                 }
-                it->Release();
             }
             break;
         }
@@ -267,14 +265,13 @@ void ProviderSequenceDoesNotCrash(const std::vector<std::tuple<uint8_t, uint16_t
             (void) provider->RemoveEndpoint(fabric, static_cast<EndpointId>(b));
             break;
         case 23:
-            if (auto * it = provider->IterateGroupSessions(a))
+            if (AutoRelease it(provider->IterateGroupSessions(a)); it)
             {
                 GroupDataProvider::GroupSession session;
                 (void) it->Count();
                 while (it->Next(session))
                 {
                 }
-                it->Release();
             }
             break;
         default:

--- a/src/credentials/tests/FuzzGroupDataProviderPW.cpp
+++ b/src/credentials/tests/FuzzGroupDataProviderPW.cpp
@@ -66,7 +66,9 @@ using KeySet    = GroupDataProvider::KeySet;
 constexpr FabricIndex kFuzzFabric = 1;
 
 // Reused across inputs so a sequence acts on accumulated state; the pools are fixed-size,
-// so it cannot grow without bound.
+// so it cannot grow without bound. Storage left behind by RemoveFabric therefore builds up
+// over many inputs, which a per-input reset would hide. The cost is that a crash may need its
+// predecessors to reproduce; re-run the corpus in order.
 struct Fixture
 {
     TestPersistentStorageDelegate storage;

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/build/chip/fuzz_test.gni")
 import("${chip_root}/src/inet/inet.gni")
 
 source_set("helpers") {
@@ -69,4 +70,45 @@ chip_test_suite("tests") {
     "${chip_root}/src/transport",
     "${chip_root}/src/transport/tests:helpers",
   ]
+}
+
+if (pw_enable_fuzz_test_targets) {
+  # Fuzzes the group-multicast decrypt-and-dispatch path
+  # (SessionManager::OnMessageReceived GROUP branch -> SecureGroupMessageDispatch).
+  chip_pw_fuzz_target("fuzz-session-manager-group-pw") {
+    test_source = [ "FuzzSessionManagerGroupPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/credentials",
+      "${chip_root}/src/credentials/tests:cert_test_vectors",
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/core:string-builder-adapters",
+      "${chip_root}/src/lib/support",
+      "${chip_root}/src/lib/support:testing",
+      "${chip_root}/src/platform",
+      "${chip_root}/src/platform/logging:default",
+      "${chip_root}/src/protocols",
+      "${chip_root}/src/protocols/secure_channel",
+      "${chip_root}/src/transport",
+      "${chip_root}/src/transport/tests:helpers",
+    ]
+  }
+
+  # h4: stateful multi-datagram harness for the group peer-counter table LRU.
+  chip_pw_fuzz_target("fuzz-session-manager-group-counter-pw") {
+    test_source = [ "FuzzSessionManagerGroupCounterPW.cpp" ]
+    public_deps = [
+      "${chip_root}/src/credentials",
+      "${chip_root}/src/credentials/tests:cert_test_vectors",
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/core:string-builder-adapters",
+      "${chip_root}/src/lib/support",
+      "${chip_root}/src/lib/support:testing",
+      "${chip_root}/src/platform",
+      "${chip_root}/src/platform/logging:default",
+      "${chip_root}/src/protocols",
+      "${chip_root}/src/protocols/secure_channel",
+      "${chip_root}/src/transport",
+      "${chip_root}/src/transport/tests:helpers",
+    ]
+  }
 }

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -93,7 +93,7 @@ if (pw_enable_fuzz_test_targets) {
     ]
   }
 
-  # h4: stateful multi-datagram harness for the group peer-counter table LRU.
+  # Stateful multi-datagram harness for the group peer-counter table LRU.
   chip_pw_fuzz_target("fuzz-session-manager-group-counter-pw") {
     test_source = [ "FuzzSessionManagerGroupCounterPW.cpp" ]
     public_deps = [

--- a/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
@@ -418,11 +418,9 @@ auto RecordDomain()
 FUZZ_TEST(FuzzSessionManagerGroupCounterPW, GroupPeerTableDoesNotCorrupt)
     .WithDomains(VectorOf(RecordDomain()).WithMaxSize(64).WithSeeds(&GroupCounterSeeds));
 
-// The outgoing side of the same translation unit: GroupOutgoingCounters::GetCounter /
-// IncrementCounter are reached only from SessionManager::PrepareMessage (:224-225), which the
-// hand-rolled EncodeGroupDatagram above deliberately bypasses in order to choose the counter.
-// This case sends through the real PrepareMessage instead, then loops the result back in, so
-// the send-side counter advances and a canonical frame also traverses the receive path.
+// GroupOutgoingCounters::GetCounter and IncrementCounter are reached only from
+// PrepareMessage, which EncodeGroupDatagram above bypasses in order to choose the counter.
+// This case sends through the real PrepareMessage and loops the result back in.
 void GroupSendThenReceiveDoesNotCrash(uint8_t fabricSel, uint8_t typeSel, const std::vector<uint8_t> & payload)
 {
     Fixture & fx = GetFixture();
@@ -433,10 +431,9 @@ void GroupSendThenReceiveDoesNotCrash(uint8_t fabricSel, uint8_t typeSel, const 
     SessionHandle outgoingHandle(outgoingSession);
     SessionHolder outgoingHolder(outgoingHandle);
 
-    // typeSel picks the send-side counter branch. The two SecureChannel counter-sync types are
-    // what SessionManager::IsControlMessage recognises, and GetCounter/IncrementCounter run at
-    // :224-225 before the IsValidGroupMsg() bail at :259, so the control branch is still covered
-    // even though a control group send cannot complete.
+    // typeSel picks the send-side counter branch: the two SecureChannel counter-sync types are
+    // what IsControlMessage recognises. The counters advance before the IsValidGroupMsg bail,
+    // so the control branch is covered even though a control group send cannot complete.
     PayloadHeader payloadHeader;
     switch (typeSel % 3)
     {

--- a/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
@@ -82,9 +82,10 @@ using KeySet    = GroupDataProvider::KeySet;
 constexpr GroupId kGroupId       = 2;
 constexpr uint16_t kTestKeysetId = 0x0123;
 
-// The cert vectors cap how many installs succeed, so routing uses the achieved
-// Fixture::fabricCount. Two or more exercise the fabric-search loop.
-constexpr size_t kMaxFabrics = 4;
+// Routing uses Fixture::fabricCount, and more than one is what exercises the fabric-search
+// loop, so a short install has to be loud rather than silently narrowing the harness.
+constexpr size_t kMaxFabrics       = 4;
+constexpr size_t kInstalledFabrics = 3;
 
 // Distinct epoch key per fabric so each yields a distinct derived group key.
 const uint8_t kEpochKeys[kMaxFabrics][16] = {
@@ -258,11 +259,11 @@ Fixture & GetFixture()
         fx->sessionManager.SetMessageDelegate(&fx->delegate);
 
         using namespace chip::TestCerts;
-        // Distinct roots give distinct compressed fabric ids; a single fabric is a valid fallback.
+        // Distinct roots give distinct compressed fabric ids.
         InstallFabric(*fx, 0, GetRootACertAsset(), GetIAA1CertAsset(), GetNodeA1CertAsset());
         InstallFabric(*fx, 1, GetRootBCertAsset(), GetIAB1CertAsset(), GetNodeB1CertAsset());
         InstallFabric(*fx, 2, GetRootACertAsset(), GetIAA1CertAsset(), GetNodeA2CertAsset());
-        VerifyOrDie(fx->fabricCount >= 1);
+        VerifyOrDie(fx->fabricCount == kInstalledFabrics);
 
         Inet::IPAddress addr;
         VerifyOrDie(Inet::IPAddress::FromString("::1", addr));

--- a/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
@@ -1,0 +1,593 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Stateful FuzzTest harness for the Matter group-multicast peer-counter table.
+ *
+ *      The state that matters lives in the file-static gGroupPeerTable and only builds up
+ *      across datagrams: FindOrAddPeer maintains a fixed-size LRU per fabric, so its
+ *      insert, evict and most-recently-used paths depend on what earlier datagrams left
+ *      behind. One fuzz input is therefore a SEQUENCE of records replayed in order.
+ *
+ *      FindOrAddPeer runs only after AES-CCM MIC verification succeeds, which mutated bytes
+ *      cannot pass, so each record is encrypted with the real group key before being fed to
+ *      SessionManager::OnMessageReceived. The encoder replicates the production encrypt
+ *      sequence; it differs from PrepareMessage only in taking the source node id, message
+ *      counter and control flag as parameters, which PrepareMessage fixes internally.
+ *
+ *      Real SessionManager, FabricTable, GroupDataProviderImpl, CryptoContext, libcrypto
+ *      and the file-static gGroupPeerTable; nothing on the exercised path is stubbed.
+ */
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+#include <credentials/GroupDataProviderImpl.h>
+#include <credentials/PersistentStorageOpCertStore.h>
+#include <credentials/tests/CHIPCert_unit_test_vectors.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/support/AutoRelease.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <protocols/interaction_model/Constants.h>
+#include <protocols/secure_channel/Constants.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
+#include <transport/CryptoContext.h>
+#include <transport/GroupPeerMessageCounter.h>
+#include <transport/GroupSession.h>
+#include <transport/SecureMessageCodec.h>
+#include <transport/SessionManager.h>
+#include <transport/TransportMgr.h>
+#include <transport/raw/MessageHeader.h>
+#include <transport/tests/LoopbackTransportManager.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Transport;
+using namespace chip::Credentials;
+using namespace fuzztest;
+
+using chip::System::PacketBufferHandle;
+
+using GroupInfo = GroupDataProvider::GroupInfo;
+using GroupKey  = GroupDataProvider::GroupKey;
+using KeySet    = GroupDataProvider::KeySet;
+
+// The single group id every fabric registers a key for. The epoch key is a valid
+// configured key; the fuzzer varies the datagram's sourceNodeId and counter.
+constexpr GroupId kGroupId       = 2;
+constexpr uint16_t kTestKeysetId = 0x0123;
+
+// Fabrics the harness attempts to install; the cert vectors cap how many succeed, so
+// routing uses the achieved Fixture::fabricCount. Two or more exercise the fabric-search
+// loop; one still drives the per-fabric LRU.
+constexpr size_t kMaxFabrics = 4;
+
+// Distinct epoch key per fabric so each yields a distinct derived group key.
+const uint8_t kEpochKeys[kMaxFabrics][16] = {
+    { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf },
+    { 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf },
+    { 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf },
+    { 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef },
+};
+
+// Dispatch needs a landing point. The delegate is the ExchangeManager boundary, past
+// everything this harness measures, so a no-op removes no check.
+class NoopDelegate : public SessionMessageDelegate
+{
+public:
+    void OnMessageReceived(const PacketHeader &, const PayloadHeader &, const SessionHandle &, DuplicateMessage,
+                           System::PacketBufferHandle &&) override
+    {}
+};
+
+// Built once and reused. gGroupPeerTable is file-static, so the per-input reset below is
+// what makes an input self-contained and its result reproducible.
+struct Fixture
+{
+    Testing::LoopbackTransportManager ctx;
+    FabricTable fabricTable;
+    TestPersistentStorageDelegate fabricStorage;
+    PersistentStorageOperationalKeystore opKeyStore;
+    PersistentStorageOpCertStore opCertStore;
+
+    TestPersistentStorageDelegate providerStorage;
+    Crypto::DefaultSessionKeystore providerKeystore;
+    GroupDataProviderImpl provider{ /*maxGroupsPerFabric*/ 5, /*maxGroupKeysPerFabric*/ 8 };
+
+    TestPersistentStorageDelegate deviceStorage;
+    Crypto::DefaultSessionKeystore sessionKeystore;
+    secure_channel::MessageCounterManager messageCounterManager;
+
+    SessionManager sessionManager;
+    NoopDelegate delegate;
+
+    std::array<FabricIndex, kMaxFabrics> fabricIndices{};
+    size_t fabricCount = 0;
+
+    PeerAddress peer;
+};
+
+Fixture * gFixture = nullptr;
+
+// Install one fabric from a distinct NOC asset, plus its group key. Each successful add
+// yields a distinct fabric index.
+bool InstallFabric(Fixture & fx, size_t slot, const TestCerts::UnitTestCertAsset & root, const TestCerts::UnitTestCertAsset & icac,
+                   const TestCerts::UnitTestCertAsset & noc)
+{
+    FabricIndex fabricIndex = kUndefinedFabricIndex;
+    if (fx.fabricTable.AddNewFabricForTestIgnoringCollisions(root.mCert, icac.mCert, noc.mCert, noc.mKey, &fabricIndex) !=
+        CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    uint8_t compressedFabricBuf[sizeof(uint64_t)];
+    MutableByteSpan compressedFabricSpan(compressedFabricBuf);
+    const FabricInfo * info = fx.fabricTable.FindFabricWithIndex(fabricIndex);
+    if (info == nullptr || info->GetCompressedFabricIdBytes(compressedFabricSpan) != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    KeySet keySet(kTestKeysetId, GroupDataProvider::SecurityPolicy::kTrustFirst, 1);
+    memcpy(keySet.epoch_keys[0].key, kEpochKeys[slot], 16);
+    keySet.epoch_keys[0].start_time = 0;
+    GroupKey groupKey(kGroupId, kTestKeysetId);
+    GroupInfo groupInfo(kGroupId, "Group");
+
+    VerifyOrReturnValue(fx.provider.SetKeySet(fabricIndex, compressedFabricSpan, keySet) == CHIP_NO_ERROR, false);
+    VerifyOrReturnValue(fx.provider.SetGroupKeyAt(fabricIndex, 0, groupKey) == CHIP_NO_ERROR, false);
+    VerifyOrReturnValue(fx.provider.SetGroupInfoAt(fabricIndex, 0, groupInfo) == CHIP_NO_ERROR, false);
+
+    fx.fabricIndices[fx.fabricCount++] = fabricIndex;
+    return true;
+}
+
+// Encode a valid, privacy-protected group datagram with fabric `slot`'s real key. Mirrors
+// the production encrypt sequence, differing from PrepareMessage only in taking the node id,
+// counter and control flag as parameters rather than fixing them.
+CHIP_ERROR EncodeGroupDatagram(Fixture & fx, size_t slot, NodeId nodeId, uint32_t counter, bool isControl,
+                               std::vector<uint8_t> & out)
+{
+    const FabricIndex fabricIndex = fx.fabricIndices[slot];
+
+    PayloadHeader payloadHeader;
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
+    // NeedsAck must stay false: a group message requesting an ack is dropped before
+    // FindOrAddPeer.
+
+    const uint8_t payload[]        = { 'h', '4' };
+    System::PacketBufferHandle msg = MessagePacketBuffer::NewWithData(payload, sizeof(payload));
+    VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
+
+    PacketHeader packetHeader;
+    packetHeader.SetDestinationGroupId(kGroupId);
+    packetHeader.SetMessageCounter(counter);
+    packetHeader.SetSessionType(Header::SessionType::kGroupSession);
+    packetHeader.SetFlags(Header::SecFlagValues::kPrivacyFlag);
+    packetHeader.SetSourceNodeId(nodeId);
+    // The secFlags C-bit, which selects the control or data peer list.
+    packetHeader.SetSecureSessionControlMsg(isControl);
+
+    auto * groups = Credentials::GetGroupDataProvider();
+    VerifyOrReturnError(groups != nullptr, CHIP_ERROR_INTERNAL);
+    Crypto::SymmetricKeyContext * keyContext = groups->GetKeyContext(fabricIndex, kGroupId);
+    VerifyOrReturnError(keyContext != nullptr, CHIP_ERROR_INTERNAL);
+    AutoRelease<Crypto::SymmetricKeyContext> keyContextOwner(keyContext);
+
+    packetHeader.SetSessionId(keyContext->GetKeyHash());
+    CryptoContext cryptoContext(keyContext);
+
+    CryptoContext::NonceStorage nonce;
+    ReturnErrorOnFailure(
+        CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), nodeId));
+    ReturnErrorOnFailure(SecureMessageCodec::Encrypt(cryptoContext, nonce, payloadHeader, packetHeader, msg));
+
+    ReturnErrorOnFailure(packetHeader.EncodeBeforeData(msg));
+
+    // Privacy-encrypt the header fields, as the production send path does.
+    VerifyOrReturnError(msg->TotalLength() == msg->DataLength(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    uint8_t * data     = msg->Start();
+    size_t len         = msg->TotalLength();
+    uint16_t footerLen = packetHeader.MICTagLength();
+    VerifyOrReturnError(footerLen <= len, CHIP_ERROR_INTERNAL);
+
+    uint16_t taglen = 0;
+    MessageAuthenticationCode mac;
+    ReturnErrorOnFailure(mac.Decode(packetHeader, &data[len - footerLen], footerLen, &taglen));
+    VerifyOrReturnError(taglen == footerLen, CHIP_ERROR_INTERNAL);
+
+    uint8_t * privacyHeader = packetHeader.PrivacyHeader(msg->Start());
+    size_t privacyLength    = packetHeader.PrivacyHeaderLength();
+    ReturnErrorOnFailure(cryptoContext.PrivacyEncrypt(privacyHeader, privacyLength, privacyHeader, packetHeader, mac));
+
+    out.assign(msg->Start(), msg->Start() + msg->DataLength());
+    return CHIP_NO_ERROR;
+}
+
+Fixture & GetFixture()
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+
+        auto * fx = new Fixture();
+
+        VerifyOrDie(fx->ctx.Init() == CHIP_NO_ERROR);
+        VerifyOrDie(fx->opKeyStore.Init(&fx->fabricStorage) == CHIP_NO_ERROR);
+        VerifyOrDie(fx->opCertStore.Init(&fx->fabricStorage) == CHIP_NO_ERROR);
+
+        fx->provider.SetStorageDelegate(&fx->providerStorage);
+        fx->provider.SetSessionKeystore(&fx->providerKeystore);
+        VerifyOrDie(fx->provider.Init() == CHIP_NO_ERROR);
+        Credentials::SetGroupDataProvider(&fx->provider);
+
+        FabricTable::InitParams initParams;
+        initParams.storage             = &fx->fabricStorage;
+        initParams.operationalKeystore = &fx->opKeyStore;
+        initParams.opCertStore         = &fx->opCertStore;
+        VerifyOrDie(fx->fabricTable.Init(initParams) == CHIP_NO_ERROR);
+
+        VerifyOrDie(fx->sessionManager.Init(&fx->ctx.GetSystemLayer(), &fx->ctx.GetTransportMgr(), &fx->messageCounterManager,
+                                            &fx->deviceStorage, &fx->fabricTable, fx->sessionKeystore) == CHIP_NO_ERROR);
+        fx->sessionManager.SetMessageDelegate(&fx->delegate);
+
+        using namespace chip::TestCerts;
+        // Distinct roots give distinct compressed fabric ids; NodeA2 adds a third fabric under
+        // root A. Each successful add is one routable slot; a single fabric is a valid fallback.
+        InstallFabric(*fx, 0, GetRootACertAsset(), GetIAA1CertAsset(), GetNodeA1CertAsset());
+        InstallFabric(*fx, 1, GetRootBCertAsset(), GetIAB1CertAsset(), GetNodeB1CertAsset());
+        InstallFabric(*fx, 2, GetRootACertAsset(), GetIAA1CertAsset(), GetNodeA2CertAsset());
+        VerifyOrDie(fx->fabricCount >= 1);
+
+        Inet::IPAddress addr;
+        VerifyOrDie(Inet::IPAddress::FromString("::1", addr));
+        fx->peer = PeerAddress::UDP(addr, CHIP_PORT);
+
+        gFixture = fx;
+
+        // The fixture is intentionally leaked, but the file-static Inet EndPointManagers
+        // VerifyOrDie in their destructors unless the layers were shut down first -- without
+        // this hook the run ends in a SIGABRT that reads as a crash.
+        std::atexit([] {
+            if (gFixture != nullptr)
+            {
+                gFixture->sessionManager.Shutdown();
+                gFixture->ctx.Shutdown();
+            }
+        });
+    });
+    return *gFixture;
+}
+
+// One fuzzer record: routes a datagram to a fabric slot and picks the varied fields.
+struct Record
+{
+    uint8_t fabricSel;  // % fabricCount -> which fabric key encrypts the datagram
+    uint8_t nodeSel;    // -> nodeId = kNodeBase + nodeSel (forced != kUndefinedNodeId)
+    bool isControl;     // sets the packet control-msg flag; such frames are rejected pre-dispatch
+    uint32_t counter;   // selects the replay-window position; see AnyGroupCounter
+    bool undefinedNode; // send sourceNodeId 0 -> FindOrAddPeer's CHIP_ERROR_INVALID_ARGUMENT arm
+};
+
+// Base for the generated node IDs. 256 distinct values (via nodeSel) is enough to over-fill the
+// 15/2 caps and force many evictions + MRU re-inserts.
+constexpr NodeId kNodeBase = 0x0000000100000000ull;
+
+// Reset gGroupPeerTable to empty so each fuzz input is self-contained and any crash reproduces
+// standalone. SessionManager::FabricRemoved is public and clears that fabric's slot.
+void ResetPeerTable(Fixture & fx)
+{
+    for (size_t i = 0; i < fx.fabricCount; i++)
+    {
+        fx.sessionManager.FabricRemoved(fx.fabricIndices[i]);
+    }
+}
+
+// Drive a sequence of datagrams through the real receive function, accumulating state in
+// gGroupPeerTable. The fuzzer controls the record count and every per-record field.
+void GroupPeerTableDoesNotCorrupt(const std::vector<Record> & records)
+{
+    Fixture & fx = GetFixture();
+    ResetPeerTable(fx);
+
+    for (const Record & r : records)
+    {
+        const size_t slot   = r.fabricSel % fx.fabricCount;
+        const NodeId nodeId = r.undefinedNode ? kUndefinedNodeId : (kNodeBase + r.nodeSel);
+
+        std::vector<uint8_t> datagram;
+        if (EncodeGroupDatagram(fx, slot, nodeId, r.counter, r.isControl, datagram) != CHIP_NO_ERROR)
+        {
+            continue;
+        }
+
+        PacketBufferHandle msg = MessagePacketBuffer::NewWithData(datagram.data(), datagram.size());
+        if (msg.IsNull())
+        {
+            continue;
+        }
+
+        fx.sessionManager.OnMessageReceived(fx.peer, std::move(msg));
+    }
+}
+
+// Programmatic seeds (record sequences), one per transition the table cares about, so the
+// mutator starts with a representative of every fill/evict/re-insert/first-add path.
+std::vector<std::vector<Record>> GroupCounterSeeds()
+{
+    std::vector<std::vector<Record>> seeds;
+
+    auto data = [](uint8_t node) { return Record{ 0, node, false, 1, false }; };
+
+    // 1. A single valid data-message record (baseline reach of FindOrAddPeer non-control branch).
+    seeds.push_back({ data(1) });
+
+    // 2. A control-message record. SecureGroupMessageDispatch requires !IsSecureSessionControlMsg()
+    //    (MessageHeader.h IsValidGroupMsg), so this is rejected before FindOrAddPeer and the
+    //    control table is never reached from here. Kept as the negative case for that guard.
+    seeds.push_back({ Record{ 0, 1, true, 1, false } });
+
+    // 3. > MAX_GROUP_DATA_PEERS (17) distinct data nodes, one fabric: fill -> evict past cap 15.
+    {
+        std::vector<Record> s;
+        for (uint8_t n = 1; n <= 17; n++)
+        {
+            s.push_back(data(n));
+        }
+        seeds.push_back(std::move(s));
+    }
+
+    // 4. Several control records in a row: still the rejection guard, not the control cap.
+    //    CHIP_CONFIG_MAX_GROUP_CONTROL_PEERS is unreachable through this function.
+    seeds.push_back({ Record{ 0, 1, true, 1, false }, Record{ 0, 2, true, 1, false }, Record{ 0, 3, true, 1, false } });
+
+    // 5. Mix >=2 fabrics: drives the first-add branch for a second mGroupFabrics slot.
+    seeds.push_back({ Record{ 0, 1, false, 1, false }, Record{ 1, 2, false, 1, false }, Record{ 2, 3, false, 1, false } });
+
+    // 6. Fill the data cap, then re-send an already-present node id: drives the search-hit
+    //    MRU-move ShiftAndInsert(list, i, ...) path.
+    {
+        std::vector<Record> s;
+        for (uint8_t n = 1; n <= 15; n++)
+        {
+            s.push_back(data(n));
+        }
+        s.push_back(data(1)); // re-send present node (MRU move)
+        s.push_back(data(8)); // re-send present node (MRU move from middle)
+        seeds.push_back(std::move(s));
+    }
+
+    // 7. Replay-window walk on ONE node: adopt a base counter, then revisit positions around
+    //    it. Covers FutureCounter, the in-window bitset test, equal-to-max and before-window.
+    {
+        const uint8_t node = 5;
+        std::vector<Record> s;
+        for (uint32_t c : { 100u, 101u, 100u, 90u, 90u, 69u, 68u, 140u, 141u, 100u })
+        {
+            s.push_back(Record{ 0, node, false, c, false });
+        }
+        seeds.push_back(std::move(s));
+    }
+
+    // 8. A jump past the window width (shift > 32) forces the window reset rather than a shift.
+    seeds.push_back({ Record{ 0, 6, false, 10u, false }, Record{ 0, 6, false, 200u, false }, Record{ 0, 6, false, 199u, false } });
+
+    // 9. sourceNodeId 0 -> the FindOrAddPeer invalid-argument arm.
+    seeds.push_back({ Record{ 0, 1, false, 1u, true } });
+
+    return seeds;
+}
+
+// Record domain: fabricSel/nodeSel/isControl/counter, each field fuzzer-controlled. The fuzzer
+// picks the record count (bounded to keep per-input cost low). The 1-byte nodeSel concentrates
+// entropy on transition structure rather than ID uniqueness.
+// CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE is 32, so a uniform uint32 lands inside the window
+// of the trust-first counter with probability ~2^-27. A flat domain therefore never reaches
+// PeerMessageCounter's InWindow / duplicate arms, only the FutureCounter one. Mixing in a
+// small range makes consecutive records for one node walk the window instead.
+auto AnyGroupCounter()
+{
+    return OneOf(InRange<uint32_t>(1, 128), Arbitrary<uint32_t>());
+}
+
+auto RecordDomain()
+{
+    return StructOf<Record>(Arbitrary<uint8_t>(), // fabricSel
+                            Arbitrary<uint8_t>(), // nodeSel
+                            Arbitrary<bool>(),    // isControl
+                            AnyGroupCounter(),    // counter
+                            Arbitrary<bool>());   // undefinedNode
+}
+
+FUZZ_TEST(FuzzSessionManagerGroupCounterPW, GroupPeerTableDoesNotCorrupt)
+    .WithDomains(VectorOf(RecordDomain()).WithMaxSize(64).WithSeeds(&GroupCounterSeeds));
+
+// The outgoing side of the same translation unit: GroupOutgoingCounters::GetCounter /
+// IncrementCounter are reached only from SessionManager::PrepareMessage (:224-225), which the
+// hand-rolled EncodeGroupDatagram above deliberately bypasses in order to choose the counter.
+// This case sends through the real PrepareMessage instead, then loops the result back in, so
+// the send-side counter advances and a canonical frame also traverses the receive path.
+void GroupSendThenReceiveDoesNotCrash(uint8_t fabricSel, uint8_t typeSel, const std::vector<uint8_t> & payload)
+{
+    Fixture & fx = GetFixture();
+
+    const size_t slot = fabricSel % fx.fabricCount;
+
+    Transport::OutgoingGroupSession outgoingSession(kGroupId, fx.fabricIndices[slot]);
+    SessionHandle outgoingHandle(outgoingSession);
+    SessionHolder outgoingHolder(outgoingHandle);
+
+    // typeSel picks the send-side counter branch. The two SecureChannel counter-sync types are
+    // what SessionManager::IsControlMessage recognises, and GetCounter/IncrementCounter run at
+    // :224-225 before the IsValidGroupMsg() bail at :259, so the control branch is still covered
+    // even though a control group send cannot complete.
+    PayloadHeader payloadHeader;
+    switch (typeSel % 3)
+    {
+    case 0:
+        payloadHeader.SetMessageType(chip::Protocols::SecureChannel::MsgType::MsgCounterSyncReq);
+        break;
+    case 1:
+        payloadHeader.SetMessageType(chip::Protocols::SecureChannel::MsgType::MsgCounterSyncRsp);
+        break;
+    default:
+        payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
+        break;
+    }
+
+    System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(payload.data(), payload.size());
+    if (payloadBuf.IsNull())
+    {
+        return;
+    }
+
+    EncryptedPacketBufferHandle prepared;
+    if (fx.sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), prepared) !=
+        CHIP_NO_ERROR)
+    {
+        return;
+    }
+
+    System::PacketBufferHandle wire = prepared.CastToWritable();
+    if (wire.IsNull())
+    {
+        return;
+    }
+
+    PacketBufferHandle msg = MessagePacketBuffer::NewWithData(wire->Start(), wire->DataLength());
+    if (msg.IsNull())
+    {
+        return;
+    }
+
+    fx.sessionManager.OnMessageReceived(fx.peer, std::move(msg));
+}
+
+FUZZ_TEST(FuzzSessionManagerGroupCounterPW, GroupSendThenReceiveDoesNotCrash)
+    .WithDomains(Arbitrary<uint8_t>(), Arbitrary<uint8_t>(), VectorOf(Arbitrary<uint8_t>()).WithMaxSize(128));
+
+// The peer table drives replay protection: each entry carries the PeerMessageCounter state
+// for one sender, and the LRU maintenance moves those entries around on every insert. The
+// two cases below drive GroupPeerTable directly, because the property worth checking is not
+// "does it crash" but "does a sender's counter state stay bound to that sender" -- if an
+// entry's counter were aliased to a neighbour by a shuffle, replays would be accepted with
+// no memory error for a sanitizer to see.
+
+constexpr FabricIndex kOracleFabric = 1;
+constexpr NodeId kOracleNodeBase    = 0x0000000200000000ull;
+
+// A committed counter must still be recognised as a replay after the victim's entry has been
+// shuffled down the list by unrelated inserts.
+void PeerCounterSurvivesLruChurn(uint8_t victimSel, uint8_t churn, uint32_t counterValue)
+{
+    Transport::GroupPeerTable table;
+
+    const NodeId victim = kOracleNodeBase + victimSel;
+
+    Transport::PeerMessageCounter * counter = nullptr;
+    ASSERT_EQ(table.FindOrAddPeer(kOracleFabric, victim, false, counter), CHIP_NO_ERROR);
+    ASSERT_NE(counter, nullptr);
+    ASSERT_EQ(counter->VerifyOrTrustFirstGroup(counterValue), CHIP_NO_ERROR);
+    counter->CommitGroup(counterValue);
+
+    // Stay strictly under CHIP_CONFIG_MAX_GROUP_DATA_PEERS so the victim cannot be evicted;
+    // eviction is the other case's subject.
+    const uint8_t inserts = churn % (CHIP_CONFIG_MAX_GROUP_DATA_PEERS - 1);
+    for (uint8_t i = 0; i < inserts; i++)
+    {
+        const NodeId other                      = kOracleNodeBase + static_cast<NodeId>(victimSel) + 1 + i;
+        Transport::PeerMessageCounter * ignored = nullptr;
+        ASSERT_EQ(table.FindOrAddPeer(kOracleFabric, other, false, ignored), CHIP_NO_ERROR);
+    }
+
+    Transport::PeerMessageCounter * again = nullptr;
+    ASSERT_EQ(table.FindOrAddPeer(kOracleFabric, victim, false, again), CHIP_NO_ERROR);
+    ASSERT_NE(again, nullptr);
+    EXPECT_EQ(again->VerifyOrTrustFirstGroup(counterValue), CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
+}
+
+FUZZ_TEST(FuzzSessionManagerGroupCounterPW, PeerCounterSurvivesLruChurn)
+    .WithDomains(Arbitrary<uint8_t>(), Arbitrary<uint8_t>(), InRange<uint32_t>(1, 0xFFFFFFFEu));
+
+// The mirror property. Whether a peer that no longer fits is admitted with fresh state or
+// refused outright is the table's policy choice, so both outcomes are accepted here; what
+// must hold either way is that the peer is never handed a counter carrying some *other*
+// peer's history, which is what a mis-shuffled list would produce.
+void PeerCounterCrowdedOutPeerKeepsNoForeignState(uint8_t victimSel, uint32_t victimCounter)
+{
+    // Far enough apart that neither counter can fall in the other's 32-entry window, so a
+    // duplicate verdict below can only come from state that belongs to a different peer.
+    const uint32_t otherCounter = victimCounter + 0x10000u;
+
+    Transport::GroupPeerTable table;
+
+    const NodeId victim = kOracleNodeBase + victimSel;
+
+    Transport::PeerMessageCounter * counter = nullptr;
+    ASSERT_EQ(table.FindOrAddPeer(kOracleFabric, victim, false, counter), CHIP_NO_ERROR);
+    ASSERT_NE(counter, nullptr);
+    ASSERT_EQ(counter->VerifyOrTrustFirstGroup(victimCounter), CHIP_NO_ERROR);
+    counter->CommitGroup(victimCounter);
+
+    // Fill every remaining slot, each peer committing a counter of its own.
+    for (uint8_t i = 0; i < CHIP_CONFIG_MAX_GROUP_DATA_PEERS; i++)
+    {
+        const NodeId other                        = kOracleNodeBase + static_cast<NodeId>(victimSel) + 1 + i;
+        Transport::PeerMessageCounter * otherPeer = nullptr;
+        if (table.FindOrAddPeer(kOracleFabric, other, false, otherPeer) != CHIP_NO_ERROR)
+        {
+            break;
+        }
+        ASSERT_NE(otherPeer, nullptr);
+        if (otherPeer->VerifyOrTrustFirstGroup(otherCounter) == CHIP_NO_ERROR)
+        {
+            otherPeer->CommitGroup(otherCounter);
+        }
+    }
+
+    Transport::PeerMessageCounter * again = nullptr;
+    const CHIP_ERROR err                  = table.FindOrAddPeer(kOracleFabric, victim, false, again);
+    if (err != CHIP_NO_ERROR)
+    {
+        return; // Refused rather than re-admitted; nothing was handed out to check.
+    }
+    ASSERT_NE(again, nullptr);
+
+    // otherCounter belongs to the peers that filled the table, never to the victim.
+    EXPECT_NE(again->VerifyOrTrustFirstGroup(otherCounter), CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
+}
+
+FUZZ_TEST(FuzzSessionManagerGroupCounterPW, PeerCounterCrowdedOutPeerKeepsNoForeignState)
+    .WithDomains(Arbitrary<uint8_t>(), InRange<uint32_t>(1, 0xFFFEFFFEu));
+
+} // namespace

--- a/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
@@ -97,6 +97,17 @@ const uint8_t kEpochKeys[kMaxFabrics][16] = {
 
 // The delegate is the ExchangeManager boundary, past everything measured here, so a
 // no-op removes no check.
+// An empty std::vector's data() may be null, and PacketBufferHandle::NewWithData passes it
+// straight to memcpy, which UBSan's nonnull check rejects. Empty inputs stay in the domain.
+System::PacketBufferHandle MakeBuf(const std::vector<uint8_t> & bytes)
+{
+    if (bytes.empty())
+    {
+        return MessagePacketBuffer::New(0);
+    }
+    return MessagePacketBuffer::NewWithData(bytes.data(), bytes.size());
+}
+
 class NoopDelegate : public SessionMessageDelegate
 {
 public:
@@ -323,7 +334,7 @@ void GroupPeerTableDoesNotCorrupt(const std::vector<Record> & records)
             continue;
         }
 
-        PacketBufferHandle msg = MessagePacketBuffer::NewWithData(datagram.data(), datagram.size());
+        PacketBufferHandle msg = MakeBuf(datagram);
         if (msg.IsNull())
         {
             continue;
@@ -449,7 +460,7 @@ void GroupSendThenReceiveDoesNotCrash(uint8_t fabricSel, uint8_t typeSel, const 
         break;
     }
 
-    System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(payload.data(), payload.size());
+    System::PacketBufferHandle payloadBuf = MakeBuf(payload);
     if (payloadBuf.IsNull())
     {
         return;

--- a/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupCounterPW.cpp
@@ -18,21 +18,15 @@
 
 /**
  *    @file
- *      Stateful FuzzTest harness for the Matter group-multicast peer-counter table.
+ *      Stateful FuzzTest harness for the group peer-counter table.
  *
- *      The state that matters lives in the file-static gGroupPeerTable and only builds up
- *      across datagrams: FindOrAddPeer maintains a fixed-size LRU per fabric, so its
- *      insert, evict and most-recently-used paths depend on what earlier datagrams left
- *      behind. One fuzz input is therefore a SEQUENCE of records replayed in order.
- *
- *      FindOrAddPeer runs only after AES-CCM MIC verification succeeds, which mutated bytes
- *      cannot pass, so each record is encrypted with the real group key before being fed to
- *      SessionManager::OnMessageReceived. The encoder replicates the production encrypt
- *      sequence; it differs from PrepareMessage only in taking the source node id, message
- *      counter and control flag as parameters, which PrepareMessage fixes internally.
+ *      FindOrAddPeer maintains a fixed-size LRU whose insert, evict and MRU paths depend on
+ *      what earlier datagrams left behind, so one input is a sequence of records. It runs
+ *      only after AES-CCM verification, which mutated bytes cannot pass, so each record is
+ *      encrypted with the real group key first.
  *
  *      Real SessionManager, FabricTable, GroupDataProviderImpl, CryptoContext, libcrypto
- *      and the file-static gGroupPeerTable; nothing on the exercised path is stubbed.
+ *      and gGroupPeerTable; nothing on the exercised path is stubbed.
  */
 
 #include <array>
@@ -50,6 +44,9 @@
 #include <credentials/tests/CHIPCert_unit_test_vectors.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
 #include <crypto/PersistentStorageOperationalKeystore.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/AutoRelease.h>
@@ -81,14 +78,12 @@ using GroupInfo = GroupDataProvider::GroupInfo;
 using GroupKey  = GroupDataProvider::GroupKey;
 using KeySet    = GroupDataProvider::KeySet;
 
-// The single group id every fabric registers a key for. The epoch key is a valid
-// configured key; the fuzzer varies the datagram's sourceNodeId and counter.
+// The key stays a valid configured key; the fuzzer varies sourceNodeId and counter.
 constexpr GroupId kGroupId       = 2;
 constexpr uint16_t kTestKeysetId = 0x0123;
 
-// Fabrics the harness attempts to install; the cert vectors cap how many succeed, so
-// routing uses the achieved Fixture::fabricCount. Two or more exercise the fabric-search
-// loop; one still drives the per-fabric LRU.
+// The cert vectors cap how many installs succeed, so routing uses the achieved
+// Fixture::fabricCount. Two or more exercise the fabric-search loop.
 constexpr size_t kMaxFabrics = 4;
 
 // Distinct epoch key per fabric so each yields a distinct derived group key.
@@ -99,8 +94,8 @@ const uint8_t kEpochKeys[kMaxFabrics][16] = {
     { 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef },
 };
 
-// Dispatch needs a landing point. The delegate is the ExchangeManager boundary, past
-// everything this harness measures, so a no-op removes no check.
+// The delegate is the ExchangeManager boundary, past everything measured here, so a
+// no-op removes no check.
 class NoopDelegate : public SessionMessageDelegate
 {
 public:
@@ -109,8 +104,8 @@ public:
     {}
 };
 
-// Built once and reused. gGroupPeerTable is file-static, so the per-input reset below is
-// what makes an input self-contained and its result reproducible.
+// Built once. gGroupPeerTable is file-static, so the per-input reset below is what makes
+// an input reproducible on its own.
 struct Fixture
 {
     Testing::LoopbackTransportManager ctx;
@@ -138,8 +133,7 @@ struct Fixture
 
 Fixture * gFixture = nullptr;
 
-// Install one fabric from a distinct NOC asset, plus its group key. Each successful add
-// yields a distinct fabric index.
+// Each successful add yields a distinct fabric index.
 bool InstallFabric(Fixture & fx, size_t slot, const TestCerts::UnitTestCertAsset & root, const TestCerts::UnitTestCertAsset & icac,
                    const TestCerts::UnitTestCertAsset & noc)
 {
@@ -172,9 +166,8 @@ bool InstallFabric(Fixture & fx, size_t slot, const TestCerts::UnitTestCertAsset
     return true;
 }
 
-// Encode a valid, privacy-protected group datagram with fabric `slot`'s real key. Mirrors
-// the production encrypt sequence, differing from PrepareMessage only in taking the node id,
-// counter and control flag as parameters rather than fixing them.
+// Mirrors the production encrypt sequence, but takes the node id, counter and control flag
+// as parameters; PrepareMessage fixes all three internally.
 CHIP_ERROR EncodeGroupDatagram(Fixture & fx, size_t slot, NodeId nodeId, uint32_t counter, bool isControl,
                                std::vector<uint8_t> & out)
 {
@@ -182,10 +175,9 @@ CHIP_ERROR EncodeGroupDatagram(Fixture & fx, size_t slot, NodeId nodeId, uint32_
 
     PayloadHeader payloadHeader;
     payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
-    // NeedsAck must stay false: a group message requesting an ack is dropped before
-    // FindOrAddPeer.
+    // Must stay false: a group message requesting an ack is dropped before FindOrAddPeer.
 
-    const uint8_t payload[]        = { 'h', '4' };
+    const uint8_t payload[]        = { 0x01, 0x02 };
     System::PacketBufferHandle msg = MessagePacketBuffer::NewWithData(payload, sizeof(payload));
     VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
 
@@ -239,6 +231,10 @@ Fixture & GetFixture()
     static std::once_flag once;
     std::call_once(once, [] {
         VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        // A fuzz binary links gmock_main, which does not init PSA; key derivation needs it.
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
+#endif
 
         auto * fx = new Fixture();
 
@@ -262,8 +258,7 @@ Fixture & GetFixture()
         fx->sessionManager.SetMessageDelegate(&fx->delegate);
 
         using namespace chip::TestCerts;
-        // Distinct roots give distinct compressed fabric ids; NodeA2 adds a third fabric under
-        // root A. Each successful add is one routable slot; a single fabric is a valid fallback.
+        // Distinct roots give distinct compressed fabric ids; a single fabric is a valid fallback.
         InstallFabric(*fx, 0, GetRootACertAsset(), GetIAA1CertAsset(), GetNodeA1CertAsset());
         InstallFabric(*fx, 1, GetRootBCertAsset(), GetIAB1CertAsset(), GetNodeB1CertAsset());
         InstallFabric(*fx, 2, GetRootACertAsset(), GetIAA1CertAsset(), GetNodeA2CertAsset());
@@ -275,9 +270,8 @@ Fixture & GetFixture()
 
         gFixture = fx;
 
-        // The fixture is intentionally leaked, but the file-static Inet EndPointManagers
-        // VerifyOrDie in their destructors unless the layers were shut down first -- without
-        // this hook the run ends in a SIGABRT that reads as a crash.
+        // The fixture is leaked, but the file-static Inet EndPointManagers VerifyOrDie in
+        // their destructors unless shut down first, which reads as a crash.
         std::atexit([] {
             if (gFixture != nullptr)
             {
@@ -299,12 +293,10 @@ struct Record
     bool undefinedNode; // send sourceNodeId 0 -> FindOrAddPeer's CHIP_ERROR_INVALID_ARGUMENT arm
 };
 
-// Base for the generated node IDs. 256 distinct values (via nodeSel) is enough to over-fill the
-// 15/2 caps and force many evictions + MRU re-inserts.
+// 256 distinct node ids via nodeSel is enough to over-fill the caps and force evictions.
 constexpr NodeId kNodeBase = 0x0000000100000000ull;
 
-// Reset gGroupPeerTable to empty so each fuzz input is self-contained and any crash reproduces
-// standalone. SessionManager::FabricRemoved is public and clears that fabric's slot.
+// Empties gGroupPeerTable so a crash reproduces from its input alone.
 void ResetPeerTable(Fixture & fx)
 {
     for (size_t i = 0; i < fx.fabricCount; i++)
@@ -313,8 +305,7 @@ void ResetPeerTable(Fixture & fx)
     }
 }
 
-// Drive a sequence of datagrams through the real receive function, accumulating state in
-// gGroupPeerTable. The fuzzer controls the record count and every per-record field.
+// State accumulates across the sequence; the fuzzer controls the count and every field.
 void GroupPeerTableDoesNotCorrupt(const std::vector<Record> & records)
 {
     Fixture & fx = GetFixture();
@@ -341,23 +332,21 @@ void GroupPeerTableDoesNotCorrupt(const std::vector<Record> & records)
     }
 }
 
-// Programmatic seeds (record sequences), one per transition the table cares about, so the
-// mutator starts with a representative of every fill/evict/re-insert/first-add path.
+// One seed per table transition, so the mutator starts from a representative of each.
 std::vector<std::vector<Record>> GroupCounterSeeds()
 {
     std::vector<std::vector<Record>> seeds;
 
     auto data = [](uint8_t node) { return Record{ 0, node, false, 1, false }; };
 
-    // 1. A single valid data-message record (baseline reach of FindOrAddPeer non-control branch).
+    // Baseline: one data record.
     seeds.push_back({ data(1) });
 
-    // 2. A control-message record. SecureGroupMessageDispatch requires !IsSecureSessionControlMsg()
-    //    (MessageHeader.h IsValidGroupMsg), so this is rejected before FindOrAddPeer and the
-    //    control table is never reached from here. Kept as the negative case for that guard.
+    // Control frames fail IsValidGroupMsg before FindOrAddPeer, so this covers that guard,
+    // not the control table.
     seeds.push_back({ Record{ 0, 1, true, 1, false } });
 
-    // 3. > MAX_GROUP_DATA_PEERS (17) distinct data nodes, one fabric: fill -> evict past cap 15.
+    // Past the data cap on one fabric: fill, then evict.
     {
         std::vector<Record> s;
         for (uint8_t n = 1; n <= 17; n++)
@@ -367,15 +356,13 @@ std::vector<std::vector<Record>> GroupCounterSeeds()
         seeds.push_back(std::move(s));
     }
 
-    // 4. Several control records in a row: still the rejection guard, not the control cap.
-    //    CHIP_CONFIG_MAX_GROUP_CONTROL_PEERS is unreachable through this function.
+    // Still the rejection guard: the control cap is unreachable through this function.
     seeds.push_back({ Record{ 0, 1, true, 1, false }, Record{ 0, 2, true, 1, false }, Record{ 0, 3, true, 1, false } });
 
-    // 5. Mix >=2 fabrics: drives the first-add branch for a second mGroupFabrics slot.
+    // Two fabrics: the first-add branch for a second slot.
     seeds.push_back({ Record{ 0, 1, false, 1, false }, Record{ 1, 2, false, 1, false }, Record{ 2, 3, false, 1, false } });
 
-    // 6. Fill the data cap, then re-send an already-present node id: drives the search-hit
-    //    MRU-move ShiftAndInsert(list, i, ...) path.
+    // Re-sending a present node id takes the search-hit MRU-move path.
     {
         std::vector<Record> s;
         for (uint8_t n = 1; n <= 15; n++)
@@ -387,8 +374,7 @@ std::vector<std::vector<Record>> GroupCounterSeeds()
         seeds.push_back(std::move(s));
     }
 
-    // 7. Replay-window walk on ONE node: adopt a base counter, then revisit positions around
-    //    it. Covers FutureCounter, the in-window bitset test, equal-to-max and before-window.
+    // Walks one node's replay window: future, in-window, equal-to-max and behind.
     {
         const uint8_t node = 5;
         std::vector<Record> s;
@@ -496,18 +482,14 @@ void GroupSendThenReceiveDoesNotCrash(uint8_t fabricSel, uint8_t typeSel, const 
 FUZZ_TEST(FuzzSessionManagerGroupCounterPW, GroupSendThenReceiveDoesNotCrash)
     .WithDomains(Arbitrary<uint8_t>(), Arbitrary<uint8_t>(), VectorOf(Arbitrary<uint8_t>()).WithMaxSize(128));
 
-// The peer table drives replay protection: each entry carries the PeerMessageCounter state
-// for one sender, and the LRU maintenance moves those entries around on every insert. The
-// two cases below drive GroupPeerTable directly, because the property worth checking is not
-// "does it crash" but "does a sender's counter state stay bound to that sender" -- if an
-// entry's counter were aliased to a neighbour by a shuffle, replays would be accepted with
-// no memory error for a sanitizer to see.
+// These two drive GroupPeerTable directly: the property is that a sender's counter state
+// stays bound to that sender across LRU shuffles. Aliasing it to a neighbour would accept
+// replays with no memory error for a sanitizer to catch.
 
 constexpr FabricIndex kOracleFabric = 1;
 constexpr NodeId kOracleNodeBase    = 0x0000000200000000ull;
 
-// A committed counter must still be recognised as a replay after the victim's entry has been
-// shuffled down the list by unrelated inserts.
+// A committed counter must still read as a replay after unrelated inserts shuffle its entry.
 void PeerCounterSurvivesLruChurn(uint8_t victimSel, uint8_t churn, uint32_t counterValue)
 {
     Transport::GroupPeerTable table;
@@ -520,9 +502,9 @@ void PeerCounterSurvivesLruChurn(uint8_t victimSel, uint8_t churn, uint32_t coun
     ASSERT_EQ(counter->VerifyOrTrustFirstGroup(counterValue), CHIP_NO_ERROR);
     counter->CommitGroup(counterValue);
 
-    // Stay strictly under CHIP_CONFIG_MAX_GROUP_DATA_PEERS so the victim cannot be evicted;
-    // eviction is the other case's subject.
-    const uint8_t inserts = churn % (CHIP_CONFIG_MAX_GROUP_DATA_PEERS - 1);
+    // Up to a full table, leaving the victim at the least-recently-used end but still
+    // present: the boundary where a ShiftAndInsert off-by-one would show.
+    const uint8_t inserts = churn % CHIP_CONFIG_MAX_GROUP_DATA_PEERS;
     for (uint8_t i = 0; i < inserts; i++)
     {
         const NodeId other                      = kOracleNodeBase + static_cast<NodeId>(victimSel) + 1 + i;
@@ -539,14 +521,12 @@ void PeerCounterSurvivesLruChurn(uint8_t victimSel, uint8_t churn, uint32_t coun
 FUZZ_TEST(FuzzSessionManagerGroupCounterPW, PeerCounterSurvivesLruChurn)
     .WithDomains(Arbitrary<uint8_t>(), Arbitrary<uint8_t>(), InRange<uint32_t>(1, 0xFFFFFFFEu));
 
-// The mirror property. Whether a peer that no longer fits is admitted with fresh state or
-// refused outright is the table's policy choice, so both outcomes are accepted here; what
-// must hold either way is that the peer is never handed a counter carrying some *other*
-// peer's history, which is what a mis-shuffled list would produce.
+// Admitting a crowded-out peer with fresh state or refusing it outright is a policy choice,
+// so both are accepted; either way it must never be handed another peer's counter history.
 void PeerCounterCrowdedOutPeerKeepsNoForeignState(uint8_t victimSel, uint32_t victimCounter)
 {
-    // Far enough apart that neither counter can fall in the other's 32-entry window, so a
-    // duplicate verdict below can only come from state that belongs to a different peer.
+    // Far enough apart to fall outside each other's 32-entry window, so a duplicate verdict
+    // can only come from another peer's state.
     const uint32_t otherCounter = victimCounter + 0x10000u;
 
     Transport::GroupPeerTable table;
@@ -559,7 +539,7 @@ void PeerCounterCrowdedOutPeerKeepsNoForeignState(uint8_t victimSel, uint32_t vi
     ASSERT_EQ(counter->VerifyOrTrustFirstGroup(victimCounter), CHIP_NO_ERROR);
     counter->CommitGroup(victimCounter);
 
-    // Fill every remaining slot, each peer committing a counter of its own.
+    // Fill the remaining slots, each peer committing its own counter.
     for (uint8_t i = 0; i < CHIP_CONFIG_MAX_GROUP_DATA_PEERS; i++)
     {
         const NodeId other                        = kOracleNodeBase + static_cast<NodeId>(victimSel) + 1 + i;

--- a/src/transport/tests/FuzzSessionManagerGroupPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupPW.cpp
@@ -44,6 +44,7 @@
 #endif
 #include <crypto/PersistentStorageOperationalKeystore.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
@@ -407,14 +408,15 @@ constexpr NodeId kManualSourceNodeIds[] = { 0x0000000011223344ULL, 0x00000000000
 // Built field by field because PrepareMessage fixes the source node id, counter and control
 // flag internally, leaving the arms keyed on those unreachable through it. Privacy off keeps
 // the frame verifiable; receive handles both forms.
-bool BuildManualGroupFrame(Fixture & fx, bool controlMsg, uint8_t sourceSelector, uint32_t counter, uint8_t payloadType,
-                           const std::vector<uint8_t> & payload, std::vector<uint8_t> & out)
+CHIP_ERROR BuildManualGroupFrame(Fixture & fx, bool controlMsg, uint8_t sourceSelector, uint32_t counter, uint8_t payloadType,
+                                 const std::vector<uint8_t> & payload, std::vector<uint8_t> & out)
 {
     GroupDataProvider * groups = GetGroupDataProvider();
-    VerifyOrReturnValue(groups != nullptr, false);
+    VerifyOrReturnError(groups != nullptr, CHIP_ERROR_INTERNAL);
 
     Crypto::SymmetricKeyContext * keyContext = groups->GetKeyContext(fx.fabricIndex, kGroupId);
-    VerifyOrReturnValue(keyContext != nullptr, false);
+    VerifyOrReturnError(keyContext != nullptr, CHIP_ERROR_INTERNAL);
+    AutoRelease<Crypto::SymmetricKeyContext> keyContextOwner(keyContext);
 
     const NodeId sourceNodeId = kManualSourceNodeIds[sourceSelector % MATTER_ARRAY_SIZE(kManualSourceNodeIds)];
 
@@ -431,24 +433,17 @@ bool BuildManualGroupFrame(Fixture & fx, bool controlMsg, uint8_t sourceSelector
     payloadHeader.SetMessageType(chip::Protocols::InteractionModel::Id, payloadType);
 
     System::PacketBufferHandle msg = MessagePacketBuffer::NewWithData(payload.data(), payload.size());
-    if (msg.IsNull())
-    {
-        keyContext->Release();
-        return false;
-    }
+    VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
 
     CryptoContext cryptoContext(keyContext);
     CryptoContext::NonceStorage nonce;
-    bool ok = CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), sourceNodeId) ==
-            CHIP_NO_ERROR &&
-        SecureMessageCodec::Encrypt(cryptoContext, nonce, payloadHeader, packetHeader, msg) == CHIP_NO_ERROR &&
-        packetHeader.EncodeBeforeData(msg) == CHIP_NO_ERROR;
-
-    keyContext->Release();
-    VerifyOrReturnValue(ok, false);
+    ReturnErrorOnFailure(
+        CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), sourceNodeId));
+    ReturnErrorOnFailure(SecureMessageCodec::Encrypt(cryptoContext, nonce, payloadHeader, packetHeader, msg));
+    ReturnErrorOnFailure(packetHeader.EncodeBeforeData(msg));
 
     out.assign(msg->Start(), msg->Start() + msg->DataLength());
-    return true;
+    return CHIP_NO_ERROR;
 }
 
 void GroupManualFrameDoesNotCrash(bool controlMsg, uint8_t sourceSelector, uint32_t counter, uint8_t payloadType,
@@ -459,7 +454,7 @@ void GroupManualFrameDoesNotCrash(bool controlMsg, uint8_t sourceSelector, uint3
     ApplyTestingMode(fx, testingEnabled);
 
     std::vector<uint8_t> datagram;
-    if (!BuildManualGroupFrame(fx, controlMsg, sourceSelector, counter, payloadType, payload, datagram))
+    if (BuildManualGroupFrame(fx, controlMsg, sourceSelector, counter, payloadType, payload, datagram) != CHIP_NO_ERROR)
     {
         return;
     }

--- a/src/transport/tests/FuzzSessionManagerGroupPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupPW.cpp
@@ -34,9 +34,6 @@
 #include <pw_fuzzer/fuzztest.h>
 #include <pw_unit_test/framework.h>
 
-// Must precede SessionManager.h: enables EncryptedPacketBufferHandle::CastToWritable.
-#define CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
-
 #include <credentials/GroupDataProviderImpl.h>
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <credentials/tests/CHIPCert_unit_test_vectors.h>
@@ -59,8 +56,6 @@
 #include <transport/TransportMgr.h>
 #include <transport/raw/GroupcastTesting.h>
 #include <transport/tests/LoopbackTransportManager.h>
-
-#undef CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
 namespace {
 
@@ -140,6 +135,12 @@ struct Fixture
 Fixture * gFixture = nullptr;
 
 // Needed for IterateGroupSessions() to yield a real group session.
+// Empties gGroupPeerTable so a crash reproduces from its input alone.
+void ResetPeerTable(Fixture & fx)
+{
+    fx.sessionManager.FabricRemoved(fx.fabricIndex);
+}
+
 void SetupGroupKeys(Fixture & fx)
 {
     using namespace chip::TestCerts;
@@ -277,6 +278,7 @@ Fixture & GetFixture()
 void GroupDispatchDoesNotCrash(bool useRawDomain, bool testingEnabled, const std::vector<uint8_t> & bytes)
 {
     Fixture & fx = GetFixture();
+    ResetPeerTable(fx);
 
     ApplyTestingMode(fx, testingEnabled);
 
@@ -355,6 +357,7 @@ void GroupValidEncryptedDoesNotCrash(uint8_t payloadType, bool needsAck, bool te
                                      const std::vector<uint8_t> & payload)
 {
     Fixture & fx = GetFixture();
+    ResetPeerTable(fx);
 
     ApplyTestingMode(fx, testingEnabled);
 
@@ -451,6 +454,7 @@ void GroupManualFrameDoesNotCrash(bool controlMsg, uint8_t sourceSelector, uint3
                                   bool testingEnabled, const std::vector<uint8_t> & payload)
 {
     Fixture & fx = GetFixture();
+    ResetPeerTable(fx);
 
     ApplyTestingMode(fx, testingEnabled);
 

--- a/src/transport/tests/FuzzSessionManagerGroupPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupPW.cpp
@@ -18,15 +18,9 @@
 
 /**
  *    @file
- *      FuzzTest harness for the Matter group-multicast decrypt-and-dispatch path.
- *
- *      Drives SessionManager::OnMessageReceived down its group branch
- *      (SecureGroupMessageDispatch): privacy AES-CTR deobfuscation, AES-CCM MIC
- *      verification, group header and counter parsing, and dispatch.
- *
- *      A real SessionManager, GroupDataProviderImpl, FabricTable and the file-static
- *      gGroupPeerTable are stood up with a valid epoch key; nothing on the parse,
- *      crypto or decode path is stubbed.
+ *      Drives SessionManager::OnMessageReceived down its group branch. Real
+ *      SessionManager, GroupDataProviderImpl, FabricTable and gGroupPeerTable;
+ *      nothing on the parse, crypto or decode path is stubbed.
  */
 
 #include <cstdint>
@@ -40,14 +34,17 @@
 #include <pw_fuzzer/fuzztest.h>
 #include <pw_unit_test/framework.h>
 
-// Must precede SessionManager.h: enables EncryptedPacketBufferHandle::CastToWritable,
-// used ONLY by the valid-seed generator (mirrors TestSessionManagerDispatch.cpp).
+// Must precede SessionManager.h: enables EncryptedPacketBufferHandle::CastToWritable.
 #define CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
 #include <credentials/GroupDataProviderImpl.h>
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <credentials/tests/CHIPCert_unit_test_vectors.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
 #include <crypto/PersistentStorageOperationalKeystore.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CHIPMem.h>
@@ -79,23 +76,21 @@ using GroupKey       = GroupDataProvider::GroupKey;
 using KeySet         = GroupDataProvider::KeySet;
 using SecurityPolicy = GroupDataProvider::SecurityPolicy;
 
-// Same parameters as TestGroupPrepareMessagePrivacy. The key is a valid configured group
-// key throughout; the fuzzer varies the datagram, not the key material.
+// The key stays a valid configured group key; the fuzzer varies the datagram, not the key.
 constexpr GroupId kGroupId  = 2;
 const uint8_t kEpochKey[16] = { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf };
 constexpr uint16_t kTestKeysetId = 0x0123;
 
-// A second group under its own keyset, so the trial-decryption loop runs more than once.
-// kCacheAndSync is deliberately not used: GroupDataProviderImpl::SetKeySet rejects every
-// policy but kTrustFirst, so no keyset carrying it can reach the receive path.
+// A second keyset so the trial-decryption loop runs more than once. Not kCacheAndSync:
+// SetKeySet rejects every policy but kTrustFirst.
 constexpr GroupId kGroupIdSecond   = 3;
 constexpr uint16_t kKeysetIdSecond = 0x0124;
 const uint8_t kEpochKeySecond[16]  = {
     0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf
 };
 
-// Dispatch needs a landing point. The delegate is the ExchangeManager boundary, past
-// everything this harness measures, so a no-op removes no check.
+// The delegate is the ExchangeManager boundary, past everything measured here, so a
+// no-op removes no check.
 class NoopDelegate : public SessionMessageDelegate
 {
 public:
@@ -104,8 +99,7 @@ public:
     {}
 };
 
-// The Groupcast testing event sink. A null delegate would leave NotifyDelegate's dispatch
-// arm unexercised.
+// A null delegate would leave NotifyDelegate's dispatch arm unexercised.
 class TestingSink : public chip::Groupcast::Testing::Delegate
 {
 public:
@@ -115,8 +109,7 @@ private:
     uint64_t mFlushes = 0;
 };
 
-// Built once and reused: gGroupPeerTable is file-static and persists regardless, so
-// rebuilding the manager per input would cost time without isolating anything.
+// Built once: gGroupPeerTable is file-static, so rebuilding per input isolates nothing.
 struct Fixture
 {
     Testing::LoopbackTransportManager ctx;
@@ -146,8 +139,7 @@ struct Fixture
 
 Fixture * gFixture = nullptr;
 
-// Register a fabric and group key so IterateGroupSessions() yields a real group session.
-// Mirrors SetupGroupKeys in TestSessionManagerDispatch.cpp.
+// Needed for IterateGroupSessions() to yield a real group session.
 void SetupGroupKeys(Fixture & fx)
 {
     using namespace chip::TestCerts;
@@ -187,8 +179,7 @@ void SetupGroupKeys(Fixture & fx)
     VerifyOrDie(provider->SetGroupInfoAt(fx.fabricIndex, 1, secondGroupInfo) == CHIP_NO_ERROR);
 }
 
-// The testing state is a process-wide singleton, so set it explicitly on every input rather
-// than only when enabling -- otherwise the mode leaks across iterations.
+// Process-wide singleton: set on every input, or the mode leaks across iterations.
 void ApplyTestingMode(Fixture & fx, bool enabled)
 {
     auto & testing = chip::Groupcast::GetTesting();
@@ -197,8 +188,7 @@ void ApplyTestingMode(Fixture & fx, bool enabled)
     testing.SetEnabled(enabled);
 }
 
-// One valid privacy-protected datagram via the real PrepareMessage round-trip, used as a
-// seed and to learn the installed sessionId. Any mutation of it breaks the MIC.
+// Seed source, and how the installed sessionId is learned. Any mutation breaks its MIC.
 void BuildValidSeed(Fixture & fx)
 {
     Transport::OutgoingGroupSession outgoingSession(kGroupId, fx.fabricIndex);
@@ -233,6 +223,10 @@ Fixture & GetFixture()
     static std::once_flag once;
     std::call_once(once, [] {
         VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        // A fuzz binary links gmock_main, which does not init PSA; key derivation needs it.
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
+#endif
 
         auto * fx = new Fixture();
 
@@ -265,9 +259,8 @@ Fixture & GetFixture()
 
         gFixture = fx;
 
-        // The fixture is intentionally leaked, but the file-static Inet EndPointManagers
-        // VerifyOrDie in their destructors unless the layers were shut down first -- without
-        // this hook the run ends in a SIGABRT that reads as a crash. atexit runs before them.
+        // The fixture is leaked, but the file-static Inet EndPointManagers VerifyOrDie in
+        // their destructors unless shut down first, which reads as a crash. atexit precedes them.
         std::atexit([] {
             if (gFixture != nullptr)
             {
@@ -279,10 +272,8 @@ Fixture & GetFixture()
     return *gFixture;
 }
 
-// One datagram of arbitrary bytes. useRawDomain leaves the session id arbitrary, so most
-// inputs are rejected before any key is tried; otherwise it is overwritten with the
-// installed key's hash, which forces every input through privacy deobfuscation and a
-// decrypt attempt.
+// useRawDomain leaves the session id arbitrary, so most inputs are rejected before any key
+// is tried; otherwise it is pinned to the installed key's hash, forcing a decrypt attempt.
 void GroupDispatchDoesNotCrash(bool useRawDomain, bool testingEnabled, const std::vector<uint8_t> & bytes)
 {
     Fixture & fx = GetFixture();
@@ -318,29 +309,37 @@ std::vector<std::vector<uint8_t>> GroupSeeds()
         seeds.push_back(fx.validSeed);
     }
 
-    const uint8_t lo = static_cast<uint8_t>(fx.sessionId & 0xff);
-    const uint8_t hi = static_cast<uint8_t>((fx.sessionId >> 8) & 0xff);
+    // Written by field offset, not by hand-counted literal: PacketHeader::Encode lays the
+    // fixed part out as [0] msgFlags, [1..2] sessionId, [3] secFlags, [4..7] counter,
+    // [8..15] sourceNodeId, [16..17] destinationGroupId, and a group id placed anywhere but
+    // 16..17 decodes as 0 and dies at the group-id compare.
+    auto headerSeed = [&fx](uint8_t msgFlags, uint8_t secFlags, const std::vector<uint8_t> & tail) {
+        std::vector<uint8_t> seed(18, 0);
+        seed[0] = msgFlags;
+        seed[1] = static_cast<uint8_t>(fx.sessionId & 0xff);
+        seed[2] = static_cast<uint8_t>((fx.sessionId >> 8) & 0xff);
+        seed[3] = secFlags;
+        // counter and sourceNodeId stay zero; the mutator explores them.
+        seed[16] = static_cast<uint8_t>(kGroupId & 0xff);
+        seed[17] = static_cast<uint8_t>((kGroupId >> 8) & 0xff);
+        seed.insert(seed.end(), tail.begin(), tail.end());
+        return seed;
+    };
 
-    // Structured header-shape seeds, each pinned to the installed sessionId (Domain A shape),
-    // giving the mutator a representative for each DSIZ/flag dispatch arm.
-    // msgFlags byte0: version 0; 0x04 = SourceNodeId present, 0x02 = DestGroupId present.
-    // secFlags byte3: 0x01 = group session, 0x80 = privacy, 0x20 = MsgExtension.
+    // Long enough for a payload header plus the 16-byte MIC.
+    const std::vector<uint8_t> body = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+                                        0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x01, 0x02 };
 
-    // Source + DestGroup, group session, privacy on (mirrors the real shape), short body.
-    seeds.push_back({ 0x06, lo,   hi,   0x81, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00 });
-    // Same but privacy OFF.
-    seeds.push_back({ 0x06, lo,   hi,   0x01, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00 });
-    // MsgExtension flag set with a small MX block (length prefix 0x0002 + 2 bytes).
-    seeds.push_back({ 0x06, lo,   hi,   0xa1, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x02, 0x00, 0xAB, 0xCD, 0x00, 0x00, 0x00,
-                      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00 });
-    // DSIZ reserved 0b11 (both node+group dest bits): byte0 = 0x06 | 0x01? DSIZ is bits 0-1:
-    // 0x03 => both DestNode(0x01)+DestGroup(0x02). Plus SourceNodeId 0x04 => 0x07.
-    seeds.push_back({ 0x07, lo,   hi,   0x81, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00 });
-    // Truncated-to-16 buffer (mirrors TestGroupIncomingPrivacyBoundsCheck's shrink → :1126 guard).
-    seeds.push_back({ 0x06, lo, hi, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+    // msgFlags 0x06 = sourceNodeId + destinationGroupId present.
+    // secFlags: 0x01 group session, 0x80 privacy, 0x20 message extension.
+    seeds.push_back(headerSeed(0x06, 0x81, body)); // the real shape: group session, privacy on
+    seeds.push_back(headerSeed(0x06, 0x01, body)); // privacy off
+    seeds.push_back(headerSeed(0x06, 0xa1, body)); // message-extension flag set
+    seeds.push_back(headerSeed(0x06, 0x81, {}));   // fixed header only, no body or MIC
+
+    // Truncated below the fixed header, for the length guards before any key lookup.
+    seeds.push_back({ 0x06, static_cast<uint8_t>(fx.sessionId & 0xff), static_cast<uint8_t>((fx.sessionId >> 8) & 0xff), 0x81, 0x00,
+                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
 
     return seeds;
 }
@@ -350,13 +349,8 @@ FUZZ_TEST(FuzzSessionManagerGroupPW, GroupDispatchDoesNotCrash)
                  // Cap input size: header + small payload + 16-byte MIC is well under 512.
                  VectorOf(Arbitrary<uint8_t>()).WithMaxSize(512).WithSeeds(&GroupSeeds));
 
-// Encrypt-per-iteration: build a group message from fuzzer-controlled inner content and encrypt
-// it with the installed epoch key on EVERY input, so the AES-CCM MIC is always valid. The seeded
-// valid datagram only reaches the post-MIC region on its single unmutated replay -- any mutation
-// breaks the MIC -- so it cannot explore the post-MIC branches. This case re-MACs each input,
-// exercising the post-MIC continuation: the group message-counter window (GroupPeerMessageCounter),
-// payload-header decode, and the dispatch arms. Reachable by a group member holding the shared
-// epoch key.
+// Re-MACs every input with the installed epoch key, so the MIC always verifies and the
+// post-MIC continuation is reachable; a mutated seed cannot get there.
 void GroupValidEncryptedDoesNotCrash(uint8_t payloadType, bool needsAck, bool testingEnabled, bool useSecondGroup,
                                      const std::vector<uint8_t> & payload)
 {
@@ -403,19 +397,14 @@ FUZZ_TEST(FuzzSessionManagerGroupPW, GroupValidEncryptedDoesNotCrash)
     .WithDomains(Arbitrary<uint8_t>(), Arbitrary<bool>(), Arbitrary<bool>(), Arbitrary<bool>(),
                  VectorOf(Arbitrary<uint8_t>()).WithMaxSize(256));
 
-// Source node ids offered to the manual-frame case. kUndefinedNodeId is included because
-// SessionManager.cpp:1331 rejects a decrypted frame whose node id the peer table will not
-// accept, and that arm is otherwise unreachable.
+// kUndefinedNodeId is included so the peer table's rejecting arm is reachable.
 constexpr NodeId kManualSourceNodeIds[] = { 0x0000000011223344ULL, 0x0000000000000001ULL, kUndefinedNodeId, 0xFFFFFFFFFFFFFFFFULL };
 
-// Build a group datagram field by field instead of through PrepareMessage, then MAC it with
-// the installed epoch key. PrepareMessage emits exactly one header shape -- destination group
-// id, its own node id, its own monotonic counter, never the control-message flag, since
-// IsValidGroupMsg() rejects that combination -- so the arms keyed on those fields cannot be
-// reached through it however the payload is mutated. Privacy is left off: both forms are
-// handled on receive and the unobfuscated form keeps the built frame verifiable.
-bool BuildManualGroupFrame(Fixture & fx, bool controlMsg, bool destinationIsNode, uint8_t sourceSelector, uint32_t counter,
-                           uint8_t payloadType, const std::vector<uint8_t> & payload, std::vector<uint8_t> & out)
+// Built field by field because PrepareMessage fixes the source node id, counter and control
+// flag internally, leaving the arms keyed on those unreachable through it. Privacy off keeps
+// the frame verifiable; receive handles both forms.
+bool BuildManualGroupFrame(Fixture & fx, bool controlMsg, uint8_t sourceSelector, uint32_t counter, uint8_t payloadType,
+                           const std::vector<uint8_t> & payload, std::vector<uint8_t> & out)
 {
     GroupDataProvider * groups = GetGroupDataProvider();
     VerifyOrReturnValue(groups != nullptr, false);
@@ -430,14 +419,8 @@ bool BuildManualGroupFrame(Fixture & fx, bool controlMsg, bool destinationIsNode
     packetHeader.SetSessionId(keyContext->GetKeyHash());
     packetHeader.SetMessageCounter(counter);
     packetHeader.SetSourceNodeId(sourceNodeId);
-    // SecureGroupMessageDispatch returns at :1178 unless a destination group id is present,
-    // while IsValidMCSPMsg() additionally requires a destination node id -- so the MCSP arm
-    // is only reachable by a frame carrying both.
+    // Group id only: Encode refuses a header carrying both destination kinds.
     packetHeader.SetDestinationGroupId(kGroupId);
-    if (destinationIsNode)
-    {
-        packetHeader.SetDestinationNodeId(sourceNodeId);
-    }
     packetHeader.SetSecureSessionControlMsg(controlMsg);
 
     PayloadHeader payloadHeader;
@@ -464,15 +447,15 @@ bool BuildManualGroupFrame(Fixture & fx, bool controlMsg, bool destinationIsNode
     return true;
 }
 
-void GroupManualFrameDoesNotCrash(bool controlMsg, bool destinationIsNode, uint8_t sourceSelector, uint32_t counter,
-                                  uint8_t payloadType, bool testingEnabled, const std::vector<uint8_t> & payload)
+void GroupManualFrameDoesNotCrash(bool controlMsg, uint8_t sourceSelector, uint32_t counter, uint8_t payloadType,
+                                  bool testingEnabled, const std::vector<uint8_t> & payload)
 {
     Fixture & fx = GetFixture();
 
     ApplyTestingMode(fx, testingEnabled);
 
     std::vector<uint8_t> datagram;
-    if (!BuildManualGroupFrame(fx, controlMsg, destinationIsNode, sourceSelector, counter, payloadType, payload, datagram))
+    if (!BuildManualGroupFrame(fx, controlMsg, sourceSelector, counter, payloadType, payload, datagram))
     {
         return;
     }
@@ -487,7 +470,7 @@ void GroupManualFrameDoesNotCrash(bool controlMsg, bool destinationIsNode, uint8
 }
 
 FUZZ_TEST(FuzzSessionManagerGroupPW, GroupManualFrameDoesNotCrash)
-    .WithDomains(Arbitrary<bool>(), Arbitrary<bool>(), Arbitrary<uint8_t>(), Arbitrary<uint32_t>(), Arbitrary<uint8_t>(),
-                 Arbitrary<bool>(), VectorOf(Arbitrary<uint8_t>()).WithMaxSize(256));
+    .WithDomains(Arbitrary<bool>(), Arbitrary<uint8_t>(), Arbitrary<uint32_t>(), Arbitrary<uint8_t>(), Arbitrary<bool>(),
+                 VectorOf(Arbitrary<uint8_t>()).WithMaxSize(256));
 
 } // namespace

--- a/src/transport/tests/FuzzSessionManagerGroupPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupPW.cpp
@@ -105,6 +105,12 @@ private:
 };
 
 // Built once: gGroupPeerTable is file-static, so rebuilding per input isolates nothing.
+//
+// The peer table is deliberately not reset between inputs either, unlike the counter harness.
+// This case sends a single datagram per input, so a reset would leave the duplicate, window
+// and MRU arms unreachable -- measured 61.38% against 71.14% region on
+// SecureGroupMessageDispatch. The cost is that a crash here may need its predecessors to
+// reproduce; re-run the corpus in order.
 struct Fixture
 {
     Testing::LoopbackTransportManager ctx;

--- a/src/transport/tests/FuzzSessionManagerGroupPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupPW.cpp
@@ -1,0 +1,493 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      FuzzTest harness for the Matter group-multicast decrypt-and-dispatch path.
+ *
+ *      Drives SessionManager::OnMessageReceived down its group branch
+ *      (SecureGroupMessageDispatch): privacy AES-CTR deobfuscation, AES-CCM MIC
+ *      verification, group header and counter parsing, and dispatch.
+ *
+ *      A real SessionManager, GroupDataProviderImpl, FabricTable and the file-static
+ *      gGroupPeerTable are stood up with a valid epoch key; nothing on the parse,
+ *      crypto or decode path is stubbed.
+ */
+
+#include <cstdint>
+#include <cstdlib>
+#include <mutex>
+#include <optional>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <pw_fuzzer/fuzztest.h>
+#include <pw_unit_test/framework.h>
+
+// Must precede SessionManager.h: enables EncryptedPacketBufferHandle::CastToWritable,
+// used ONLY by the valid-seed generator (mirrors TestSessionManagerDispatch.cpp).
+#define CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
+
+#include <credentials/GroupDataProviderImpl.h>
+#include <credentials/PersistentStorageOpCertStore.h>
+#include <credentials/tests/CHIPCert_unit_test_vectors.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <protocols/interaction_model/Constants.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
+#include <transport/CryptoContext.h>
+#include <transport/GroupSession.h>
+#include <transport/SecureMessageCodec.h>
+#include <transport/SessionManager.h>
+#include <transport/TransportMgr.h>
+#include <transport/raw/GroupcastTesting.h>
+#include <transport/tests/LoopbackTransportManager.h>
+
+#undef CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
+
+namespace {
+
+using namespace chip;
+using namespace chip::Transport;
+using namespace chip::Credentials;
+using namespace fuzztest;
+
+using chip::System::PacketBufferHandle;
+
+using GroupInfo      = GroupDataProvider::GroupInfo;
+using GroupKey       = GroupDataProvider::GroupKey;
+using KeySet         = GroupDataProvider::KeySet;
+using SecurityPolicy = GroupDataProvider::SecurityPolicy;
+
+// Same parameters as TestGroupPrepareMessagePrivacy. The key is a valid configured group
+// key throughout; the fuzzer varies the datagram, not the key material.
+constexpr GroupId kGroupId  = 2;
+const uint8_t kEpochKey[16] = { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf };
+constexpr uint16_t kTestKeysetId = 0x0123;
+
+// A second group under its own keyset, so the trial-decryption loop runs more than once.
+// kCacheAndSync is deliberately not used: GroupDataProviderImpl::SetKeySet rejects every
+// policy but kTrustFirst, so no keyset carrying it can reach the receive path.
+constexpr GroupId kGroupIdSecond   = 3;
+constexpr uint16_t kKeysetIdSecond = 0x0124;
+const uint8_t kEpochKeySecond[16]  = {
+    0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf
+};
+
+// Dispatch needs a landing point. The delegate is the ExchangeManager boundary, past
+// everything this harness measures, so a no-op removes no check.
+class NoopDelegate : public SessionMessageDelegate
+{
+public:
+    void OnMessageReceived(const PacketHeader &, const PayloadHeader &, const SessionHandle &, DuplicateMessage,
+                           System::PacketBufferHandle &&) override
+    {}
+};
+
+// The Groupcast testing event sink. A null delegate would leave NotifyDelegate's dispatch
+// arm unexercised.
+class TestingSink : public chip::Groupcast::Testing::Delegate
+{
+public:
+    void FlushGroupcastTestingEvent() override { mFlushes++; }
+
+private:
+    uint64_t mFlushes = 0;
+};
+
+// Built once and reused: gGroupPeerTable is file-static and persists regardless, so
+// rebuilding the manager per input would cost time without isolating anything.
+struct Fixture
+{
+    Testing::LoopbackTransportManager ctx;
+    FabricTable fabricTable;
+    TestPersistentStorageDelegate fabricStorage;
+    PersistentStorageOperationalKeystore opKeyStore;
+    PersistentStorageOpCertStore opCertStore;
+
+    TestPersistentStorageDelegate providerStorage;
+    Crypto::DefaultSessionKeystore providerKeystore;
+    GroupDataProviderImpl provider{ /*maxGroupsPerFabric*/ 5, /*maxGroupKeysPerFabric*/ 8 };
+
+    TestPersistentStorageDelegate deviceStorage;
+    Crypto::DefaultSessionKeystore sessionKeystore;
+    secure_channel::MessageCounterManager messageCounterManager;
+
+    SessionManager sessionManager;
+    NoopDelegate delegate;
+    TestingSink testingSink;
+
+    FabricIndex fabricIndex = kUndefinedFabricIndex;
+    uint16_t sessionId      = 0; // learned from the prepared valid message
+    std::vector<uint8_t> validSeed;
+
+    PeerAddress peer;
+};
+
+Fixture * gFixture = nullptr;
+
+// Register a fabric and group key so IterateGroupSessions() yields a real group session.
+// Mirrors SetupGroupKeys in TestSessionManagerDispatch.cpp.
+void SetupGroupKeys(Fixture & fx)
+{
+    using namespace chip::TestCerts;
+
+    FabricTable * fabricTable = fx.sessionManager.GetFabricTable();
+    VerifyOrDie(fabricTable != nullptr);
+    VerifyOrDie(fabricTable->AddNewFabricForTestIgnoringCollisions(GetRootACertAsset().mCert, GetIAA1CertAsset().mCert,
+                                                                   GetNodeA1CertAsset().mCert, GetNodeA1CertAsset().mKey,
+                                                                   &fx.fabricIndex) == CHIP_NO_ERROR);
+
+    uint8_t compressedFabricBuf[sizeof(uint64_t)];
+    MutableByteSpan compressedFabricSpan(compressedFabricBuf);
+    VerifyOrDie(fabricTable->FindFabricWithIndex(fx.fabricIndex)->GetCompressedFabricIdBytes(compressedFabricSpan) ==
+                CHIP_NO_ERROR);
+
+    GroupDataProvider * provider = GetGroupDataProvider();
+    VerifyOrDie(provider != nullptr);
+
+    KeySet keySet(kTestKeysetId, GroupDataProvider::SecurityPolicy::kTrustFirst, 1);
+    memcpy(keySet.epoch_keys[0].key, kEpochKey, 16);
+    keySet.epoch_keys[0].start_time = 0;
+    GroupKey groupKey(kGroupId, kTestKeysetId);
+    GroupInfo groupInfo(kGroupId, "Privacy Group");
+
+    VerifyOrDie(provider->SetKeySet(fx.fabricIndex, compressedFabricSpan, keySet) == CHIP_NO_ERROR);
+    VerifyOrDie(provider->SetGroupKeyAt(fx.fabricIndex, 0, groupKey) == CHIP_NO_ERROR);
+    VerifyOrDie(provider->SetGroupInfoAt(fx.fabricIndex, 0, groupInfo) == CHIP_NO_ERROR);
+
+    KeySet secondKeySet(kKeysetIdSecond, GroupDataProvider::SecurityPolicy::kTrustFirst, 1);
+    memcpy(secondKeySet.epoch_keys[0].key, kEpochKeySecond, 16);
+    secondKeySet.epoch_keys[0].start_time = 0;
+    GroupKey secondGroupKey(kGroupIdSecond, kKeysetIdSecond);
+    GroupInfo secondGroupInfo(kGroupIdSecond, "Second Group");
+
+    VerifyOrDie(provider->SetKeySet(fx.fabricIndex, compressedFabricSpan, secondKeySet) == CHIP_NO_ERROR);
+    VerifyOrDie(provider->SetGroupKeyAt(fx.fabricIndex, 1, secondGroupKey) == CHIP_NO_ERROR);
+    VerifyOrDie(provider->SetGroupInfoAt(fx.fabricIndex, 1, secondGroupInfo) == CHIP_NO_ERROR);
+}
+
+// The testing state is a process-wide singleton, so set it explicitly on every input rather
+// than only when enabling -- otherwise the mode leaks across iterations.
+void ApplyTestingMode(Fixture & fx, bool enabled)
+{
+    auto & testing = chip::Groupcast::GetTesting();
+    testing.SetDelegate(enabled ? &fx.testingSink : nullptr);
+    testing.SetFabricIndex(fx.fabricIndex);
+    testing.SetEnabled(enabled);
+}
+
+// One valid privacy-protected datagram via the real PrepareMessage round-trip, used as a
+// seed and to learn the installed sessionId. Any mutation of it breaks the MIC.
+void BuildValidSeed(Fixture & fx)
+{
+    Transport::OutgoingGroupSession outgoingSession(kGroupId, fx.fabricIndex);
+    SessionHandle outgoingHandle(outgoingSession);
+    SessionHolder outgoingHolder(outgoingHandle);
+
+    PayloadHeader payloadHeader;
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::MsgType::InvokeCommandRequest);
+    const char testPayload[] = "PrivacyTest";
+    System::PacketBufferHandle payloadBuf =
+        MessagePacketBuffer::NewWithData(reinterpret_cast<const uint8_t *>(testPayload), sizeof(testPayload));
+    VerifyOrDie(!payloadBuf.IsNull());
+
+    EncryptedPacketBufferHandle preparedMessage;
+    VerifyOrDie(fx.sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf),
+                                                 preparedMessage) == CHIP_NO_ERROR);
+
+    System::PacketBufferHandle writableMsg = preparedMessage.CastToWritable();
+    VerifyOrDie(!writableMsg.IsNull());
+
+    PacketHeader decodedHeader;
+    uint16_t headerSize = 0;
+    VerifyOrDie(decodedHeader.Decode(writableMsg->Start(), writableMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+    VerifyOrDie(decodedHeader.IsGroupSession());
+    fx.sessionId = decodedHeader.GetSessionId();
+
+    fx.validSeed.assign(writableMsg->Start(), writableMsg->Start() + writableMsg->DataLength());
+}
+
+Fixture & GetFixture()
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+
+        auto * fx = new Fixture();
+
+        VerifyOrDie(fx->ctx.Init() == CHIP_NO_ERROR);
+
+        VerifyOrDie(fx->opKeyStore.Init(&fx->fabricStorage) == CHIP_NO_ERROR);
+        VerifyOrDie(fx->opCertStore.Init(&fx->fabricStorage) == CHIP_NO_ERROR);
+
+        fx->provider.SetStorageDelegate(&fx->providerStorage);
+        fx->provider.SetSessionKeystore(&fx->providerKeystore);
+        VerifyOrDie(fx->provider.Init() == CHIP_NO_ERROR);
+        Credentials::SetGroupDataProvider(&fx->provider);
+
+        FabricTable::InitParams initParams;
+        initParams.storage             = &fx->fabricStorage;
+        initParams.operationalKeystore = &fx->opKeyStore;
+        initParams.opCertStore         = &fx->opCertStore;
+        VerifyOrDie(fx->fabricTable.Init(initParams) == CHIP_NO_ERROR);
+
+        VerifyOrDie(fx->sessionManager.Init(&fx->ctx.GetSystemLayer(), &fx->ctx.GetTransportMgr(), &fx->messageCounterManager,
+                                            &fx->deviceStorage, &fx->fabricTable, fx->sessionKeystore) == CHIP_NO_ERROR);
+        fx->sessionManager.SetMessageDelegate(&fx->delegate);
+
+        SetupGroupKeys(*fx);
+        BuildValidSeed(*fx);
+
+        Inet::IPAddress addr;
+        VerifyOrDie(Inet::IPAddress::FromString("::1", addr));
+        fx->peer = PeerAddress::UDP(addr, CHIP_PORT);
+
+        gFixture = fx;
+
+        // The fixture is intentionally leaked, but the file-static Inet EndPointManagers
+        // VerifyOrDie in their destructors unless the layers were shut down first -- without
+        // this hook the run ends in a SIGABRT that reads as a crash. atexit runs before them.
+        std::atexit([] {
+            if (gFixture != nullptr)
+            {
+                gFixture->sessionManager.Shutdown();
+                gFixture->ctx.Shutdown();
+            }
+        });
+    });
+    return *gFixture;
+}
+
+// One datagram of arbitrary bytes. useRawDomain leaves the session id arbitrary, so most
+// inputs are rejected before any key is tried; otherwise it is overwritten with the
+// installed key's hash, which forces every input through privacy deobfuscation and a
+// decrypt attempt.
+void GroupDispatchDoesNotCrash(bool useRawDomain, bool testingEnabled, const std::vector<uint8_t> & bytes)
+{
+    Fixture & fx = GetFixture();
+
+    ApplyTestingMode(fx, testingEnabled);
+
+    std::vector<uint8_t> datagram = bytes;
+    if (!useRawDomain && datagram.size() >= 3)
+    {
+        // PacketHeader layout: byte0 msgFlags, bytes 1-2 sessionId (little-endian), byte3 secFlags.
+        datagram[1] = static_cast<uint8_t>(fx.sessionId & 0xff);
+        datagram[2] = static_cast<uint8_t>((fx.sessionId >> 8) & 0xff);
+    }
+
+    PacketBufferHandle msg = MessagePacketBuffer::NewWithData(datagram.data(), datagram.size());
+    if (msg.IsNull())
+    {
+        return;
+    }
+
+    fx.sessionManager.OnMessageReceived(fx.peer, std::move(msg));
+}
+
+// Seeds (evaluated lazily via the SeedProvider overload, so the fixture is stood up first).
+std::vector<std::vector<uint8_t>> GroupSeeds()
+{
+    Fixture & fx = GetFixture();
+    std::vector<std::vector<uint8_t>> seeds;
+
+    // Programmatic valid seed: full privacy + valid MIC, drives the post-MIC region.
+    if (!fx.validSeed.empty())
+    {
+        seeds.push_back(fx.validSeed);
+    }
+
+    const uint8_t lo = static_cast<uint8_t>(fx.sessionId & 0xff);
+    const uint8_t hi = static_cast<uint8_t>((fx.sessionId >> 8) & 0xff);
+
+    // Structured header-shape seeds, each pinned to the installed sessionId (Domain A shape),
+    // giving the mutator a representative for each DSIZ/flag dispatch arm.
+    // msgFlags byte0: version 0; 0x04 = SourceNodeId present, 0x02 = DestGroupId present.
+    // secFlags byte3: 0x01 = group session, 0x80 = privacy, 0x20 = MsgExtension.
+
+    // Source + DestGroup, group session, privacy on (mirrors the real shape), short body.
+    seeds.push_back({ 0x06, lo,   hi,   0x81, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00 });
+    // Same but privacy OFF.
+    seeds.push_back({ 0x06, lo,   hi,   0x01, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00 });
+    // MsgExtension flag set with a small MX block (length prefix 0x0002 + 2 bytes).
+    seeds.push_back({ 0x06, lo,   hi,   0xa1, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x02, 0x00, 0xAB, 0xCD, 0x00, 0x00, 0x00,
+                      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00 });
+    // DSIZ reserved 0b11 (both node+group dest bits): byte0 = 0x06 | 0x01? DSIZ is bits 0-1:
+    // 0x03 => both DestNode(0x01)+DestGroup(0x02). Plus SourceNodeId 0x04 => 0x07.
+    seeds.push_back({ 0x07, lo,   hi,   0x81, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00 });
+    // Truncated-to-16 buffer (mirrors TestGroupIncomingPrivacyBoundsCheck's shrink → :1126 guard).
+    seeds.push_back({ 0x06, lo, hi, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+    return seeds;
+}
+
+FUZZ_TEST(FuzzSessionManagerGroupPW, GroupDispatchDoesNotCrash)
+    .WithDomains(Arbitrary<bool>(), Arbitrary<bool>(),
+                 // Cap input size: header + small payload + 16-byte MIC is well under 512.
+                 VectorOf(Arbitrary<uint8_t>()).WithMaxSize(512).WithSeeds(&GroupSeeds));
+
+// Encrypt-per-iteration: build a group message from fuzzer-controlled inner content and encrypt
+// it with the installed epoch key on EVERY input, so the AES-CCM MIC is always valid. The seeded
+// valid datagram only reaches the post-MIC region on its single unmutated replay -- any mutation
+// breaks the MIC -- so it cannot explore the post-MIC branches. This case re-MACs each input,
+// exercising the post-MIC continuation: the group message-counter window (GroupPeerMessageCounter),
+// payload-header decode, and the dispatch arms. Reachable by a group member holding the shared
+// epoch key.
+void GroupValidEncryptedDoesNotCrash(uint8_t payloadType, bool needsAck, bool testingEnabled, bool useSecondGroup,
+                                     const std::vector<uint8_t> & payload)
+{
+    Fixture & fx = GetFixture();
+
+    ApplyTestingMode(fx, testingEnabled);
+
+    Transport::OutgoingGroupSession outgoingSession(useSecondGroup ? kGroupIdSecond : kGroupId, fx.fabricIndex);
+    SessionHandle outgoingHandle(outgoingSession);
+    SessionHolder outgoingHolder(outgoingHandle);
+
+    PayloadHeader payloadHeader;
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::Id, payloadType);
+    payloadHeader.SetNeedsAck(needsAck);
+
+    System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(payload.data(), payload.size());
+    if (payloadBuf.IsNull())
+    {
+        return;
+    }
+
+    EncryptedPacketBufferHandle prepared;
+    if (fx.sessionManager.PrepareMessage(outgoingHolder.Get().Value(), payloadHeader, std::move(payloadBuf), prepared) !=
+        CHIP_NO_ERROR)
+    {
+        return;
+    }
+
+    System::PacketBufferHandle wire = prepared.CastToWritable();
+    if (wire.IsNull())
+    {
+        return;
+    }
+
+    PacketBufferHandle msg = MessagePacketBuffer::NewWithData(wire->Start(), wire->DataLength());
+    if (msg.IsNull())
+    {
+        return;
+    }
+    fx.sessionManager.OnMessageReceived(fx.peer, std::move(msg));
+}
+
+FUZZ_TEST(FuzzSessionManagerGroupPW, GroupValidEncryptedDoesNotCrash)
+    .WithDomains(Arbitrary<uint8_t>(), Arbitrary<bool>(), Arbitrary<bool>(), Arbitrary<bool>(),
+                 VectorOf(Arbitrary<uint8_t>()).WithMaxSize(256));
+
+// Source node ids offered to the manual-frame case. kUndefinedNodeId is included because
+// SessionManager.cpp:1331 rejects a decrypted frame whose node id the peer table will not
+// accept, and that arm is otherwise unreachable.
+constexpr NodeId kManualSourceNodeIds[] = { 0x0000000011223344ULL, 0x0000000000000001ULL, kUndefinedNodeId, 0xFFFFFFFFFFFFFFFFULL };
+
+// Build a group datagram field by field instead of through PrepareMessage, then MAC it with
+// the installed epoch key. PrepareMessage emits exactly one header shape -- destination group
+// id, its own node id, its own monotonic counter, never the control-message flag, since
+// IsValidGroupMsg() rejects that combination -- so the arms keyed on those fields cannot be
+// reached through it however the payload is mutated. Privacy is left off: both forms are
+// handled on receive and the unobfuscated form keeps the built frame verifiable.
+bool BuildManualGroupFrame(Fixture & fx, bool controlMsg, bool destinationIsNode, uint8_t sourceSelector, uint32_t counter,
+                           uint8_t payloadType, const std::vector<uint8_t> & payload, std::vector<uint8_t> & out)
+{
+    GroupDataProvider * groups = GetGroupDataProvider();
+    VerifyOrReturnValue(groups != nullptr, false);
+
+    Crypto::SymmetricKeyContext * keyContext = groups->GetKeyContext(fx.fabricIndex, kGroupId);
+    VerifyOrReturnValue(keyContext != nullptr, false);
+
+    const NodeId sourceNodeId = kManualSourceNodeIds[sourceSelector % MATTER_ARRAY_SIZE(kManualSourceNodeIds)];
+
+    PacketHeader packetHeader;
+    packetHeader.SetSessionType(Header::SessionType::kGroupSession);
+    packetHeader.SetSessionId(keyContext->GetKeyHash());
+    packetHeader.SetMessageCounter(counter);
+    packetHeader.SetSourceNodeId(sourceNodeId);
+    // SecureGroupMessageDispatch returns at :1178 unless a destination group id is present,
+    // while IsValidMCSPMsg() additionally requires a destination node id -- so the MCSP arm
+    // is only reachable by a frame carrying both.
+    packetHeader.SetDestinationGroupId(kGroupId);
+    if (destinationIsNode)
+    {
+        packetHeader.SetDestinationNodeId(sourceNodeId);
+    }
+    packetHeader.SetSecureSessionControlMsg(controlMsg);
+
+    PayloadHeader payloadHeader;
+    payloadHeader.SetMessageType(chip::Protocols::InteractionModel::Id, payloadType);
+
+    System::PacketBufferHandle msg = MessagePacketBuffer::NewWithData(payload.data(), payload.size());
+    if (msg.IsNull())
+    {
+        keyContext->Release();
+        return false;
+    }
+
+    CryptoContext cryptoContext(keyContext);
+    CryptoContext::NonceStorage nonce;
+    bool ok = CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), sourceNodeId) ==
+            CHIP_NO_ERROR &&
+        SecureMessageCodec::Encrypt(cryptoContext, nonce, payloadHeader, packetHeader, msg) == CHIP_NO_ERROR &&
+        packetHeader.EncodeBeforeData(msg) == CHIP_NO_ERROR;
+
+    keyContext->Release();
+    VerifyOrReturnValue(ok, false);
+
+    out.assign(msg->Start(), msg->Start() + msg->DataLength());
+    return true;
+}
+
+void GroupManualFrameDoesNotCrash(bool controlMsg, bool destinationIsNode, uint8_t sourceSelector, uint32_t counter,
+                                  uint8_t payloadType, bool testingEnabled, const std::vector<uint8_t> & payload)
+{
+    Fixture & fx = GetFixture();
+
+    ApplyTestingMode(fx, testingEnabled);
+
+    std::vector<uint8_t> datagram;
+    if (!BuildManualGroupFrame(fx, controlMsg, destinationIsNode, sourceSelector, counter, payloadType, payload, datagram))
+    {
+        return;
+    }
+
+    PacketBufferHandle msg = MessagePacketBuffer::NewWithData(datagram.data(), datagram.size());
+    if (msg.IsNull())
+    {
+        return;
+    }
+
+    fx.sessionManager.OnMessageReceived(fx.peer, std::move(msg));
+}
+
+FUZZ_TEST(FuzzSessionManagerGroupPW, GroupManualFrameDoesNotCrash)
+    .WithDomains(Arbitrary<bool>(), Arbitrary<bool>(), Arbitrary<uint8_t>(), Arbitrary<uint32_t>(), Arbitrary<uint8_t>(),
+                 Arbitrary<bool>(), VectorOf(Arbitrary<uint8_t>()).WithMaxSize(256));
+
+} // namespace

--- a/src/transport/tests/FuzzSessionManagerGroupPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupPW.cpp
@@ -135,12 +135,6 @@ struct Fixture
 Fixture * gFixture = nullptr;
 
 // Needed for IterateGroupSessions() to yield a real group session.
-// Empties gGroupPeerTable so a crash reproduces from its input alone.
-void ResetPeerTable(Fixture & fx)
-{
-    fx.sessionManager.FabricRemoved(fx.fabricIndex);
-}
-
 void SetupGroupKeys(Fixture & fx)
 {
     using namespace chip::TestCerts;
@@ -273,19 +267,21 @@ Fixture & GetFixture()
     return *gFixture;
 }
 
-// useRawDomain leaves the session id arbitrary, so most inputs are rejected before any key
-// is tried; otherwise it is pinned to the installed key's hash, forcing a decrypt attempt.
+// useRawDomain leaves the session id arbitrary; otherwise it is pinned to the installed
+// key's hash so that inputs whose header shape passes reach a decrypt attempt.
 void GroupDispatchDoesNotCrash(bool useRawDomain, bool testingEnabled, const std::vector<uint8_t> & bytes)
 {
     Fixture & fx = GetFixture();
-    ResetPeerTable(fx);
 
     ApplyTestingMode(fx, testingEnabled);
 
     std::vector<uint8_t> datagram = bytes;
     if (!useRawDomain && datagram.size() >= 3)
     {
-        // PacketHeader layout: byte0 msgFlags, bytes 1-2 sessionId (little-endian), byte3 secFlags.
+        // Only the session id, at bytes 1-2. The flag bytes stay fuzzer-controlled, so most
+        // inputs are still rejected on header shape before any key is tried; the seeds below
+        // supply the well-formed shapes. Pinning the flags too costs more than it gains: it
+        // measured 10 points lower, because the free bytes are what reach the reject arms.
         datagram[1] = static_cast<uint8_t>(fx.sessionId & 0xff);
         datagram[2] = static_cast<uint8_t>((fx.sessionId >> 8) & 0xff);
     }
@@ -357,7 +353,6 @@ void GroupValidEncryptedDoesNotCrash(uint8_t payloadType, bool needsAck, bool te
                                      const std::vector<uint8_t> & payload)
 {
     Fixture & fx = GetFixture();
-    ResetPeerTable(fx);
 
     ApplyTestingMode(fx, testingEnabled);
 
@@ -454,7 +449,6 @@ void GroupManualFrameDoesNotCrash(bool controlMsg, uint8_t sourceSelector, uint3
                                   bool testingEnabled, const std::vector<uint8_t> & payload)
 {
     Fixture & fx = GetFixture();
-    ResetPeerTable(fx);
 
     ApplyTestingMode(fx, testingEnabled);
 

--- a/src/transport/tests/FuzzSessionManagerGroupPW.cpp
+++ b/src/transport/tests/FuzzSessionManagerGroupPW.cpp
@@ -85,6 +85,17 @@ const uint8_t kEpochKeySecond[16]  = {
     0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf
 };
 
+// An empty std::vector's data() may be null, and PacketBufferHandle::NewWithData passes it
+// straight to memcpy, which UBSan's nonnull check rejects. Empty inputs stay in the domain.
+System::PacketBufferHandle MakeBuf(const std::vector<uint8_t> & bytes)
+{
+    if (bytes.empty())
+    {
+        return MessagePacketBuffer::New(0);
+    }
+    return MessagePacketBuffer::NewWithData(bytes.data(), bytes.size());
+}
+
 // The delegate is the ExchangeManager boundary, past everything measured here, so a
 // no-op removes no check.
 class NoopDelegate : public SessionMessageDelegate
@@ -293,7 +304,7 @@ void GroupDispatchDoesNotCrash(bool useRawDomain, bool testingEnabled, const std
         datagram[2] = static_cast<uint8_t>((fx.sessionId >> 8) & 0xff);
     }
 
-    PacketBufferHandle msg = MessagePacketBuffer::NewWithData(datagram.data(), datagram.size());
+    PacketBufferHandle msg = MakeBuf(datagram);
     if (msg.IsNull())
     {
         return;
@@ -371,7 +382,7 @@ void GroupValidEncryptedDoesNotCrash(uint8_t payloadType, bool needsAck, bool te
     payloadHeader.SetMessageType(chip::Protocols::InteractionModel::Id, payloadType);
     payloadHeader.SetNeedsAck(needsAck);
 
-    System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(payload.data(), payload.size());
+    System::PacketBufferHandle payloadBuf = MakeBuf(payload);
     if (payloadBuf.IsNull())
     {
         return;
@@ -432,7 +443,7 @@ CHIP_ERROR BuildManualGroupFrame(Fixture & fx, bool controlMsg, uint8_t sourceSe
     PayloadHeader payloadHeader;
     payloadHeader.SetMessageType(chip::Protocols::InteractionModel::Id, payloadType);
 
-    System::PacketBufferHandle msg = MessagePacketBuffer::NewWithData(payload.data(), payload.size());
+    System::PacketBufferHandle msg = MakeBuf(payload);
     VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
 
     CryptoContext cryptoContext(keyContext);
@@ -459,7 +470,7 @@ void GroupManualFrameDoesNotCrash(bool controlMsg, uint8_t sourceSelector, uint3
         return;
     }
 
-    PacketBufferHandle msg = MessagePacketBuffer::NewWithData(datagram.data(), datagram.size());
+    PacketBufferHandle msg = MakeBuf(datagram);
     if (msg.IsNull())
     {
         return;


### PR DESCRIPTION
#### Summary

Adds three pw_fuzztest harnesses for the Matter group-messaging data plane: the group branch of `SessionManager::OnMessageReceived`, the group peer-counter table, and `GroupDataProviderImpl`'s management API.

##### Problem

-   Nothing in the existing target set reaches `SecureGroupMessageDispatch`, the group peer-counter table, or `GroupDataProviderImpl`. The last of those measures **0% on the project coverage report** despite being linked into five fuzz binaries.
-   The path resists generic input by construction:
    -   the wire session id is a **hash of the group key**, so a datagram is processed only if some installed key's hash matches;
    -   the AES-CCM **nonce is derived from the message counter and source node id, which sit inside the AES-CTR-obfuscated header**, so a candidate key must be applied before the frame can be authenticated;
    -   everything past the MIC check needs a **valid tag**, which mutated bytes cannot produce.
-   `PrepareMessage` fixes the source node id, counter and control flag internally, so seeding through it leaves the arms keyed on those fields unreachable however the payload is mutated.

##### Solution

-   **`fuzz-session-manager-group-pw`** — three cases over the real `SessionManager`, `FabricTable`, `GroupDataProviderImpl` and the file-static peer table, with nothing on the parse, crypto or decode path stubbed: arbitrary bytes with the session id either arbitrary or pinned to an installed key hash; a valid privacy-protected frame via `PrepareMessage`; and a frame assembled field by field then MAC'd.
-   **`fuzz-session-manager-group-counter-pw`** — a stateful sequence of encrypted datagrams driving the fixed-size peer LRU, plus two cases asserting a sender's counter state stays bound to that sender: it must still read as a duplicate after unrelated inserts shuffle its entry, and a crowded-out peer must never be handed another peer's counter history.
-   **`fuzz-group-data-provider-pw`** — the group, key-set and endpoint API as an operation sequence, since the behaviour of interest is index arithmetic and the persisted TLV round trip across operations. Assertions cover store/read-back agreement and that a second `RemoveFabric` frees nothing further.

| File / function | Region | Line |
| --- | --- | --- |
| `GroupDataProviderImpl.cpp` (was 0%) | 85.30% | 87.14% |
| `SecureGroupMessageDispatch` | 71.14% | 83.89% |
| `GroupKeyDecryptAttempt` | 95.45% | 90.32% |
| `GroupPeerMessageCounter.cpp` | 52.42% | 53.96% |

##### Caveats

-   Arms left uncovered because they are unreachable: the cache-and-sync policy arm (`SetKeySet` accepts only `kTrustFirst`), the MCSP arm (`PacketHeader::Encode` refuses a header carrying both destination kinds, and the dispatcher requires a destination group id), the control half of the peer table (rejected by `IsValidGroupMsg` first), and two allocation-failure arms.
-   The counter domain mixes a small range with the full `uint32_t` range: `CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE` is 32, so uniform values almost never land inside a sender's window.

#### Testing

-   All three binaries pass in unit-test mode (8 cases, no `--fuzz`).
-   1.12M fuzz iterations across the 8 cases under ASan and UBSan, 0 crashes.
-   Coverage measured with `linux-x64-tests-clang-pw-fuzztest-ossfuzz-coverage`; per-case seed reach checked in unit-test mode, which loads the domain seeds deterministically.
