### PR TITLE
Fix Thread MeshCoP proxy socket teardown race

### DIFF
--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -102,33 +102,10 @@ ThreadMeshcopCommissionProxy::ThreadMeshcopCommissionProxy() : mState(State::kCo
 ThreadMeshcopCommissionProxy::~ThreadMeshcopCommissionProxy()
 {
     std::unique_lock<std::recursive_mutex> lock(mMutex);
+    mStopProxyThread = true;
     if (mProxyFd != -1)
     {
-        if (shutdown(mProxyFd, SHUT_RDWR) == 0 || errno != EBADF)
-        {
-            close(mProxyFd);
-        }
-
-        mProxyFd = -1;
-    }
-
-    if (mProxyThread.joinable())
-    {
-        lock.unlock();
-        mProxyThread.join();
-    }
-}
-
-void ThreadMeshcopCommissionProxy::ResetCommissionerForDiscovery()
-{
-    std::unique_lock<std::recursive_mutex> lock(mMutex);
-    if (mProxyFd != -1)
-    {
-        if (shutdown(mProxyFd, SHUT_RDWR) == 0 || errno != EBADF)
-        {
-            close(mProxyFd);
-        }
-        mProxyFd = -1;
+        shutdown(mProxyFd, SHUT_RDWR);
     }
 
     if (mProxyThread.joinable())
@@ -136,6 +113,36 @@ void ThreadMeshcopCommissionProxy::ResetCommissionerForDiscovery()
         lock.unlock();
         mProxyThread.join();
         lock.lock();
+    }
+
+    // The receiver must stop using the descriptor before it can be closed or reused.
+    if (mProxyFd != -1)
+    {
+        close(mProxyFd);
+        mProxyFd = -1;
+    }
+}
+
+void ThreadMeshcopCommissionProxy::ResetCommissionerForDiscovery()
+{
+    std::unique_lock<std::recursive_mutex> lock(mMutex);
+    mStopProxyThread = true;
+    if (mProxyFd != -1)
+    {
+        shutdown(mProxyFd, SHUT_RDWR);
+    }
+
+    if (mProxyThread.joinable())
+    {
+        lock.unlock();
+        mProxyThread.join();
+        lock.lock();
+    }
+
+    if (mProxyFd != -1)
+    {
+        close(mProxyFd);
+        mProxyFd = -1;
     }
 
     mServicePort  = 0;
@@ -404,13 +411,16 @@ void ThreadMeshcopCommissionProxy::ProcessAnnouncement(const std::vector<uint8_t
         mProxyThread.join();
     }
 
-    mProxyThread = std::thread([id = joinerIdBytes, this]() {
+    mStopProxyThread = false;
+    mProxyThread     = std::thread([id = joinerIdBytes, this]() {
         struct sockaddr_storage addr;
         socklen_t len = sizeof(addr);
         uint8_t buf[chip::detail::kMaxIPPacketSizeBytes];
         ssize_t received;
 
-        while ((received = recvfrom(mProxyFd, buf, sizeof(buf), 0, reinterpret_cast<struct sockaddr *>(&addr), &len)) > 0)
+        while (!mStopProxyThread &&
+               (received = recvfrom(mProxyFd, buf, sizeof(buf), 0, reinterpret_cast<struct sockaddr *>(&addr), &len)) > 0 &&
+               !mStopProxyThread)
         {
             switch (mState)
             {

--- a/src/controller/ThreadMeshcopCommissionProxy.h
+++ b/src/controller/ThreadMeshcopCommissionProxy.h
@@ -128,6 +128,7 @@ private:
     std::promise<Dnssd::DiscoveredNodeData> mDiscoveredNodePromise;
 
     std::shared_ptr<ot::commissioner::Commissioner> mCommissioner;
+    std::atomic<bool> mStopProxyThread{ false };
     std::thread mProxyThread;
     DiscoveryDiagnostic mLastDiscoveryDiagnostic;
 };

--- a/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/tests/TestThreadMeshcopCommissionProxy.cpp
@@ -180,6 +180,30 @@ TEST(TestThreadMeshcopCommissionProxy, AcceptsCompleteResponse)
     EXPECT_TRUE(LastDiscoveryIsValid(proxy));
 }
 
+TEST(TestThreadMeshcopCommissionProxy, CanRediscoverAfterStoppingProxy)
+{
+    ThreadMeshcopCommissionProxy proxy;
+    ByteSpan invalidPskc;
+    Transport::PeerAddress peerAddress;
+    Dnssd::DiscoveredNodeData nodeData;
+
+    for (unsigned i = 0; i < 4; ++i)
+    {
+        SendJoinerPacket(proxy, kCompleteMattercResponse);
+        ASSERT_TRUE(LastDiscoveryIsValid(proxy));
+
+        // Discover stops the previous receiver before validating the PSKc. An empty PSKc
+        // avoids contacting a border agent while exercising socket teardown under TSAN.
+        ASSERT_EQ(proxy.Discover(invalidPskc, peerAddress, Thread::DiscoveryCode(), SetupDiscriminator(), nodeData, 0),
+                  CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_FALSE(LastDiscoveryIsValid(proxy));
+    }
+
+    // A fresh receiver must also be stopped when the proxy is destroyed.
+    SendJoinerPacket(proxy, kCompleteMattercResponse);
+    EXPECT_TRUE(LastDiscoveryIsValid(proxy));
+}
+
 } // namespace
 } // namespace Controller
 } // namespace chip


### PR DESCRIPTION
### Summary

- Stop and join the receiver before closing or resetting its socket in destruction and rediscovery.
- Add an atomic stop flag and a repeated-discovery regression test.

### Related issues

NA

### Testing
all 7 TestThreadMeshcopCommissionProxy tests pass under ThreadSanitizer without race warnings