### PR TITLE
python: Add ChipDeviceCtrl.CommissioningStage derived from the C++ enum

### DIFF
--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -854,6 +854,15 @@ bool pychip_SetTestCommissionerPrematureCompleteAfter(uint8_t stage)
     return sTestCommissioner.PrematureCompleteAfter(static_cast<chip::Controller::CommissioningStage>(stage));
 }
 
+// Returns the name of the given CommissioningStage, or a non-identifier placeholder if the
+// value is not a stage. Python builds its CommissioningStage enum by probing this over the
+// full uint8_t range, so that stage numbers never have to be duplicated (and kept in sync)
+// on that side.
+const char * pychip_CommissioningStageToString(uint8_t stage)
+{
+    return chip::Controller::StageToString(static_cast<chip::Controller::CommissioningStage>(stage));
+}
+
 PyChipError pychip_GetCompletionError()
 {
     return ToPyChipError(sTestCommissioner.GetCompletionError());

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -37,6 +37,7 @@ import ctypes
 import enum
 import json
 import logging
+import re
 import secrets
 import threading
 import typing
@@ -57,9 +58,9 @@ from .clusters.CHIPClusters import ChipClusters
 from .crypto import p256keypair
 from .exceptions import ChipStackError
 from .interaction_model import SessionParameters, SessionParametersStruct
-from .native import PyChipError
+from .native import GetLibraryHandle, HandleFlags, PyChipError
 
-__all__ = ["ChipDeviceController", "CommissioningParameters",
+__all__ = ["ChipDeviceController", "CommissioningParameters", "CommissioningStage",
            "AttributeReadRequest", "AttributeReadRequestList", "SubscriptionTargetList"]
 
 # Type aliases for ReadAttribute method to improve type safety
@@ -148,6 +149,56 @@ class TransportPayloadCapability(ctypes.c_int):
     MRP_PAYLOAD = 0
     LARGE_PAYLOAD = 1
     MRP_OR_TCP_PAYLOAD = 2
+
+
+# Stage names are identifiers; StageToString() returns a placeholder ("???") for anything else.
+_kCommissioningStageName = re.compile(r"[A-Za-z][A-Za-z0-9]*")
+
+_commissioningStage: type[enum.IntEnum] | None = None
+
+if typing.TYPE_CHECKING:
+    # Declared for the benefit of linters; actually produced by __getattr__ below.
+    CommissioningStage: type[enum.IntEnum]
+
+
+def _BuildCommissioningStage() -> type[enum.IntEnum]:
+    '''Mirrors the C++ CommissioningStage enum (src/controller/CommissioningDelegate.h).
+
+    That enum is not a stable interface: stages get inserted and removed as commissioning
+    evolves, which silently invalidates any copy of the numeric values kept over here. So
+    instead of maintaining a copy, ask the library to name each possible value and build the
+    enum from the ones it recognizes. Members are named without the `k` prefix, and a stage
+    that is compiled out (e.g. NFC commissioning) is simply absent.
+    '''
+    handle = GetLibraryHandle(HandleFlags(0))  # StageToString() does not need an initialized stack
+    handle.pychip_CommissioningStageToString.argtypes = [c_uint8]
+    handle.pychip_CommissioningStageToString.restype = c_char_p
+
+    stages: dict[str, int] = {}
+    for value in range(256):
+        name = handle.pychip_CommissioningStageToString(value).decode("utf-8")
+        if not _kCommissioningStageName.fullmatch(name):
+            continue
+        if name in stages:
+            raise RuntimeError(f"CommissioningStage {name} reported for both {stages[name]} and {value}")
+        stages[name] = value
+
+    # The C++ enumerators have implicit values, so the named stages must cover 0..N-1 exactly.
+    # A gap or a stray value means the scan above missed a stage or picked up a non-stage.
+    if not stages or sorted(stages.values()) != list(range(len(stages))):
+        raise RuntimeError(f"Unexpected CommissioningStage values: {sorted(stages.values())}")
+    return enum.IntEnum("CommissioningStage", stages)
+
+
+def __getattr__(name: str):
+    # `CommissioningStage` is built on first access rather than at import time, so that importing
+    # this module does not by itself require the native library to be present and loadable.
+    if name == "CommissioningStage":
+        global _commissioningStage
+        if _commissioningStage is None:
+            _commissioningStage = _BuildCommissioningStage()
+        return _commissioningStage
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @dataclass
@@ -1132,8 +1183,8 @@ class ChipDeviceControllerBase:
 
         Args:
             stage (int): The commissioning stage where failure will be simulated.
-                         This corresponds to the enum `CommissioningStage` (e.g. kError, kSecurePairing, etc.). For full details
-                         ref https://github.com/project-chip/connectedhomeip/blob/master/src/controller/CommissioningDelegate.h
+                         Use the `CommissioningStage` enum from this module (e.g. CommissioningStage.SendComplete)
+                         rather than a literal number; stage numbers change as the C++ enum evolves.
 
         Returns:
             bool: True if the failure simulate success, False if not.
@@ -1147,8 +1198,8 @@ class ChipDeviceControllerBase:
 
         Args:
             stage (int): The commissioning stage where failure will be simulated.
-                         This corresponds to the enum `CommissioningStage` (e.g. kError, kSecurePairing, etc.). For full details
-                         ref https://github.com/project-chip/connectedhomeip/blob/master/src/controller/CommissioningDelegate.h
+                         Use the `CommissioningStage` enum from this module (e.g. CommissioningStage.SendComplete)
+                         rather than a literal number; stage numbers change as the C++ enum evolves.
 
         Returns:
             bool: True if the failure simulate success, False if not.
@@ -1162,8 +1213,8 @@ class ChipDeviceControllerBase:
 
         Args:
             stage (int): The commissioning stage after a premature completion is simulated.
-                         This corresponds to the enum `CommissioningStage` (e.g. kError, kSecurePairing, etc.). For full details
-                         ref https://github.com/project-chip/connectedhomeip/blob/master/src/controller/CommissioningDelegate.h
+                         Use the `CommissioningStage` enum from this module (e.g. CommissioningStage.SendComplete)
+                         rather than a literal number; stage numbers change as the C++ enum evolves.
 
         Returns:
             bool: True if the premature complete success, False if not.
@@ -1187,7 +1238,9 @@ class ChipDeviceControllerBase:
         Check the test commissioner stage success.
 
         Args:
-            stage (int): The commissioning to simulate.
+            stage (int): The commissioning stage to check.
+                         Use the `CommissioningStage` enum from this module (e.g. CommissioningStage.SendComplete)
+                         rather than a literal number; stage numbers change as the C++ enum evolves.
 
         Returns:
             bool: True if test commissioner stage success, False if not.

--- a/src/python_testing/TC_CGEN_2_2.py
+++ b/src/python_testing/TC_CGEN_2_2.py
@@ -484,14 +484,11 @@ class TC_CGEN_2_2(MatterBaseTest):
         log.info('Step #20 - TH1 Original size of the trusted_root list: %s', trusted_roots_list_size)
 
         self.step(21)
-        # Commissioning stage numbers - we should find a better way to match these to the C++ code
-        # CommissioningDelegate.h
-        # TODO: https://github.com/project-chip/connectedhomeip/issues/36629
-        kFindOperationalForCommissioningComplete = 30
+        stage = ChipDeviceCtrl.CommissioningStage.FindOperationalForCommissioningComplete
         log.info(
-            'Step #21 - TH2 Commissioning stage SetTestCommissionerPrematureCompleteAfter enum: %s', kFindOperationalForCommissioningComplete)
+            'Step #21 - TH2 Commissioning stage SetTestCommissionerPrematureCompleteAfter enum: %s', stage)
 
-        resp = TH2.SetTestCommissionerPrematureCompleteAfter(kFindOperationalForCommissioningComplete)
+        resp = TH2.SetTestCommissionerPrematureCompleteAfter(stage)
         log.info('Step #21 - TH2 Commissioning DOES NOT send the CommissioningComplete command')
 
         # TH2.SetSkipCommissioningComplete(True)

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -45,7 +45,7 @@ import matter.clusters as Clusters
 import matter.clusters.enum
 import matter.FabricAdmin
 from matter import ChipDeviceCtrl
-from matter.ChipDeviceCtrl import CommissioningParameters
+from matter.ChipDeviceCtrl import CommissioningParameters, CommissioningStage
 from matter.exceptions import ChipStackError
 from matter.native import PyChipError
 from matter.testing.decorators import async_test_body
@@ -53,17 +53,6 @@ from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import default_matter_test_main
 
 log = logging.getLogger(__name__)
-
-# Commissioning stage numbers - we should find a better way to match these to the C++ code
-# TODO: https://github.com/project-chip/connectedhomeip/issues/36629
-kArmFailsafe = 3
-kConfigRegulatory = 4
-kSendPAICertificateRequest = 9
-kSendDACCertificateRequest = 10
-kSendAttestationRequest = 11
-kSendOpCertSigningRequest = 15
-kSendTrustedRootCert = 18
-kSendNOC = 19
 
 
 class TC_CGEN_2_4(MatterBaseTest):
@@ -106,22 +95,19 @@ class TC_CGEN_2_4(MatterBaseTest):
         th2_certificate_authority = self.certificate_authority_manager.NewCertificateAuthority()
         th2_fabric_admin = th2_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=self.th1.fabricId + 1)
         self.th2 = th2_fabric_admin.NewController(nodeId=2, useTestCommissioner=True)
-        # kArmFailsafe, expect General error 0x7e (UNSUPPORTED_ACCESS)
-        await self.CommissionToStageSendCompleteAndCleanup(kArmFailsafe, matter.native.ErrorSDKPart.IM_GLOBAL_STATUS, 0x7e)
-        # kConfigRegulatory, expect General error 0x7e (UNSUPPORTED_ACCESS)
-        await self.CommissionToStageSendCompleteAndCleanup(kConfigRegulatory, matter.native.ErrorSDKPart.IM_GLOBAL_STATUS, 0x7e)
-        # kSendPAICertificateRequest, expect General error 0x7e (UNSUPPORTED_ACCESS)
-        await self.CommissionToStageSendCompleteAndCleanup(kSendPAICertificateRequest, matter.native.ErrorSDKPart.IM_GLOBAL_STATUS, 0x7e)
-        # kSendDACCertificateRequest, expect General error 0x7e (UNSUPPORTED_ACCESS)
-        await self.CommissionToStageSendCompleteAndCleanup(kSendDACCertificateRequest, matter.native.ErrorSDKPart.IM_GLOBAL_STATUS, 0x7e)
-        # kSendAttestationRequest, expect General error 0x7e (UNSUPPORTED_ACCESS)
-        await self.CommissionToStageSendCompleteAndCleanup(kSendAttestationRequest, matter.native.ErrorSDKPart.IM_GLOBAL_STATUS, 0x7e)
-        # kSendOpCertSigningRequest, expect General error 0x7e (UNSUPPORTED_ACCESS)
-        await self.CommissionToStageSendCompleteAndCleanup(kSendOpCertSigningRequest, matter.native.ErrorSDKPart.IM_GLOBAL_STATUS, 0x7e)
-        # kSendTrustedRootCert, expect General error 0x7e (UNSUPPORTED_ACCESS)
-        await self.CommissionToStageSendCompleteAndCleanup(kSendTrustedRootCert, matter.native.ErrorSDKPart.IM_GLOBAL_STATUS, 0x7e)
-        # kSendNOC, expect cluster error InvalidAuthentication
-        await self.CommissionToStageSendCompleteAndCleanup(kSendNOC, matter.native.ErrorSDKPart.IM_CLUSTER_STATUS, 0x02)
+
+        # Stages that arm the failsafe or run under it: expect General error 0x7e (UNSUPPORTED_ACCESS)
+        for stage in (CommissioningStage.ArmFailSafe,
+                      CommissioningStage.ConfigRegulatory,
+                      CommissioningStage.SendPAICertificateRequest,
+                      CommissioningStage.SendDACCertificateRequest,
+                      CommissioningStage.SendAttestationRequest,
+                      CommissioningStage.SendOpCertSigningRequest,
+                      CommissioningStage.SendTrustedRootCert):
+            await self.CommissionToStageSendCompleteAndCleanup(stage, matter.native.ErrorSDKPart.IM_GLOBAL_STATUS, 0x7e)
+        # SendNOC, expect cluster error InvalidAuthentication
+        await self.CommissionToStageSendCompleteAndCleanup(
+            CommissioningStage.SendNOC, matter.native.ErrorSDKPart.IM_CLUSTER_STATUS, 0x02)
 
         log.info('Step 15 - TH1 opens a commissioning window')
         params = await self.OpenCommissioningWindow()

--- a/src/python_testing/test_testing/TestCommissioningTimeSync.py
+++ b/src/python_testing/test_testing/TestCommissioningTimeSync.py
@@ -20,6 +20,7 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
+from matter.ChipDeviceCtrl import CommissioningStage
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import async_test_body
@@ -28,16 +29,6 @@ from matter.testing.runner import default_matter_test_main
 from matter.testing.timeoperations import utc_time_in_matter_epoch
 
 log = logging.getLogger(__name__)
-
-# We don't have a good pipe between the c++ enums in CommissioningDelegate and python
-# so this is hardcoded.
-# I realize this is dodgy, not sure how to cross the enum from c++ to python cleanly
-kCheckForMatchingFabric = 3
-kConfigureUTCTime = 6
-kConfigureTimeZone = 7
-kConfigureDSTOffset = 8
-kConfigureDefaultNTP = 9
-kConfigureTrustedTimeSource = 19
 
 
 class TestCommissioningTimeSync(MatterTestCommissionedDevice):
@@ -82,7 +73,7 @@ class TestCommissioningTimeSync(MatterTestCommissionedDevice):
             self.supports_time = False
 
         asserts.assert_equal(self.commissioner.CheckStageSuccessful(
-            kConfigureUTCTime), self.supports_time, 'UTC time stage incorrect')
+            CommissioningStage.ConfigureUTCTime), self.supports_time, 'UTC time stage incorrect')
 
         if self.supports_time:
             self.supports_time_zone = bool(features & Clusters.TimeSynchronization.Bitmaps.Feature.kTimeZone)
@@ -138,14 +129,14 @@ class TestCommissioningTimeSync(MatterTestCommissionedDevice):
         should_set_default_ntp = bool(self.supports_default_ntp and default_ntp)
         should_set_trusted_time = bool(self.supports_trusted_time_source and trusted_time_source)
 
-        asserts.assert_equal(self.commissioner.CheckStageSuccessful(kConfigureTimeZone),
+        asserts.assert_equal(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureTimeZone),
                              should_set_time_zone, 'Incorrect value for time zone stage check')
-        asserts.assert_equal(self.commissioner.CheckStageSuccessful(kConfigureDSTOffset),
-                             should_set_dst, 'Incorrect value for kConfigureDSTOffset stage')
-        asserts.assert_equal(self.commissioner.CheckStageSuccessful(kConfigureDefaultNTP),
-                             should_set_default_ntp, 'Incorrect value for kConfigureDefaultNTP stage')
-        asserts.assert_equal(self.commissioner.CheckStageSuccessful(kConfigureTrustedTimeSource),
-                             should_set_trusted_time, 'Incorrect value for kConfigureTrustedTimeSource stage')
+        asserts.assert_equal(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureDSTOffset),
+                             should_set_dst, 'Incorrect value for ConfigureDSTOffset stage')
+        asserts.assert_equal(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureDefaultNTP),
+                             should_set_default_ntp, 'Incorrect value for ConfigureDefaultNTP stage')
+        asserts.assert_equal(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureTrustedTimeSource),
+                             should_set_trusted_time, 'Incorrect value for ConfigureTrustedTimeSource stage')
 
         if should_set_time_zone:
             received = await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.TimeZone)
@@ -208,24 +199,25 @@ class TestCommissioningTimeSync(MatterTestCommissionedDevice):
         self.commissioner.SetTrustedTimeSource(self.commissioner.nodeId, 0)
 
         await self.commission_and_base_checks()
-        asserts.assert_equal(self.commissioner.CheckStageSuccessful(kConfigureTimeZone),
+        asserts.assert_equal(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureTimeZone),
                              self.supports_time_zone, 'Incorrect value for time zone stage check')
-        asserts.assert_equal(self.commissioner.CheckStageSuccessful(kConfigureDSTOffset),
-                             self.supports_time_zone, 'Incorrect value for kConfigureDSTOffset stage')
-        asserts.assert_false(self.commissioner.CheckStageSuccessful(kConfigureDefaultNTP), 'kConfigureDefaultNTP incorrectly set')
+        asserts.assert_equal(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureDSTOffset),
+                             self.supports_time_zone, 'Incorrect value for ConfigureDSTOffset stage')
+        asserts.assert_false(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureDefaultNTP),
+                             'ConfigureDefaultNTP incorrectly set')
         asserts.assert_false(self.commissioner.CheckStageSuccessful(
-            kConfigureTrustedTimeSource), 'kConfigureTrustedTimeSource incorrectly set')
+            CommissioningStage.ConfigureTrustedTimeSource), 'ConfigureTrustedTimeSource incorrectly set')
 
     @async_test_body
     async def test_FabricCheckStage(self):
         await self.create_commissioner()
 
-        # This was moved into a different stage when the time sync stuff was added
+        # The fabric check no longer has a commissioning stage of its own; it is part of
+        # ReadCommissioningInfo, which always runs. GetFabricCheckResult() is the observable
+        # difference between having asked for the check and not.
         asserts.assert_equal(self.commissioner.GetFabricCheckResult(), -1, "Fabric check result is already set")
         self.commissioner.SetCheckMatchingFabric(True)
         await self.commission_and_base_checks()
-        asserts.assert_true(self.commissioner.CheckStageSuccessful(
-            kCheckForMatchingFabric), "Did not run check for matching fabric stage")
         asserts.assert_equal(self.commissioner.GetFabricCheckResult(), 0, "Fabric check result did not get set by pairing delegate")
 
         # Let's try it again with no check
@@ -233,8 +225,6 @@ class TestCommissioningTimeSync(MatterTestCommissionedDevice):
         asserts.assert_equal(self.commissioner.GetFabricCheckResult(), -1, "Fabric check result is already set")
         self.commissioner.SetCheckMatchingFabric(False)
         await self.commission_and_base_checks()
-        asserts.assert_false(self.commissioner.CheckStageSuccessful(
-            kCheckForMatchingFabric), "Incorrectly ran check for matching fabric stage")
         asserts.assert_equal(self.commissioner.GetFabricCheckResult(), -1, "Fabric check result incorrectly set")
 
     @async_test_body
@@ -242,7 +232,8 @@ class TestCommissioningTimeSync(MatterTestCommissionedDevice):
         await self.create_commissioner()
         self.commissioner.SetTimeZone(offset=3600, validAt=0, name="test")
         await self.commission_and_base_checks()
-        asserts.assert_true(self.commissioner.CheckStageSuccessful(kConfigureTimeZone), 'Time zone was not successfully set')
+        asserts.assert_true(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureTimeZone),
+                            'Time zone was not successfully set')
 
         received = await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.TimeZone)
         expected = [Clusters.TimeSynchronization.Structs.TimeZoneStruct(offset=3600, validAt=0, name="test")]
@@ -253,7 +244,8 @@ class TestCommissioningTimeSync(MatterTestCommissionedDevice):
         sixty_five_byte_string = "x" * 65
         self.commissioner.SetTimeZone(offset=3600, validAt=0, name=sixty_five_byte_string)
         await self.commission_and_base_checks()
-        asserts.assert_true(self.commissioner.CheckStageSuccessful(kConfigureTimeZone), 'Time zone was not successfully set')
+        asserts.assert_true(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureTimeZone),
+                            'Time zone was not successfully set')
 
         received = await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.TimeZone)
         expected = [Clusters.TimeSynchronization.Structs.TimeZoneStruct(offset=3600, validAt=0, name=None)]
@@ -264,7 +256,8 @@ class TestCommissioningTimeSync(MatterTestCommissionedDevice):
         sixty_four_byte_string = "x" * 64
         self.commissioner.SetTimeZone(offset=3600, validAt=0, name=sixty_four_byte_string)
         await self.commission_and_base_checks()
-        asserts.assert_true(self.commissioner.CheckStageSuccessful(kConfigureTimeZone), 'Time zone was not successfully set')
+        asserts.assert_true(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureTimeZone),
+                            'Time zone was not successfully set')
 
         received = await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.TimeZone)
         expected = [Clusters.TimeSynchronization.Structs.TimeZoneStruct(offset=3600, validAt=0, name=sixty_four_byte_string)]
@@ -276,14 +269,14 @@ class TestCommissioningTimeSync(MatterTestCommissionedDevice):
         too_long_name = "x." + "x" * 127
         self.commissioner.SetDefaultNTP(too_long_name)
         await self.commission_and_base_checks()
-        asserts.assert_false(self.commissioner.CheckStageSuccessful(kConfigureDefaultNTP),
+        asserts.assert_false(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureDefaultNTP),
                              'Commissioner attempted to set default NTP to a too long value')
 
         await self.create_commissioner()
         just_fits_name = "x." + "x" * 126
         self.commissioner.SetDefaultNTP(just_fits_name)
         await self.commission_and_base_checks()
-        asserts.assert_true(self.commissioner.CheckStageSuccessful(kConfigureDefaultNTP),
+        asserts.assert_true(self.commissioner.CheckStageSuccessful(CommissioningStage.ConfigureDefaultNTP),
                             'Commissioner did not correctly set default NTP')
         received = await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.DefaultNTP)
         asserts.assert_equal(received, just_fits_name, 'Commissioner incorrectly set default NTP name')

--- a/src/python_testing/test_testing/TestTimeSyncTrustedTimeSource.py
+++ b/src/python_testing/test_testing/TestTimeSyncTrustedTimeSource.py
@@ -25,15 +25,6 @@ from matter.testing.decorators import async_test_body
 from matter.testing.matter_testing import MatterTestCommissionedDevice
 from matter.testing.runner import default_matter_test_main
 
-# We don't have a good pipe between the c++ enums in CommissioningDelegate and python
-# so this is hardcoded.
-# I realize this is dodgy, not sure how to cross the enum from c++ to python cleanly
-kConfigureUTCTime = 6
-kConfigureTimeZone = 7
-kConfigureDSTOffset = 8
-kConfigureDefaultNTP = 9
-kConfigureTrustedTimeSource = 19
-
 # NOTE: all of these tests require a specific app setup. Please see TestTimeSyncTrustedTimeSourceRunner.py
 
 


### PR DESCRIPTION
### Summary

The mapping is generated once on first access by running all possible
values through StageToString().

Fixes #36629

### Testing

Existing tests.
