### PR TITLE
[WTLREPMON] Add test for water tank level and media

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_HEPAFREMON_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_HEPAFREMON_2_1.yaml
@@ -88,3 +88,14 @@ tests:
       response:
           constraints:
               type: list
+
+    - label:
+          "Step 8: TH reads from the DUT the Medium attribute"
+      PICS: HEPAFREMON.S.A0006
+      command: "readAttribute"
+      attribute: "Medium"
+      response:
+          constraints:
+              type: enum8
+              minValue: 0
+              maxValue: 1

--- a/src/app/tests/suites/certification/Test_TC_WTLREPMON_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WTLREPMON_2_1.yaml
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 165.2.1. [TC-ACFREMON-2.1] Attributes with server as DUT
+name: 165.2.1. [TC-WTLREPMON-2.1] Attributes with server as DUT
 
 PICS:
-    - ACFREMON.S
+    - WTLREPMON.S
 
 config:
     nodeId: 0x12344321
-    cluster: "Activated Carbon Filter Monitoring"
+    cluster: "Water Tank Level Monitoring"
     endpoint: 1
 
 tests:
@@ -34,7 +34,7 @@ tests:
                 value: nodeId
 
     - label: "Step 2: TH reads from the DUT the Condition attribute."
-      PICS: ACFREMON.S.A0000
+      PICS: WTLREPMON.S.A0000
       command: "readAttribute"
       attribute: "Condition"
       response:
@@ -45,7 +45,7 @@ tests:
 
     - label:
           "Step 3: TH reads from the DUT the DegradationDirection attribute.."
-      PICS: ACFREMON.S.A0001
+      PICS: WTLREPMON.S.A0001
       command: "readAttribute"
       attribute: "DegradationDirection"
       response:
@@ -55,7 +55,7 @@ tests:
               maxValue: 1
 
     - label: "Step 4a: TH reads from the DUT the ChangeIndication attribute."
-      PICS: ACFREMON.S.A0002 && !ACFREMON.S.F01
+      PICS: WTLREPMON.S.A0002 && !WTLREPMON.S.F01
       command: "readAttribute"
       attribute: "ChangeIndication"
       response:
@@ -64,7 +64,7 @@ tests:
               anyOf: [0, 2]
 
     - label: "Step 4b: TH reads from the DUT the ChangeIndication attribute."
-      PICS: ACFREMON.S.F01 && ACFREMON.S.A0002
+      PICS: WTLREPMON.S.F01 && WTLREPMON.S.A0002
       command: "readAttribute"
       attribute: "ChangeIndication"
       response:
@@ -74,7 +74,7 @@ tests:
               maxValue: 2
 
     - label: "Step 5: TH reads from the DUT the InPlaceIndicator attribute"
-      PICS: ACFREMON.S.A0003
+      PICS: WTLREPMON.S.A0003
       command: "readAttribute"
       attribute: "InPlaceIndicator"
       response:
@@ -82,7 +82,7 @@ tests:
               type: boolean
 
     - label: "Step 6: TH reads from the DUT the LastChangedTime attribute"
-      PICS: ACFREMON.S.A0004
+      PICS: WTLREPMON.S.A0004
       command: "readAttribute"
       attribute: "LastChangedTime"
       response:
@@ -91,7 +91,7 @@ tests:
 
     - label:
           "Step 7: TH reads from the DUT the ReplacementProductList attribute"
-      PICS: ACFREMON.S.A0005
+      PICS: WTLREPMON.S.A0005
       command: "readAttribute"
       attribute: "ReplacementProductList"
       response:
@@ -100,7 +100,7 @@ tests:
 
     - label:
           "Step 8: TH reads from the DUT the Medium attribute"
-      PICS: ACFREMON.S.A0006
+      PICS: WTLREPMON.S.A0006
       command: "readAttribute"
       attribute: "Medium"
       response:

--- a/src/app/tests/suites/ciTests.json
+++ b/src/app/tests/suites/ciTests.json
@@ -234,7 +234,8 @@
         "TestActivatedCarbonFilterMonitoring",
         "TestHepaFilterMonitoring",
         "Test_TC_ACFREMON_2_1",
-        "Test_TC_HEPAFREMON_2_1"
+        "Test_TC_HEPAFREMON_2_1",
+        "Test_TC_WTLREPMON_2_1"
     ],
     "AirQuality": ["Test_TC_AIRQUAL_2_1"],
     "ConcentrationMeasurement": [

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
@@ -390,6 +390,7 @@ ALIAS_PICS = {0x040C: 'CMOCONC',
               0x042F: 'RNCONC',
               0x0071: 'HEPAFREMON',
               0x0072: 'ACFREMON',
+              0x0079: 'WTLREPMON',
               0x0405: 'RH',
               0x001C: 'PWM'}
 

--- a/src/python_testing/test_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/test_testing/TestSpecParsingSupport.py
@@ -490,6 +490,7 @@ class TestSpecParsingSupport(CertificationUnitTestNoDevice):
             (0x042F, 'Radon Concentration Measurement', 'RNCONC'),
             (0x0071, 'HEPA Filter Monitoring', 'HEPAFREMON'),
             (0x0072, 'Activated Carbon Filter Monitoring', 'ACFREMON'),
+            (0x0079, 'Water Tank Level Monitoring', 'WTLREPMON'),
             (0x0405, 'Relative Humidity Measurement', 'RH'),
         }
 


### PR DESCRIPTION
### Summary

This PR:

- Adds a test YAML for the Water Tank Level Monitoring cluster. Note: Copied from existing YAML script for a resource monitoring cluster.
- Adds a test step for the new Media attribute to the resource monitoring cluster

### Testing

<!--
    Describe how you tested this change.

    Examples:
        - Added unit tests
        - Verified by YAML test: TC_ABC.yaml
        - Added Python test: TC_DEF.py
        - Manually tested (describe steps)

    Please replace this HTML comment with the actual testing details.
-->
