### PR TITLE
Fixes in the Humidistat cluster's setpoint/MistType handling

### DIFF
--- a/src/app/clusters/humidistat-server/HumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.cpp
@@ -444,6 +444,10 @@ CHIP_ERROR HumidistatCluster::SetSystemState(Humidistat::SystemStateEnum systemS
 
 chip::Percent HumidistatCluster::SnapToNearestStep(chip::Percent value) const
 {
+    if (value < mMinSetpoint)
+    {
+        return mMinSetpoint;
+    }
     if (value > mMaxSetpoint)
     {
         return mMaxSetpoint;

--- a/src/app/clusters/humidistat-server/HumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/HumidistatCluster.cpp
@@ -218,9 +218,10 @@ void HumidistatCluster::LoadPersistentAttributes()
             ChipLogDetail(Zcl, "Humidistat: Unable to load MistType attribute, using default");
         }
 
-        chip::BitMask<MistTypeBitmap> loadedMistType(rawMistType);
+        // Discard unknown bits before feature-based clearing to guard against stale/corrupt persisted data.
+        chip::BitMask<MistTypeBitmap> loadedMistType = chip::BitMask<MistTypeBitmap>(rawMistType) &
+            chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold, MistTypeBitmap::kMistWarm);
 
-        // Clear any bits not supported by the current feature set to guard against stale persisted data.
         if (!mFeatures.Has(Feature::kColdMist))
         {
             loadedMistType.Clear(MistTypeBitmap::kMistCold);

--- a/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
@@ -631,6 +631,14 @@ TEST_F(TestHumidistatCluster, SetMistTypeAllowsEmptyValueInHumidifierMode)
     EXPECT_EQ(cluster.GetMistType().Raw(), 0u);
     EXPECT_TRUE(tester.IsAttributeDirty(MistType::Id));
 
+    ASSERT_EQ(cluster.SetMistType(chip::BitMask<MistTypeBitmap>(MistTypeBitmap::kMistCold)), CHIP_NO_ERROR);
+    tester.GetDirtyList().clear();
+
+    // Exercise the WriteAttribute path as well, not just the direct setter.
+    EXPECT_EQ(tester.WriteAttribute(MistType::Id, chip::BitMask<MistTypeBitmap>()), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.GetMistType().Raw(), 0u);
+    EXPECT_TRUE(tester.IsAttributeDirty(MistType::Id));
+
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 

--- a/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
+++ b/src/app/clusters/humidistat-server/tests/TestHumidistatCluster.cpp
@@ -496,6 +496,26 @@ TEST_F(TestHumidistatCluster, SetSettingsUserSetpoint)
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
+TEST_F(TestHumidistatCluster, SnapToNearestStepBelowMin)
+{
+    // Regression: value < mMinSetpoint caused unsigned wrap-around in offset calculation.
+    // The constructor calls SnapToNearestStep on config.userSetpoint without a prior range check.
+    HumidistatCluster::StartupConfiguration config;
+    config.minSetpoint  = 20;
+    config.maxSetpoint  = 80;
+    config.step         = 5;
+    config.userSetpoint = 10; // below minSetpoint — triggers wrap-around without the fix
+
+    const BitFlags<Feature> features{ Feature::kHumidifier, Feature::kSensor, Feature::kColdMist };
+    HumidistatCluster cluster(kTestEndpointId, features, {}, config);
+    ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    // Without the fix, wrap-around produces a garbage snapped value far above maxSetpoint.
+    EXPECT_EQ(cluster.GetUserSetpoint(), 20);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
 TEST_F(TestHumidistatCluster, SetSettingsUnsupportedFieldsIgnored)
 {
     // Cluster with only mode support and NO optional features — optional fields must be silently ignored.


### PR DESCRIPTION
### Summary

LoadPersistentAttributes() now masks the loaded MistType raw value against the valid bits (kMistCold | kMistWarm)
before applying feature-based clearing, so stale/corrupt persisted data with undefined bits set can no longer produce an invalid live MistType value.

SnapToNearestStep() now clamps values below mMinSetpoint to mMinSetpoint. Previously, since chip::Percent is 
uint8_t, a value below mMinSetpoint underflowed in value - mMinSetpoint, producing a garbage
 snapped result. This was reachable at startup via the constructor's call to SnapToNearestStep on 
config.userSetpoint.

### Testing

 Added unit test SnapToNearestStepBelowMin in TestHumidistatCluster.cpp verifying a startup userSetpoint below minSetpoint is clamped instead of wrapping around.
Extended SetMistTypeAllowsEmptyValueInHumidifierMode to also exercise the WriteAttribute path for clearing MistType.
Ran TestHumidistatCluster via linux-x64-tests-clang; all tests pass.
