### PR TITLE
Add electrical-protection-app to chip-cert-bins Docker image

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -180,6 +180,7 @@ RUN printf '%s\n' \
     lit-icd-ipv6only \
     energy-gateway-ipv6only \
     evse-ipv6only \
+    electrical-protection-ipv6only \
     microwave-oven-ipv6only \
     rvc-ipv6only \
     fabric-bridge-rpc-ipv6only \


### PR DESCRIPTION
### Problem

The 1.7 TE2 Energy Management features (Smart electrical alarms [ESALM], Electrical Distribution [ELDIST], Smart electrical panels Electrical Protection Alarm [EPALM]) require the Electrical Protection App to perform validation via the Test Harness (TH). The TH pulls prebuilt binaries from the `chip-cert-bins` Docker image, but `examples/electrical-protection-app` was missing from that image's build target list even though it's already implemented and wired into the build system (`HostApp.ELECTRICAL_PROTECTION` in `scripts/build/build/targets.py` / `scripts/build/builders/host.py`, output binary `chip-electrical-protection-app`).

### Change

Adds `electrical-protection-ipv6only` to the target list in `integrations/docker/images/chip-cert-bins/Dockerfile`, grouped with the other Energy Management apps (`energy-gateway-ipv6only`, `evse-ipv6only`).

### Testing

N/A (Dockerfile target list addition, follows the same pattern used for prior additions such as `all-devices-ipv6only`).

Related: project-chip/certification-tool#1107