### PR TITLE
Scope pending operational certificates to their owning fabric index

### DIFF
--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1890,6 +1890,11 @@ CHIP_ERROR FabricTable::CommitPendingFabricData()
             ChipLogError(FabricProvisioning, "Missing pending fabric on update during commit!");
             hasInvalidInternalState = true;
         }
+        if (!mOpCertStore->HasPendingNocChain())
+        {
+            ChipLogError(FabricProvisioning, "Missing pending NOC chain for fabric update during commit!");
+            hasInvalidInternalState = true;
+        }
     }
 
     if (isAdding && hasPending && !hasInvalidInternalState)

--- a/src/credentials/PersistentStorageOpCertStore.cpp
+++ b/src/credentials/PersistentStorageOpCertStore.cpp
@@ -541,7 +541,8 @@ bool PersistentStorageOpCertStore::HasAnyCertificateForFabric(FabricIndex fabric
     bool rcacMissing = !StorageHasCertificate(mStorage, fabricIndex, CertChainElement::kRcac);
     bool icacMissing = !StorageHasCertificate(mStorage, fabricIndex, CertChainElement::kIcac);
     bool nocMissing  = !StorageHasCertificate(mStorage, fabricIndex, CertChainElement::kNoc);
-    bool anyPending  = (mPendingRcac.Get() != nullptr) || (mPendingIcac.Get() != nullptr) || (mPendingNoc.Get() != nullptr);
+    bool anyPending  = (fabricIndex == mPendingFabricIndex) &&
+        ((mPendingRcac.Get() != nullptr) || (mPendingIcac.Get() != nullptr) || (mPendingNoc.Get() != nullptr));
 
     if (rcacMissing && icacMissing && nocMissing && !anyPending)
     {
@@ -559,8 +560,12 @@ CHIP_ERROR PersistentStorageOpCertStore::RemoveOpCertsForFabric(FabricIndex fabr
     // If there was *no* state, pending or persisted, we have an error
     VerifyOrReturnError(HasAnyCertificateForFabric(fabricIndex), CHIP_ERROR_INVALID_FABRIC_INDEX);
 
-    // Clear any pending state
-    RevertPendingOpCerts();
+    // The pending certificates belong to a single fabric index, so they must only be cleared when
+    // that same index is the one being removed.
+    if (fabricIndex == mPendingFabricIndex)
+    {
+        RevertPendingOpCerts();
+    }
 
     // Remove all persisted certs for the given fabric, blindly
     CHIP_ERROR nocErr  = DeleteCertFromStorage(mStorage, fabricIndex, CertChainElement::kNoc);


### PR DESCRIPTION
#### Summary

##### Problem

-   `PersistentStorageOpCertStore` holds **one** set of pending certificates for the whole node, owned by a single fabric index recorded in `mPendingFabricIndex`.
-   `HasAnyCertificateForFabric` tested whether *any* pending certificate existed without comparing the requested index against that member, so `RemoveOpCertsForFabric` accepted an index owning no state of its own and then called the index-free `RevertPendingOpCerts`.
-   Removing the certificates of one fabric therefore discarded a pending chain staged by a **different** fabric:
    -   a concurrent `AddNOC` fails with `kInvalidNOC`, which points at the certificate the caller supplied rather than at the missing pending state
    -   a concurrent `UpdateNOC` commits part-way, and the error epilogue in `CommitPendingFabricData` then removes the fabric that was being updated

##### Solution

-   Compare the requested index against `mPendingFabricIndex` in the pending term, and revert pending certificates only for the index that owns them. Both conditions are required: an index holding its own persisted certificates satisfies the first on the storage lookups alone.
-   Add the missing pending-NOC-chain condition to the update pre-flight in `FabricTable::CommitPendingFabricData`, mirroring the trusted-root check already performed on the add path. An incoherent update now fails before the commit transaction touches storage rather than during it.

##### Caveats

-   Behaviour change on last-fabric removal: a pending trusted root staged under another administrator's fail-safe now survives it, where previously it was discarded as a side effect. It is still cleared when that fail-safe resolves. `TrustedRootCertificates` publishes pending roots, so the difference is observable.

#### Testing

-   Unit tests covering both paths follow in a separate PR.
-   Verified locally that the existing suites are unaffected: `TestFabricTable` 31/31 and `TestPersistentStorageOpCertStore` 5/5, built with `is_asan=true is_clang=true`.
