### PR TITLE
[ESP32] Build the ESP-TEE DAC path (IDF 6.0 + tee_sec_storage include)

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -468,6 +468,20 @@ target_include_directories(${COMPONENT_LIB} PRIVATE
     "${freertos_dir}/include/freertos"
     "${freertos_dir}/FreeRTOS-Kernel/include/freertos")
 
+# ESP32SecureCertDACProvider.cpp includes esp_tee_sec_storage.h (owned by the tee_sec_storage
+# component, an esp_tee subproject component that is not in this component's REQUIRES) on the
+# PBKDF2 TEE-DAC path. Add its include dir to the gn compile path for that feature. A config-gated
+# PRIV_REQUIRES is unreliable here: CONFIG_* is unset during IDF's early-expansion pass when
+# REQUIRES is resolved, so inject the dir directly instead.
+if (CONFIG_USE_ESP32_TEE_DAC_KEY_PBKDF2)
+    idf_component_get_property(tee_sec_storage_dir tee_sec_storage COMPONENT_DIR)
+    set(tee_sec_storage_inc "${tee_sec_storage_dir}/include")
+    if (NOT EXISTS "${tee_sec_storage_inc}")
+        message(FATAL_ERROR "tee_sec_storage include dir not found: ${tee_sec_storage_inc}")
+    endif()
+    target_include_directories(${COMPONENT_LIB} PRIVATE "${tee_sec_storage_inc}")
+endif()
+
 target_include_directories(${COMPONENT_LIB} INTERFACE
     "${CHIP_ROOT}/src/platform/ESP32"
     "${CHIP_ROOT}/src/platform/OpenThread"

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
@@ -28,6 +28,7 @@
 #endif // CONFIG_USE_ESP32_ECDSA_PERIPHERAL
 
 #ifdef CONFIG_USE_ESP32_TEE_DAC_KEY_PBKDF2
+#include <esp_idf_version.h>
 #include <esp_tee_sec_storage.h>
 #include <platform/ESP32/ESP32FactoryDataProvider.h>
 #endif // CONFIG_USE_ESP32_TEE_DAC_KEY_PBKDF2
@@ -154,8 +155,13 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
         VerifyOrReturnError(esp_err == ESP_OK, CHIP_ERROR_INTERNAL,
                             ESP_LOGE(TAG, "TEE PBKDF2 DAC signing failed, esp_err:%d", esp_err));
 
+        // IDF v6.0 merged sign_r/sign_s into a single signature[] holding R||S.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+        memcpy(signature.Bytes(), teeSign.signature, Crypto::kP256_ECDSA_Signature_Length_Raw);
+#else
         memcpy(signature.Bytes(), teeSign.sign_r, Crypto::kP256_FE_Length);
         memcpy(signature.Bytes() + Crypto::kP256_FE_Length, teeSign.sign_s, Crypto::kP256_FE_Length);
+#endif
         ReturnErrorOnFailure(signature.SetLength(Crypto::kP256_ECDSA_Signature_Length_Raw));
 
         return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);


### PR DESCRIPTION
## Summary

Two fixes required to compile the ESP-TEE DAC provider (`ESP32SecureCertDACProvider`) on current setups:

1. **Expose `esp_tee_sec_storage.h` to the chip GN library.** The `tee_sec_storage` component is not in the chip component's `REQUIRES`, so its include directory was missing from the GN compile of `libCHIP.a`. Inject the include dir onto the chip component (and link `tee_sec_storage`) under `CONFIG_SECURE_ENABLE_TEE`.
2. **IDF v6.0 API change.** `esp_tee_sec_storage_ecdsa_sign_t` merged its separate `sign_r`/`sign_s` fields into a single `signature[]` buffer (R‖S). Gate the PBKDF2 DAC signature extraction on `ESP_IDF_VERSION` so it builds on both IDF 5.5.x and 6.0.x.

### Testing

- Built `examples/lighting-app/esp32` with `sdkconfig.defaults.esp32c6_tee` (TEE DAC / PBKDF2) on ESP32-C6 against IDF 5.5.x and 6.0.2.
- Verified end-to-end commissioning on ESP32-C6 hardware with the TEE-derived DAC.
