### PR TITLE
[third_party] Update Pigweed submodule URL to official Gerrit repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	platforms = esp32
 [submodule "pigweed"]
 	path = third_party/pigweed/repo
-	url = https://github.com/pigweed-project/pigweed.git
+	url = https://pigweed.googlesource.com/pigweed/pigweed.git
 	branch  = main
 [submodule "openthread"]
 	path = third_party/openthread/repo


### PR DESCRIPTION
#### Summary

##### Problem
- The Pigweed submodule URL currently points to the GitHub repository rather than the canonical upstream Gerrit repository.

##### Solution
- Updated the submodule remote URL in `.gitmodules` to `https://pigweed.googlesource.com/pigweed/pigweed.git`.

#### Testing
- N/A: Submodule URL configuration change. Verified `.gitmodules` format and pre-commit checks.
