### PR TITLE
TC-CNET-4.11/4.12 - disable wildcard subscriptions

### DIFF
--- a/src/python_testing/TC_CNET_4_11.py
+++ b/src/python_testing/TC_CNET_4_11.py
@@ -989,6 +989,9 @@ async def verify_operational_network(test, ssid):
 
 
 class TC_CNET_4_11(MatterBaseTest):
+    # Wildcard subscriptions are disabled because this test includes a network swap and a
+    # session expiry where clients would not expect to maintain a long-term subscription
+    disable_wildcard_subscription = True
 
     @classmethod
     def setup_class(cls):

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -48,6 +48,9 @@ class TC_CNET_4_12(MatterBaseTest):
 
     If any of the above PIXITs are missing, the test will raise an error.
     """
+    # Wildcard subscriptions are disabled because this test includes a network swap and a
+    # session expiry where clients would not expect to maintain a long-term subscription
+    disable_wildcard_subscription = True
 
     CLUSTER_CNET = Clusters.NetworkCommissioning
     CLUSTER_DESC = Clusters.Descriptor


### PR DESCRIPTION
### Summary

Both of these involve a network swap where a client would not be expecting to maintain a persistent subscription.

### Related issues

https://github.com/project-chip/connectedhomeip/issues/74000
### Testing

QA
