### PR TITLE
[WEBRTCP] Set received SDP as the remote on the webrtc peer

### DIFF
--- a/src/python_testing/TC_WEBRTCP_2_17.py
+++ b/src/python_testing/TC_WEBRTCP_2_17.py
@@ -174,6 +174,9 @@ class TC_WEBRTCP_2_17(MatterBaseTest, WEBRTCPTestBase):
 
         log.info("SDP answer validated successfully. Answer length: %s bytes", len(answer_sdp))
         log.info("SDP answer preview: %s...", answer_sdp[:400])
+        
+        # SDP valid, set it as the remote
+        webrtc_peer.set_remote_answer(answer_sdp)
 
         self.step(5)
         # Send EndSession command to terminate the WebRTC session

--- a/src/python_testing/TC_WEBRTCP_2_17.py
+++ b/src/python_testing/TC_WEBRTCP_2_17.py
@@ -174,7 +174,7 @@ class TC_WEBRTCP_2_17(MatterBaseTest, WEBRTCPTestBase):
 
         log.info("SDP answer validated successfully. Answer length: %s bytes", len(answer_sdp))
         log.info("SDP answer preview: %s...", answer_sdp[:400])
-        
+
         # SDP valid, set it as the remote
         webrtc_peer.set_remote_answer(answer_sdp)
 


### PR DESCRIPTION
### Summary

CCB 4386 identifies an issue in WEBRTCP 2.17; in that received SDP is never set as the remote on the webrtc peer, this can cause the script to hang attempting the EndSession. This change adds the missing step in the script. 

### Related issues

See: https://zigbeecertifiedproducts.knack.com/zigbee-alliance-ccb-tool#home/ccbs/ccbdetails2/6a9fbe5d6a123efb6a3bfbeb/


### Testing

Run WEBRTCP_2_17 before and after the change.  Ensure no issues and that the test passes cleanly.
