### PR TITLE
[ci] Add MG26 LLVM Bluetooth library in EFR32 Docker

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-211 : [nrfconnect] Update nRF Connect SDK version in Docker to 3.4.0
+212 : [Silabs] Add MG26 LLVM Bluetooth library in EFR32

--- a/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
@@ -53,6 +53,7 @@ bluetooth_le_controller/build/gcc/xg21/release/liblinklayer.a
 bluetooth_le_controller/build/gcc/xg24/release/liblinklayer.a
 bluetooth_le_controller/build/gcc/xg26/release/liblinklayer.a
 bluetooth_le_controller/build/llvm/xg24/release/liblinklayer.a
+bluetooth_le_controller/build/llvm/xg26/release/liblinklayer.a
 bluetooth_le_controller/build/llvm/x301/release/liblinklayer.a
 bluetooth_le_host/build/gcc/cortex-m33/privacy/rpa_resolution/release/libble_host_rpa_resolution_stub.a
 bluetooth_le_host/build/gcc/cortex-m33/privacy/resolving_list/release/libble_host_resolving_list_stub.a


### PR DESCRIPTION
### Summary

A Bluetooth library was missing to be able to build MG26 with LLVM. This PR adds that lib to the `simplicity_sdk_keep_folders.txt` so it will be available within the Docker image.

### Related issues

N/A

### Testing

Confirmed locally this is the required change.
Docker CI should fail if this change breaks something.