### PR TITLE
[ArgParser] Validate option ID fits in uint8_t before short option check

### DIFF
--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -71,7 +71,7 @@ static bool SanityCheckOptions(OptionSet * optSets[]);
 
 static inline bool IsShortOptionChar(int ch)
 {
-    return isgraph(ch);
+    return CanCastTo<uint8_t>(ch) && isgraph(ch);
 }
 
 /**

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -664,6 +664,50 @@ TEST_F(TestCHIPArgParser, MissingValueTest_MissingLongOptionValue)
     VerifyArgErrorContains(0, "--run");
 }
 
+TEST_F(TestCHIPArgParser, LargeOptionIdTest)
+{
+    // clang-format off
+    static OptionDef optionDefsLarge[] =
+    {
+        { "large-id-1", kNoArgument, 65488 },
+        { "large-id-2", kArgumentRequired, 0xFFFF },
+        { }
+    };
+    static OptionSet optionSetLarge =
+    {
+        HandleOption,
+        optionDefsLarge,
+        "LARGE ID OPTION SET",
+        "help text\n"
+        "--large-id-1\n"
+        "--large-id-2\n"
+    };
+    // clang-format on
+
+    static OptionSet * optionSets[] = { &optionSetLarge, nullptr };
+    // clang-format off
+    static const char * argv[] =
+    {
+        "",
+        "--large-id-1",
+        "--large-id-2", "val",
+        nullptr
+    };
+    // clang-format on
+    static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
+
+    ClearCallbackRecords();
+    PrintArgError = HandleArgError;
+
+    TestArgv argsDup = DupeArgs(argv, argc);
+    bool res         = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    ASSERT_TRUE(res) << "ParseArgs() returned false";
+    ASSERT_EQ(sCallbackRecordCount, 3u) << "Invalid value returned for sCallbackRecordCount";
+    VerifyHandleOptionCallback(0, __FUNCTION__, &optionSetLarge, 65488, "--large-id-1", nullptr);
+    VerifyHandleOptionCallback(1, __FUNCTION__, &optionSetLarge, 0xFFFF, "--large-id-2", "val");
+    VerifyHandleNonOptionArgsCallback(2, __FUNCTION__, 0);
+}
+
 static void ClearCallbackRecords()
 {
     for (size_t i = 0; i < sCallbackRecordCount; i++)


### PR DESCRIPTION
#### Summary

Fixes potential crash/undefined behavior in `IsShortOptionChar` when handling option IDs > 255.

##### Problem

- `IsShortOptionChar(int ch)` directly invokes `isgraph(ch)` with the option ID (`OptionDef::Id`).
- For options without a short option character alias, integer IDs >= 256 (such as `65488` / `0xFFD0` or values >= 1000) are commonly used.
- Passing integer values outside the range `[0, 255]` (and not `EOF`) to `<cctype>` functions like `isgraph()` violates the C/C++ standard and causes out-of-bounds array access in glibc (`__ctype_b_loc()[ch]`), triggering a `SIGSEGV` on 32-bit platforms.

##### Solution

- Added a `CanCastTo<uint8_t>(ch)` precheck in `IsShortOptionChar` before calling `isgraph(ch)`.
- Option definitions with IDs >= 256 safely evaluate to `false` and are not treated as short option characters.

#### Testing

- Added unit test `LargeOptionIdTest` in `src/lib/support/tests/TestCHIPArgParser.cpp` covering option IDs exceeding 255.
