### PR TITLE
[all-devices-app] Fix teardown ordering in RoboticVacuumCleaner

### DIFF
--- a/examples/all-devices-app/all-devices-common/device/api/Interface.h
+++ b/examples/all-devices-app/all-devices-common/device/api/Interface.h
@@ -99,8 +99,8 @@ public:
     /// Required teardown order:
     /// Subclasses MUST call UnregisterDescriptor() (which unregisters the endpoint from the provider
     /// via provider.RemoveEndpoint()) BEFORE unregistering or destroying any device-specific clusters
-    /// via provider.RemoveCluster(). Attempting to call RemoveCluster() while the endpoint remains
-    /// registered will fail with CHIP_ERROR_INCORRECT_STATE.
+    /// via provider.RemoveCluster(). Once the provider has been started, attempting to call RemoveCluster()
+    /// while the endpoint remains registered will fail with CHIP_ERROR_INCORRECT_STATE.
     virtual void Unregister(CodeDrivenDataModelProvider & provider) = 0;
 
     // Endpoint interface implementation
@@ -125,7 +125,7 @@ protected:
     ///
     /// This MUST be called FIRST in any device's Unregister() implementation before removing any
     /// other clusters from the provider, because CodeDrivenDataModelProvider disallows removing
-    /// clusters while their associated endpoint is still registered.
+    /// clusters while their associated endpoint is still registered once the provider has been started.
     virtual void UnregisterDescriptor(EndpointId endpoint, CodeDrivenDataModelProvider & provider);
 
     Span<const DataModel::DeviceTypeEntry> mDeviceTypes;

--- a/examples/all-devices-app/all-devices-common/device/api/Interface.h
+++ b/examples/all-devices-app/all-devices-common/device/api/Interface.h
@@ -91,10 +91,16 @@ public:
     virtual CHIP_ERROR Register(EndpointIdAllocator & allocator, CodeDrivenDataModelProvider & provider,
                                 EndpointComposition composition = {}) = 0;
 
-    /// Removes a device's clusters from the given provider. This
+    /// Removes a device's clusters and endpoint from the given provider. This
     /// must only be called when register has succeeded before. Expected
     /// usage of this function is for when the device is no longer needed
     /// (for example, on shutdown), to destroy the device's clusters.
+    ///
+    /// Required teardown order:
+    /// Subclasses MUST call UnregisterDescriptor() (which unregisters the endpoint from the provider
+    /// via provider.RemoveEndpoint()) BEFORE unregistering or destroying any device-specific clusters
+    /// via provider.RemoveCluster(). Attempting to call RemoveCluster() while the endpoint remains
+    /// registered will fail with CHIP_ERROR_INCORRECT_STATE.
     virtual void Unregister(CodeDrivenDataModelProvider & provider) = 0;
 
     // Endpoint interface implementation
@@ -114,7 +120,12 @@ protected:
     virtual CHIP_ERROR RegisterDescriptor(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                                           EndpointComposition composition = {});
 
-    /// Reverse of `RegisterDescrioptor`
+    /// Unregisters the endpoint from the data model provider (via provider.RemoveEndpoint()) and
+    /// unregisters/destroys the Descriptor cluster.
+    ///
+    /// This MUST be called FIRST in any device's Unregister() implementation before removing any
+    /// other clusters from the provider, because CodeDrivenDataModelProvider disallows removing
+    /// clusters while their associated endpoint is still registered.
     virtual void UnregisterDescriptor(EndpointId endpoint, CodeDrivenDataModelProvider & provider);
 
     Span<const DataModel::DeviceTypeEntry> mDeviceTypes;

--- a/examples/all-devices-app/all-devices-common/device/api/SingleEndpoint.h
+++ b/examples/all-devices-app/all-devices-common/device/api/SingleEndpoint.h
@@ -65,10 +65,13 @@ protected:
     /// make this visible to not have the overload below error out. Should not be used directly.
     using DeviceInterface::UnregisterDescriptor;
 
-    /// Internal function to unregister a single endpoint device. This will destroy the clusters part of
-    /// this class, and must be called in a subclass' device-specific Unregister() function. This allows
-    /// for the destruction of the general SingleEndpoint clusters and device-specific clusters from
-    /// the subclass, as well as removal of the device endpoint from the provider to happen together.
+    /// Internal function to unregister a single endpoint device. This unregisters the endpoint from
+    /// the provider (via provider.RemoveEndpoint()) and destroys the Descriptor cluster.
+    ///
+    /// Subclasses MUST call this FIRST in their device-specific Unregister() function before
+    /// removing or destroying any subclass clusters. CodeDrivenDataModelProvider prevents non-atomic
+    /// modifications and will return CHIP_ERROR_INCORRECT_STATE if RemoveCluster() is called while
+    /// the endpoint remains registered.
     void UnregisterDescriptor(CodeDrivenDataModelProvider & provider);
 
     /// A default value of kInvalidEndpointId is used for the endpoint ID. When this is the value of the endpoint ID,

--- a/examples/all-devices-app/all-devices-common/device/api/SingleEndpoint.h
+++ b/examples/all-devices-app/all-devices-common/device/api/SingleEndpoint.h
@@ -69,9 +69,9 @@ protected:
     /// the provider (via provider.RemoveEndpoint()) and destroys the Descriptor cluster.
     ///
     /// Subclasses MUST call this FIRST in their device-specific Unregister() function before
-    /// removing or destroying any subclass clusters. CodeDrivenDataModelProvider prevents non-atomic
-    /// modifications and will return CHIP_ERROR_INCORRECT_STATE if RemoveCluster() is called while
-    /// the endpoint remains registered.
+    /// removing or destroying any subclass clusters. Once started, CodeDrivenDataModelProvider prevents
+    /// non-atomic modifications and will return CHIP_ERROR_INCORRECT_STATE if RemoveCluster() is called
+    /// while the endpoint remains registered.
     void UnregisterDescriptor(CodeDrivenDataModelProvider & provider);
 
     /// A default value of kInvalidEndpointId is used for the endpoint ID. When this is the value of the endpoint ID,

--- a/examples/all-devices-app/all-devices-common/device/types/robotic-vacuum-cleaner/RoboticVacuumCleaner.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/robotic-vacuum-cleaner/RoboticVacuumCleaner.cpp
@@ -57,8 +57,8 @@ CHIP_ERROR RoboticVacuumCleaner::Register(EndpointId endpoint, CodeDrivenDataMod
 
 void RoboticVacuumCleaner::Unregister(CodeDrivenDataModelProvider & provider)
 {
-    UnregisterOptionalClusters(provider);
     UnregisterDescriptor(provider);
+    UnregisterOptionalClusters(provider);
     if (mRunModeCluster.IsConstructed())
     {
         LogErrorOnFailure(provider.RemoveCluster(&mRunModeCluster.Cluster()));

--- a/examples/all-devices-app/all-devices-common/device/types/robotic-vacuum-cleaner/RoboticVacuumCleaner.h
+++ b/examples/all-devices-app/all-devices-common/device/types/robotic-vacuum-cleaner/RoboticVacuumCleaner.h
@@ -64,6 +64,8 @@ protected:
 
     // Counterpart to RegisterOptionalClusters(): a subclass that overrides one must override the
     // other, to tear down whatever optional clusters it added.
+    // Note: This hook is invoked from Unregister() AFTER UnregisterDescriptor() has already
+    // unregistered the endpoint, ensuring provider.RemoveCluster() calls can succeed.
     virtual void UnregisterOptionalClusters(CodeDrivenDataModelProvider & provider) {}
 
 private:

--- a/examples/all-devices-app/docs/adding_new_device.md
+++ b/examples/all-devices-app/docs/adding_new_device.md
@@ -108,15 +108,15 @@ and easy to test:
       the descriptor cluster and initialize endpoint metadata), create and add
       all domain and optional clusters via `provider.AddCluster()`, and finally
       register the endpoint via `provider.AddEndpoint(mEndpointRegistration)`.
-      `CodeDrivenDataModelProvider` rejects adding clusters to an
+      Once started, `CodeDrivenDataModelProvider` rejects adding clusters to an
       already-registered endpoint (`CHIP_ERROR_INCORRECT_STATE`).
     - **Teardown order**: Call `UnregisterDescriptor(provider)` **first**,
       before removing or destroying any domain or optional clusters.
-      `UnregisterDescriptor()` unregisters the endpoint from the provider via
-      `provider.RemoveEndpoint()`. `CodeDrivenDataModelProvider` prevents
-      non-atomic endpoint modifications and returns `CHIP_ERROR_INCORRECT_STATE`
-      if `provider.RemoveCluster()` is called while the endpoint is still
-      registered.
+      `UnregisterDescriptor()` removes the endpoint from the provider via
+      `provider.RemoveEndpoint()`. Once started, `CodeDrivenDataModelProvider`
+      prevents non-atomic endpoint modifications and returns
+      `CHIP_ERROR_INCORRECT_STATE` if `provider.RemoveCluster()` is called while
+      the endpoint is still registered.
 
 ---
 
@@ -204,7 +204,7 @@ CHIP_ERROR MySensorDevice::Register(chip::EndpointId endpoint, CodeDrivenDataMod
 void MySensorDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     // UnregisterDescriptor MUST be called first to remove the endpoint from the provider.
-    // Calling provider.RemoveCluster while the endpoint is still registered returns CHIP_ERROR_INCORRECT_STATE.
+    // Once started, calling provider.RemoveCluster while the endpoint is still registered returns CHIP_ERROR_INCORRECT_STATE.
     UnregisterDescriptor(provider);
     if (mMySensorCluster.IsConstructed())
     {

--- a/examples/all-devices-app/docs/adding_new_device.md
+++ b/examples/all-devices-app/docs/adding_new_device.md
@@ -91,6 +91,7 @@ and easy to test:
       by `DeviceFactory` or unit tests without requiring external wiring.
 
 5. **Spec-Pure Directory Layout & Extracted Capabilities**:
+
     - Keep the root of the `devices/` directory pure: it should contain _only_
       real, spec-defined Matter Device Types (like `dimmable-light`, `fan`,
       `air-purifier`).
@@ -101,6 +102,21 @@ and easy to test:
       `device/capabilities/<capability-name>/` (e.g.,
       `device/capabilities/dimmable-load/`). Concrete leaf devices then inherit
       publicly from this capability base.
+
+6. **Registration & Teardown Ordering**:
+    - **Registration order**: Call `RegisterDescriptor()` first (to construct
+      the descriptor cluster and initialize endpoint metadata), create and add
+      all domain and optional clusters via `provider.AddCluster()`, and finally
+      register the endpoint via `provider.AddEndpoint(mEndpointRegistration)`.
+      `CodeDrivenDataModelProvider` rejects adding clusters to an
+      already-registered endpoint (`CHIP_ERROR_INCORRECT_STATE`).
+    - **Teardown order**: Call `UnregisterDescriptor(provider)` **first**,
+      before removing or destroying any domain or optional clusters.
+      `UnregisterDescriptor()` unregisters the endpoint from the provider via
+      `provider.RemoveEndpoint()`. `CodeDrivenDataModelProvider` prevents
+      non-atomic endpoint modifications and returns `CHIP_ERROR_INCORRECT_STATE`
+      if `provider.RemoveCluster()` is called while the endpoint is still
+      registered.
 
 ---
 
@@ -187,6 +203,8 @@ CHIP_ERROR MySensorDevice::Register(chip::EndpointId endpoint, CodeDrivenDataMod
 
 void MySensorDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
+    // UnregisterDescriptor MUST be called first to remove the endpoint from the provider.
+    // Calling provider.RemoveCluster while the endpoint is still registered returns CHIP_ERROR_INCORRECT_STATE.
     UnregisterDescriptor(provider);
     if (mMySensorCluster.IsConstructed())
     {

--- a/examples/all-devices-app/docs/architecture.md
+++ b/examples/all-devices-app/docs/architecture.md
@@ -155,7 +155,8 @@ following guidelines:
    explicitly by executing `Unregister(provider)`. Teardown must unregister the
    endpoint first (via `UnregisterDescriptor()`) before removing or destroying
    individual clusters, as `CodeDrivenDataModelProvider` disallows removing
-   clusters from an actively registered endpoint (`CHIP_ERROR_INCORRECT_STATE`).
+   clusters from an actively registered endpoint once started
+   (`CHIP_ERROR_INCORRECT_STATE`).
 4. **Concrete Naming**: Avoid ambiguous umbrella folders or generic utility
    names. Use specific operational titles (e.g., `DeviceTypeParser.h`,
    `NetworkInfrastructureManager.h`).

--- a/examples/all-devices-app/docs/architecture.md
+++ b/examples/all-devices-app/docs/architecture.md
@@ -152,7 +152,10 @@ following guidelines:
 3. **Explicit Lifecycle Management**: Do not rely on RAII or C++ destructor
    methods for automated endpoint teardown. Core device type implementations
    must use `~Device() override = default;` and manage lifecycle teardown
-   explicitly by executing `Unregister(provider)`.
+   explicitly by executing `Unregister(provider)`. Teardown must unregister the
+   endpoint first (via `UnregisterDescriptor()`) before removing or destroying
+   individual clusters, as `CodeDrivenDataModelProvider` disallows removing
+   clusters from an actively registered endpoint (`CHIP_ERROR_INCORRECT_STATE`).
 4. **Concrete Naming**: Avoid ambiguous umbrella folders or generic utility
    names. Use specific operational titles (e.g., `DeviceTypeParser.h`,
    `NetworkInfrastructureManager.h`).


### PR DESCRIPTION
#### Summary

Fixes an inverted teardown sequence in `RoboticVacuumCleaner::Unregister` that caused an AddressSanitizer SEGV crash on application shutdown.

##### Problem

In `RoboticVacuumCleaner::Unregister`, `UnregisterOptionalClusters(provider)` was called before `UnregisterDescriptor(provider)`.
Because `CodeDrivenDataModelProvider::RemoveCluster()` requires that the parent endpoint is not registered in the provider interface registry (`mEndpointInterfaceRegistry`), calling `RemoveCluster()` while the endpoint was still live returned `CHIP_ERROR_INCORRECT_STATE`.
`SimulatedRoboticVacuumCleaner::UnregisterOptionalClusters()` then called `.Destroy()` on `mCleanModeCluster` and `mServiceAreaCluster`, destroying the C++ objects while they remained registered in `CodeDrivenDataModelProvider::mServerClusterRegistry`.
When `UnregisterDescriptor(provider)` was subsequently invoked, `CodeDrivenDataModelProvider::RemoveEndpoint()` iterated over `AllServerClusterInstances()` and called `cluster->GetPaths()` on the already-destroyed cluster instances, triggering an AddressSanitizer SEGV (read null/garbage vtable).

##### Solution

Invoke `UnregisterDescriptor(provider)` before `UnregisterOptionalClusters(provider)`, matching the teardown order of all other device implementations in `all-devices-app`. The endpoint is removed from the provider interface registry first, allowing subsequent `RemoveCluster()` calls to succeed and cleanly unregister clusters before destruction.

#### Testing

- Built `linux-x64-all-devices-clang`.
- Verified clean SIGTERM shutdown (`exit 0`, no `CHIP_ERROR_INCORRECT_STATE` or ASan SEGV) running `all-devices-app` with `--device robotic-vacuum-cleaner` and `--device '*'`.
- Verified `pre-commit` passes.
