### PR TITLE
[NXP][Zephyr] Fix zephyr main branch build errors and slim down docker image

### DIFF
--- a/config/nxp/chip-module/Kconfig
+++ b/config/nxp/chip-module/Kconfig
@@ -53,4 +53,7 @@ if CHIP_APP_OPERATIONAL_KEYSTORE
 	endchoice # CHIP_APP_OPERATIONAL_KEYSTORE_SELECTION
 endif # CHIP_APP_OPERATIONAL_KEYSTORE
 
+config CHIP_CRYPTO_HW_ENGINE
+	bool "Crypto hardware engine for acceleration and key storage"
+
 endif # SOC_FAMILY_NXP_RW || SOC_FAMILY_MCXW

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -537,9 +537,6 @@ config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 config WIFI_NM_WPA_SUPPLICANT_WQ_STACK_SIZE
 	default 5120
 
-config WIFI_NM_WPA_SUPPLICANT_INF_MON
-	default n
-
 config NET_TCP_WORKQ_STACK_SIZE
 	default 2048
 
@@ -550,7 +547,7 @@ config NET_IF_UNICAST_IPV6_ADDR_COUNT
 config NET_IF_MCAST_IPV6_ADDR_COUNT
 	default 8
 
-config NET_SOCKETS_POLL_MAX
+config ZVFS_POLL_MAX
 	default 14
 
 config NET_IPV4_FRAGMENT_MAX_COUNT
@@ -630,7 +627,7 @@ endchoice
 
 if CHIP_ETHERNET
 
-config NET_SOCKETS_POLL_MAX
+config ZVFS_POLL_MAX
 	default 7
 
 endif

--- a/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612.overlay
@@ -90,26 +90,31 @@
 
 	partitions {
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x440000>;
 		};
 
 		slot1_partition: partition@460000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00460000 0x440000>;
 		};
 
 		storage_partition: partition@3FEF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x03FEF000 DT_SIZE_K(64)>;
 		};
 
 		factory_partition: partition@3FFF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "factory-data";
 			reg = <0x03FFF000 DT_SIZE_K(4)>;
 		};

--- a/examples/all-clusters-app/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/examples/all-clusters-app/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -65,26 +65,31 @@
 
 	partitions {
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x440000>;
 		};
 
 		slot1_partition: partition@460000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00460000 0x440000>;
 		};
 
 		storage_partition: partition@3FEF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x03FEF000 DT_SIZE_K(64)>;
 		};
 
 		factory_partition: partition@3FFF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "factory-data";
 			reg = <0x03FFF000 DT_SIZE_K(4)>;
 		};

--- a/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612.overlay
@@ -64,26 +64,31 @@
 
 	partitions {
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x440000>;
 		};
 
 		slot1_partition: partition@460000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00460000 0x440000>;
 		};
 
 		storage_partition: partition@3FEF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x03FEF000 DT_SIZE_K(64)>;
 		};
 
 		factory_partition: partition@3FFF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "factory-data";
 			reg = <0x03FFF000 DT_SIZE_K(4)>;
 		};

--- a/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -65,26 +65,31 @@
 
 	partitions {
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x440000>;
 		};
 
 		slot1_partition: partition@460000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00460000 0x440000>;
 		};
 
 		storage_partition: partition@3FEF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x03FEF000 DT_SIZE_K(64)>;
 		};
 
 		factory_partition: partition@3FFF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "factory-data";
 			reg = <0x03FFF000 DT_SIZE_K(4)>;
 		};

--- a/examples/platform/nxp/common/app_task/source/AppTaskZephyr.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskZephyr.cpp
@@ -48,7 +48,7 @@
 
 #if CONFIG_CHIP_CRYPTO_PSA
 #include <crypto/PSAOperationalKeystore.h>
-#if CONFIG_SOC_FAMILY_NXP_RW
+#if CONFIG_SOC_FAMILY_NXP_RW && CONFIG_CHIP_CRYPTO_HW_ENGINE
 #include <platform/nxp/common/crypto/S50/S50KeyAllocator.h>
 #endif // CONFIG_SOC_FAMILY_NXP_RW
 #endif // CONFIG_CHIP_CRYPTO_PSA
@@ -95,7 +95,7 @@ chip::DeviceLayer::NetworkCommissioning::EthernetDriver * chip::NXP::App::AppTas
 
 void chip::NXP::App::AppTaskZephyr::PreInitMatterServerInstance()
 {
-#if CONFIG_CHIP_CRYPTO_PSA && CONFIG_SOC_FAMILY_NXP_RW
+#if CONFIG_CHIP_CRYPTO_PSA && CONFIG_SOC_FAMILY_NXP_RW && CONFIG_CHIP_CRYPTO_HW_ENGINE
     // Configure the PSA crypto subsystem to use the S50 secure element
     // for hardware-backed key storage.
     static chip::DeviceLayer::S50KeyAllocator s50KeyAllocator;

--- a/examples/thermostat/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/thermostat/nxp/zephyr/boards/frdm_rw612.overlay
@@ -90,26 +90,31 @@
 
 	partitions {
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x440000>;
 		};
 
 		slot1_partition: partition@460000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00460000 0x440000>;
 		};
 
 		storage_partition: partition@3FEF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x03FEF000 DT_SIZE_K(64)>;
 		};
 
 		factory_partition: partition@3FFF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "factory-data";
 			reg = <0x03FFF000 DT_SIZE_K(4)>;
 		};

--- a/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -64,26 +64,31 @@
 
 	partitions {
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x440000>;
 		};
 
 		slot1_partition: partition@460000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00460000 0x440000>;
 		};
 
 		storage_partition: partition@3FEF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x03FEF000 DT_SIZE_K(64)>;
 		};
 
 		factory_partition: partition@3FFF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "factory-data";
 			reg = <0x03FFF000 DT_SIZE_K(4)>;
 		};

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-211 : [nrfconnect] Update nRF Connect SDK version in Docker to 3.4.0
+212 : [NXP] Remove pre-installed NXP ZSDK from Zephyr docker image

--- a/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION=1
-FROM ghcr.io/project-chip/chip-build:${VERSION} AS build
+FROM ghcr.io/project-chip/chip-build:${VERSION}
 LABEL org.opencontainers.image.source=https://github.com/project-chip/connectedhomeip
 
 RUN set -x \
@@ -11,22 +11,10 @@ RUN set -x \
 WORKDIR /opt/nxp-zephyr
 RUN set -x \
     && ZEPHYR_SDK_VERSION=1.0.1 \
-    && NXP_ZSDK_VERSION=nxp-v4.4.1.1 \
     && wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.xz | tar -xJ \
     && zephyr-sdk-${ZEPHYR_SDK_VERSION}/setup.sh -t arm-zephyr-eabi \
     && pip3 install --break-system-packages -U --no-cache-dir west \
-    && west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr ${NXP_ZSDK_VERSION} \
-    && cd zephyrproject \
-    && west update -o=--depth=1 -n \
-    && west zephyr-export \
     && : # last line
-
-FROM ghcr.io/project-chip/chip-build:${VERSION}
-
-COPY --from=build /opt/nxp-zephyr/zephyr-sdk-1.0.1/ /opt/nxp-zephyr/zephyr-sdk-1.0.1/
-COPY --from=build /opt/nxp-zephyr/zephyrproject/ /opt/nxp-zephyr/zephyrproject/
-
-WORKDIR /opt/nxp-zephyr
 
 ENV ZEPHYR_NXP_BASE=/opt/nxp-zephyr/zephyrproject/zephyr
 ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-1.0.1

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
@@ -28,14 +28,18 @@
 #else
 #include "mbedtls/aes.h"
 #endif // MBEDTLS_VERSION_NUMBER >= 0x04000000
+#if (MBEDTLS_VERSION_NUMBER >= 0x04000000)
+#include "mbedtls/private/sha256.h"
+#else
 #include "mbedtls/sha256.h"
+#endif // MBEDTLS_VERSION_NUMBER >= 0x04000000
 
-#if defined(CONFIG_SOC_SERIES_RW6XX)
+#if defined(CONFIG_SOC_SERIES_RW6XX) && defined(CONFIG_CHIP_CRYPTO_HW_ENGINE)
 #include "els_pkc_driver.h"
 #if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION)
 #include "ELSFactoryData.h"
 #endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) */
-#endif /* defined(CONFIG_SOC_SERIES_RW6XX) */
+#endif /* defined(CONFIG_SOC_SERIES_RW6XX) && defined(CONFIG_CHIP_CRYPTO_HW_ENGINE) */
 
 /* -------------------------------------------------------------------------- */
 /*                               Private macros                               */
@@ -43,9 +47,10 @@
 
 #define HASH_ID 0xCE47BA5E
 
-#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX)
+#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) && defined(CONFIG_CHIP_CRYPTO_HW_ENGINE)
 #define DAC_KEY_BLOB_SIZE 48
-#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) */
+#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) &&                                   \
+          defined(CONFIG_CHIP_CRYPTO_HW_ENGINE) */
 
 /* -------------------------------------------------------------------------- */
 /*                            Class implementation                            */
@@ -112,14 +117,14 @@ CHIP_ERROR FactoryDataProviderImpl::SearchForId(uint8_t searchedType, uint8_t * 
 
 void FactoryDataProviderImpl::UpdateKeyAttributes(psa_key_attributes_t & attrs)
 {
-#ifdef CONFIG_SOC_SERIES_RW6XX
+#if defined(CONFIG_SOC_SERIES_RW6XX) && defined(CONFIG_CHIP_CRYPTO_HW_ENGINE)
     if (psa_get_key_lifetime(&attrs) == PSA_KEY_LIFETIME_PERSISTENT)
     {
         psa_set_key_lifetime(&attrs,
                              PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_LIFETIME_PERSISTENT,
                                                                             PSA_CRYPTO_ELS_PKC_LOCATION_S50_RFC3394_STORAGE));
     }
-#endif /* CONFIG_SOC_SERIES_RW6XX */
+#endif /* CONFIG_SOC_SERIES_RW6XX && CONFIG_CHIP_CRYPTO_HW_ENGINE */
 }
 
 CHIP_ERROR FactoryDataProviderImpl::Init(void)
@@ -205,7 +210,7 @@ CHIP_ERROR FactoryDataProviderImpl::Init(void)
         ChipLogProgress(DeviceLayer, "Factory data hash verified successfully");
     }
 
-#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX)
+#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) && defined(CONFIG_CHIP_CRYPTO_HW_ENGINE)
     uint16_t keySize = 0;
 
     ChipLogProgress(DeviceLayer, "Init: only protect DAC private key");
@@ -225,7 +230,8 @@ CHIP_ERROR FactoryDataProviderImpl::Init(void)
         els_enable();
         ReturnLogErrorOnFailure(ELS_ConvertDacKey());
     }
-#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) */
+#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) &&                                   \
+          defined(CONFIG_CHIP_CRYPTO_HW_ENGINE) */
 
     // Import the DAC private key into PSA once at Init time so that
     // SignWithDacKey() does not have to import/destroy the key on every
@@ -272,7 +278,7 @@ CHIP_ERROR FactoryDataProviderImpl::ReadEncryptedData(uint8_t * dest, uint8_t * 
     return CHIP_NO_ERROR;
 }
 
-#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX)
+#if defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) && defined(CONFIG_CHIP_CRYPTO_HW_ENGINE)
 
 CHIP_ERROR FactoryDataProviderImpl::ELS_ConvertDacKey()
 {
@@ -394,7 +400,8 @@ CHIP_ERROR FactoryDataProviderImpl::ReplaceWithBlob(uint8_t * data, uint8_t * bl
     return CHIP_NO_ERROR;
 }
 
-#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) */
+#endif /* defined(CONFIG_NXP_FACTORY_DAC_BLOB_GENERATION) && defined(CONFIG_SOC_SERIES_RW6XX) &&                                   \
+          defined(CONFIG_CHIP_CRYPTO_HW_ENGINE) */
 
 #ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()

--- a/src/test_driver/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/src/test_driver/nxp/zephyr/boards/frdm_rw612.overlay
@@ -55,26 +55,31 @@
 
 	partitions {
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x440000>;
 		};
 
 		slot1_partition: partition@460000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00460000 0x440000>;
 		};
 
 		storage_partition: partition@3FEF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x03FEF000 DT_SIZE_K(64)>;
 		};
 
 		factory_partition: partition@3FFF000 {
+			compatible = "zephyr,mapped-partition";
 			label = "factory-data";
 			reg = <0x03FFF000 DT_SIZE_K(4)>;
 		};

--- a/src/test_driver/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/src/test_driver/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -55,26 +55,31 @@
 
 		partitions {
 			boot_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
 
 			slot0_partition: partition@20000 {
+				compatible = "zephyr,mapped-partition";
 				label = "image-0";
 				reg = <0x00020000 0x440000>;
 			};
 
 			slot1_partition: partition@460000 {
+				compatible = "zephyr,mapped-partition";
 				label = "image-1";
 				reg = <0x00460000 0x440000>;
 			};
 
 			storage_partition: partition@3FEF000 {
+				compatible = "zephyr,mapped-partition";
 				label = "storage";
 				reg = <0x03FEF000 DT_SIZE_K(64)>;
 			};
 
 			factory_partition: partition@3FFF000 {
+				compatible = "zephyr,mapped-partition";
 				label = "factory-data";
 				reg = <0x03FFF000 DT_SIZE_K(4)>;
 			};


### PR DESCRIPTION
### Summary

Fix build errors that surface when building the NXP Matter examples against
upstream zephyrproject-rtos/zephyr main (4.5+) instead of the pinned NXP ZSDK,
and slim down the chip-build-nxp-zephyr docker image so the Zephyr workspace can
be initialized at CI runtime.

Changes:
- Rename deprecated Kconfig options (`NET_SOCKETS_POLL_MAX` -> `ZVFS_POLL_MAX`,
  drop obsolete `WIFI_NM_WPA_SUPPLICANT_INF_MON` default).
- Add `compatible = "zephyr,mapped-partition"` to RW61x board overlays for
  Zephyr 4.5+ (all-clusters-app, laundry-washer-app, thermostat).
- Add `CONFIG_CHIP_CRYPTO_HW_ENGINE` kconfig option to guard the S50 hardware
  crypto key allocator.
- Remove the pre-installed NXP ZSDK workspace from the chip-build-nxp-zephyr
  docker image (keep toolchain + west) and bump the chip-build version to 212
  to trigger a rebuild of the lighter image.

Note: the "Build Docker CHIP Build images - stage 1 (-crosscompile)" check is
expected to fail on this PR, because the new `chip-build:212` image is only built
and published after merge to master.


### Related issues

NXP Zephyr main branch build errors.

A follow-up PR switches the NXP Zephyr CI to build against upstream Zephyr main
at runtime (uses this image); the link will be added once it is opened.

### Testing

Build pass on NXP Zephyr platform (upstream zephyrproject-rtos/zephyr main).
