### PR TITLE
Commissioning Proxy PR4: Add PAF to all-devices-app (backport #72818)

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1645,6 +1645,7 @@ unregister
 unregistration
 Unsecure
 Unselect
+unsynchronized
 untrusted
 updateAvailable
 updateNotAvailable

--- a/examples/all-devices-app/README.md
+++ b/examples/all-devices-app/README.md
@@ -232,43 +232,55 @@ device types. When an endpoint is specified, it represents the starting number.
 
 ## Commissioning Proxy
 
-This example can act as a Commissioning Proxy. The `commissioning-proxy` device
-type implements the Commissioning By Proxy device type
-(`MA-commissioning-by-proxy`, 0x0092) with a Commissioning Proxy cluster server.
-It is available on the Linux (posix) platform only — the device is registered
-from `posix/linux/DeviceFactoryPlatformOverride.cpp`.
+This example can act as a Commissioning Proxy over WiFi-PAF and/or BLE. The
+`commissioning-proxy` device type implements the Commissioning By Proxy device
+type (`MA-commissioning-by-proxy`, 0x0092) with a Commissioning Proxy cluster
+server. It is available on the Linux (posix) platform only — the device is
+registered from `posix/linux/DeviceFactoryPlatformOverride.cpp`.
 
-Supported for: `ProxyScanRequest`, the `ProxyConnectRequest` /
+Supported commands: `ProxyScanRequest`, the `ProxyConnectRequest` /
 `ProxyMessageRequest` / `ProxyDisconnectRequest` flow, and the BackgroundScan
-feature (`ProxyBackGroundScanStartRequest` / `ProxyBackGroundScanStopRequest`).
-The proxy serves one commissioning session at a time across all transports
-(`MaxSessions` = 1) and caches up to 10 background-scan results.
+feature (`ProxyBackGroundScanStartRequest` / `ProxyBackGroundScanStopRequest`),
+over whichever transport(s) are compiled in. The proxy serves one commissioning
+session at a time across all transports (`MaxSessions` = 1) and caches up to 10
+background-scan results.
 
 The BLE transport performs a one-way peripheral→central role switch on the CP's
 first `ProxyConnectRequest(BLE)`. After that the CP no longer advertises over
 BLE for its own (re-)commissioning; restart the process to regain peripheral
 mode. An already-commissioned node must announce over DNS-SD rather than BLE, so
 `OpenCommissioningWindow` still works — but it is worth planning around when
-setting a CP device up.
+setting a CP device up. The Wi-Fi PAF transport is unaffected.
 
-Two build switches are involved:
+Two build switches gate the device itself:
 
 -   `commissioning-proxy` must be in the device-factory enable list. All devices
     are enabled by default; `all_devices_enabled_devices` in
     `all-devices-common/device-factory/enabled_devices.gni` selects a subset.
 -   `CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY`, set for this app in
-    `posix/include/CHIPProjectAppConfig.h`, enables the Linux `BLEManagerImpl`
-    proxy-scan and peripheral→central role-switch support that the BLE transport
-    calls.
+    `posix/include/CHIPProjectAppConfig.h`, enables the Linux platform support
+    the transports call: the `BLEManagerImpl` proxy scan and peripheral→central
+    role switch, and the `ConnectivityManagerImpl` WiFi-PAF proxy entry points.
 
-The BLE transport is compiled when `chip_config_network_layer_ble` is true, so
-build variants that disable BLE — `-no-ble` and `-nodeps` — omit it. With no
-transport compiled in the device is not registered with the factory at all, so
-`--device commissioning-proxy` reports an invalid device type there rather than
+The compiled-in transport(s) follow this build configuration:
+
+-   **WiFi-PAF** is included when `chip_device_config_enable_wifipaf` is true
+    (the default for Linux builds with WiFi enabled). When WiFi-PAF is compiled
+    in, the cluster advertises the `WiFiNetworkInterface` feature and the
+    `WiFiBand` attribute; the supported bands are derived from the `freq_list`
+    passed via `--wifipaf`. Note that WiFi-PAF scanning does not work on a stock
+    host: it needs a `wpa_supplicant` built with `CONFIG_NAN_USD` and the
+    `discovery_only` patch. See
+    [wpa_supplicant with the Matter NAN patch](all-devices-common/device/types/commissioning-proxy/README.md#2-wpa_supplicant-with-the-matter-nan-patch-proxy-device).
+-   **BLE** is included when `chip_config_network_layer_ble` is true.
+
+The `-no-ble` build variants disable the BLE transport. With no transport
+compiled in the device is not registered with the factory at all, so
+`--device commissioning-proxy` reports an invalid device type rather than
 starting a proxy whose every command fails. Darwin behaves the same way, as
 `src/platform/Darwin` has no proxy-capable `BLEManagerImpl`.
 
-To build on Linux x86-64 run:
+To build with both BLE and WiFi-PAF on Linux x86-64 run:
 
 ```bash
 ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-devices-boringssl build"
@@ -288,10 +300,10 @@ docker run -it --user "$(id -u):$(id -g)" -v "$PWD":"$PWD" -w "$PWD" \
 ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-arm64-all-devices-boringssl-clang build"
 ```
 
-To start the app as a proxy on endpoint 5:
+To start the app as a proxy over WiFi-PAF on channel 6 (2437 MHz) on endpoint 5:
 
 ```bash
-./out/linux-x64-all-devices-boringssl/all-devices-app --device commissioning-proxy:5
+./out/linux-x64-all-devices-boringssl/all-devices-app --device commissioning-proxy:5 --wifi --wifipaf freq_list=2437
 ```
 
 The cluster's attributes and commands can then be exercised on endpoint 5.

--- a/examples/all-devices-app/all-devices-common/device/types/commissioning-proxy/README.md
+++ b/examples/all-devices-app/all-devices-common/device/types/commissioning-proxy/README.md
@@ -1,0 +1,471 @@
+# Getting Started: Wi-Fi PAF for the Commissioning Proxy
+
+This guide is a self-contained walkthrough for getting the **Commissioning Proxy
+(CP)** device in `all-devices-app` working over **Wi-Fi PAF** (Wi-Fi Aware / NAN
+— Neighbor Awareness Networking).
+
+The Commissioning Proxy tunnels commissioning traffic between a Commissioner
+(chip-tool) and a Commissionee that the Commissioner cannot reach directly:
+
+```
+chip-tool  ──Matter (TCP/IP)──►  all-devices-app (CP)  ──Wi-Fi PAF (NAN)──►  Commissionee
+```
+
+Wi-Fi PAF is one of the transports the CP device can be built with (BLE is
+another). Both are compiled in by default on Linux; the transport used to reach
+a commissionee is chosen **per command** by the `Transport` field of the
+request, not by a command-line flag. This guide covers Wi-Fi PAF end to end —
+everything you need to do to make PAF work, from hardware to a completed
+commission-through-proxy.
+
+<hr>
+
+-   [1. Hardware prerequisites](#1-hardware-prerequisites)
+-   [2. wpa_supplicant with the Matter NAN patch (proxy device)](#2-wpa_supplicant-with-the-matter-nan-patch-proxy-device)
+    -   [2.1 Why the stock package is not enough](#21-why-the-stock-package-is-not-enough)
+    -   [2.2 The patch](#22-the-patch)
+    -   [2.3 Build and install](#23-build-and-install)
+-   [3. Build all-devices-app with Wi-Fi PAF](#3-build-all-devices-app-with-wi-fi-paf)
+-   [4. Run the Commissioning Proxy](#4-run-the-commissioning-proxy)
+-   [5. Commission the proxy onto the fabric](#5-commission-the-proxy-onto-the-fabric)
+-   [6. Run the End Device (commissionee)](#6-run-the-end-device-commissionee)
+-   [7. Scanning (optional)](#7-scanning-optional)
+-   [8. Commission the End Device through the proxy](#8-commission-the-end-device-through-the-proxy)
+-   [9. How Wi-Fi PAF is wired into the CP device](#9-how-wi-fi-paf-is-wired-into-the-cp-device)
+-   [10. Troubleshooting](#10-troubleshooting)
+
+<hr>
+
+## 1. Hardware prerequisites
+
+Wi-Fi PAF needs a radio and driver that support **NAN USD** (Wi-Fi Aware
+Unsynchronized Service Discovery). Both the proxy and the commissionee need it.
+
+| Role                      | Requirement                                                                                                                                        |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Commissioning Proxy (DUT) | Linux host (e.g. Raspberry Pi 4/5) with a **USB Wi-Fi dongle that supports NAN USD.** See https://groups.csa-iot.org/wg/members-all/document/44361 |
+| End Device (commissionee) | Same NAN-USD-capable USB Wi-Fi dongle requirement                                                                                                  |
+
+> The **on-board Raspberry Pi Wi-Fi does not support NAN USD** and cannot be
+> used for Wi-Fi PAF. The USB dongle must be the interface wpa_supplicant
+> manages.
+
+On each device with a PAF dongle, install the wireless utilities. Without them
+the proxy fails at startup with
+`[PAF] Failed to start Wi-Fi PAF publish: ... CHIP Error 0x00000003: Incorrect state`:
+
+```bash
+sudo apt install net-tools wireless-tools
+```
+
+<hr>
+
+## 2. wpa_supplicant with the Matter NAN patch (proxy device)
+
+The Commissioning Proxy requires a custom build of wpa_supplicant. The stock
+Ubuntu package does not compile in NAN USD support, and its default NAN scan
+behavior interferes with the proxy's background scan.
+
+### 2.1 Why the stock package is not enough
+
+-   The stock `wpa_supplicant` is built with `CONFIG_NAN_USD` disabled, so it
+    has no Wi-Fi Aware support at all.
+-   When the proxy performs a NAN scan it subscribes to the Matter NAN service
+    as a passive listener. By default wpa_supplicant automatically sends a NAN
+    Follow-up frame back to every matching publisher, which triggers spurious
+    session setup. The patch adds a `discovery_only` flag that suppresses those
+    automatic replies for discovery-only scans.
+
+### 2.2 The patch
+
+The patch touches four files:
+
+| File                                      | Change                                                                                                           |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `wpa_supplicant/defconfig`                | Enables `CONFIG_NAN_USD=y` so NAN USD support is compiled in                                                     |
+| `src/common/nan_de.h`                     | Adds a `discovery_only` boolean to `nan_subscribe_params`                                                        |
+| `src/common/nan_de.c`                     | Skips the automatic Follow-up reply to the publisher when `discovery_only` is set                                |
+| `wpa_supplicant/dbus/dbus_new_handlers.c` | Exposes `discovery_only` as a D-Bus parameter so the Matter stack can pass it from the background-scan call path |
+
+Save the following as `wpa-supplicant-matter.patch`:
+
+```diff
+diff --git a/src/common/nan_de.c b/src/common/nan_de.c
+index 2af1afd73..1196ec617 100644
+--- a/src/common/nan_de.c
++++ b/src/common/nan_de.c
+@@ -910,7 +910,8 @@ static void nan_de_rx_publish(struct nan_de *de, struct nan_de_service *srv,
+ 		nan_de_tx_multicast(de, srv, instance_id);
+ 	}
+
+-	if (!de->offload && !srv->subscribe.active && req_instance_id == 0) {
++	if (!de->offload && !srv->subscribe.active && req_instance_id == 0 &&
++	    !srv->subscribe.discovery_only) {
+ 		/* Passive subscriber replies with a Follow-up message without
+ 		 * Service Specific Info field if it received a matching
+ 		 * unsolicited Publish message. */
+diff --git a/src/common/nan_de.h b/src/common/nan_de.h
+index b2688a83c..6b9e2ad1f 100644
+--- a/src/common/nan_de.h
++++ b/src/common/nan_de.h
+@@ -154,6 +154,11 @@ struct nan_subscribe_params {
+
+ 	/* Proximity ranging flag */
+ 	bool proximity_ranging;
++
++	/* If true, suppress the automatic Follow-up sent to the publisher when
++	 * a passive subscriber matches an unsolicited Publish frame.  Use for
++	 * discovery-only scans where no session is to be established. */
++	bool discovery_only;
+ };
+
+ /* Returns -1 on failure or >0 subscribe_id */
+diff --git a/wpa_supplicant/dbus/dbus_new_handlers.c b/wpa_supplicant/dbus/dbus_new_handlers.c
+index 76a9297eb..8a9cec6a3 100644
+--- a/wpa_supplicant/dbus/dbus_new_handlers.c
++++ b/wpa_supplicant/dbus/dbus_new_handlers.c
+@@ -6855,6 +6855,10 @@ DBusMessage * wpas_dbus_handler_nan_subscribe(DBusMessage *message,
+ 			for (i = 0; i < entry.array_len; i++)
+ 				int_array_add_unique(
+ 					&freq_list, entry.uint16array_value[i]);
++		} else if (os_strcmp(entry.key, "discovery_only") == 0 &&
++			   entry.type == DBUS_TYPE_BOOLEAN) {
++			params.discovery_only = entry.bool_value;
++			wpa_dbus_dict_entry_clear(&entry);
+ 		} else {
+ 			wpa_printf(MSG_DEBUG,
+ 				   "dbus: NANSubscribe - unsupported dict entry '%s'",
+diff --git a/wpa_supplicant/defconfig b/wpa_supplicant/defconfig
+index 84ac8ba12..2a8f3e9f3 100644
+--- a/wpa_supplicant/defconfig
++++ b/wpa_supplicant/defconfig
+@@ -681,4 +681,4 @@ CONFIG_DPP2=y
+ #CONFIG_NO_WMM_AC=y
+
+ # Wi-Fi Aware unsynchronized service discovery (NAN USD)
+-#CONFIG_NAN_USD=y
++CONFIG_NAN_USD=y
+```
+
+### 2.3 Build and install
+
+Building natively on the proxy device is simplest:
+
+```bash
+# 1. Clone upstream hostap and check out the pinned commit
+git clone https://w1.fi/hostap.git
+cd hostap
+git checkout e17107912
+
+# 2. Apply the Matter NAN patch (adjust the path to where you saved it)
+git apply /path/to/wpa-supplicant-matter.patch
+
+# 3. Use the patched defconfig as the active build config
+cd wpa_supplicant
+cp defconfig .config
+
+# 4. Install build dependencies
+sudo apt update
+sudo apt install libnl-3-dev libnl-genl-3-dev libnl-route-3-dev
+
+# 5. Build
+make all
+```
+
+Verify NAN USD was compiled in, then install and restart the service:
+
+```bash
+strings wpa_supplicant | grep -c nan_usd   # should be > 0
+
+sudo systemctl stop wpa_supplicant
+sudo cp wpa_supplicant /usr/sbin/wpa_supplicant
+sudo systemctl start wpa_supplicant
+systemctl status wpa_supplicant            # expect active (running)
+```
+
+<hr>
+
+## 3. Build all-devices-app with Wi-Fi PAF
+
+Wi-Fi PAF is gated by the GN arg `chip_device_config_enable_wifipaf`, which
+defaults to **true** on Linux builds with Wi-Fi enabled (see
+`src/platform/device.gni`). The Commissioning Proxy cluster itself is enabled by
+`CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY`, which is forced on for this app
+in `posix/include/CHIPProjectAppConfig.h`. So a normal Linux build already
+includes Wi-Fi PAF — no extra args are required.
+
+The PAF transport driver (`CommissioningProxyPafTransport.cpp`) is compiled only
+when `chip_device_config_enable_wifipaf` is set; a build with it off drops the
+`WiFiNetworkInterface` cluster feature and the `WiFiBand` attribute.
+
+**Upstream build (Linux x86-64 / ARM), both transports:**
+
+```bash
+# x86-64
+./scripts/run_in_build_env.sh \
+  "./scripts/build/build_examples.py --target linux-x64-all-devices-boringssl build"
+
+# ARM (arm64)
+./scripts/run_in_build_env.sh \
+  "./scripts/build/build_examples.py --target linux-arm64-all-devices-boringssl build"
+```
+
+The binary is at `out/linux-x64-all-devices-boringssl/all-devices-app` (or the
+`arm64` equivalent).
+
+**Select the transports at build time:**
+
+The targets above compile every transport the platform supports. To build a
+single-transport binary, configure the application's own gn root and pass the
+flag that disables the other transport:
+
+```bash
+./scripts/run_in_build_env.sh "cd examples/all-devices-app/posix && \
+  gn gen out/paf-only --args='chip_config_network_layer_ble=false' && \
+  ninja -C out/paf-only all-devices-app"
+```
+
+| gn argument                               | Transports compiled in |
+| ----------------------------------------- | ---------------------- |
+| _(none of the below)_                     | BLE and Wi-Fi PAF      |
+| `chip_config_network_layer_ble=false`     | Wi-Fi PAF only         |
+| `chip_device_config_enable_wifipaf=false` | BLE only               |
+
+The binary lands at `out/<name>/all-devices-app` under
+`examples/all-devices-app/posix`. Cross-compiling for a Raspberry Pi adds the
+usual aarch64 arguments to the same `gn gen` line — `target_os="linux"`,
+`target_cpu="arm64"`, and a `sysroot=` and `system_libdir=` pointing at your
+aarch64 sysroot.
+
+<hr>
+
+## 4. Run the Commissioning Proxy
+
+Start the proxy on the device with the NAN-capable dongle. Select the CP device
+and its endpoint with `--device commissioning-proxy:5`, and enable Wi-Fi
+management. `freq_list=2437` selects channel 6 (2.4 GHz) — the default Matter
+PAF channel, permitted in all regulatory regions:
+
+```bash
+./all-devices-app \
+    --device commissioning-proxy:5 \
+    --wifi \
+    --wifipaf "freq_list=2437" \
+    --discriminator 3947
+```
+
+| Argument                         | Description                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `--device commissioning-proxy:5` | Instantiate the CP device on endpoint 5                                         |
+| `--wifi`                         | Enable Wi-Fi management via wpa_supplicant (required for PAF)                   |
+| `--wifipaf "freq_list=<MHz>"`    | NAN frequencies in MHz. `2437` = channel 6 (2.4 GHz); add e.g. `5745` for 5 GHz |
+| `--discriminator <value>`        | 12-bit value identifying the proxy during its own commissioning                 |
+
+`freq_list` is parsed once at startup and drives three things. The `WiFiBand`
+attribute advertised by the cluster follows the bands it covers: 2412–2484 MHz →
+2.4 GHz, 5035–5980 MHz → 5 GHz, defaulting to 2.4 GHz if no valid frequency is
+parsed. Scans and `ProxyConnectRequest` create a subscribe instance on a single
+channel: 2437 when it is listed, otherwise the first frequency given. The
+proxy's own NAN publisher advertises on the whole list, so the proxy can be
+commissioned over Wi-Fi PAF itself.
+
+That publisher stops once the proxy joins a fabric, as the NAN radio is needed
+to subscribe on a Commissionee behalf.
+
+Once the proxy is commissioned (next step), it disconnects the NAN receive
+handler, so the PAF subscribe calls it makes on behalf of commissioners register
+exactly one handler.
+
+<hr>
+
+## 5. Commission the proxy onto the fabric
+
+The proxy must itself join the Matter fabric before it can tunnel for others.
+From the Commissioner run a one-time on-network pairing (the proxy is reachable
+over IP):
+
+```bash
+./chip-tool pairing onnetwork 1998 20202021
+```
+
+`1998` is the node ID assigned to the proxy (any non-zero value); `20202021` is
+the default PASE passcode. Success prints:
+
+```
+CHIP:TOO: Device commissioning completed with success
+```
+
+> **Tip:** the proxy re-reads its stored fabric credential on restart. You do
+> not need to re-pair unless you clear its key-value store (`/tmp/chip_*`).
+
+<hr>
+
+## 6. Run the End Device (commissionee)
+
+Start the commissionee (for example a lighting-app) with a `freq_list` that
+matches — or overlaps — the proxy's. The End Device must **not** already be on a
+network, as it is about to be commissioned:
+
+```bash
+./chip-lighting-app \
+    --wifi \
+    --wifipaf "freq_list=2437" \
+    --discriminator 3840
+```
+
+The End Device advertises itself as a NAN publisher. Confirm in its log:
+
+```
+WiFi-PAF: Starting NAN publish
+```
+
+> The End Device discriminator (`3840` here) must match the value you pass to
+> `chip-tool pairing proxy` in step 8.
+
+<hr>
+
+## 7. Scanning (optional)
+
+Before connecting, a Commissioner can ask the proxy to scan for nearby
+commissionable devices. In these commands `8` is the Wi-Fi PAF transport bit,
+`1998` is the proxy node ID (use whatever you paired in step 5), and `5` is the
+endpoint where the cluster lives. The `--WiFiBands` bitmap is `1` = 2.4 GHz, `4`
+= 5 GHz, `5` = both.
+
+**Foreground (one-shot) scan** — results are returned inline. This command
+carries a large payload, so TCP must be forced:
+
+```bash
+./chip-tool commissioningproxy proxy-scan-request 8 1998 5 \
+    --allow-large-payload true --WiFiBands 5 --timeout 20
+```
+
+**Background scan** — the proxy scans continuously and caches results, pushed to
+subscribers via attribute reporting. `Timeout 0` means no expiry:
+
+```bash
+# start
+./chip-tool commissioningproxy proxy-back-ground-scan-start-request 8 0 1998 5 \
+    --WiFiBands 5
+
+# read the cache
+./chip-tool commissioningproxy read cached-results 1998 5
+
+# stop
+./chip-tool commissioningproxy proxy-back-ground-scan-stop-request 8 1998 5 \
+    --WiFiBands 5
+```
+
+<hr>
+
+## 8. Commission the End Device through the proxy
+
+Use `chip-tool pairing proxy` to commission the End Device through the proxy.
+The proxy opens a Wi-Fi PAF (NAN) session to the End Device and tunnels the PASE
+and commissioning packets between chip-tool and the device:
+
+```bash
+./chip-tool pairing proxy <node-id> <ssid> <password> <setup-pin-code> \
+    <ed-discriminator> <proxy-node-id> <proxy-connect-timeout> <proxy-transport> \
+    [--proxy-endpoint <endpoint>] [--proxy-wifi-band 2g4|5g]
+```
+
+| Argument                | Description                                                                 |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `node-id`               | Node ID to assign to the new device                                         |
+| `ssid`                  | Wi-Fi network SSID to configure on the device                               |
+| `password`              | Wi-Fi network password                                                      |
+| `setup-pin-code`        | Commissionee PASE setup PIN code                                            |
+| `ed-discriminator`      | Commissionee discriminator (matches step 6)                                 |
+| `proxy-node-id`         | Node ID of the already-commissioned proxy                                   |
+| `proxy-connect-timeout` | Seconds the proxy may spend connecting to the commissionee; `0` = no limit  |
+| `proxy-transport`       | `wifipaf` or `ble` — the transport the proxy uses to reach the commissionee |
+| `--proxy-endpoint`      | Endpoint hosting the cluster. Defaults to `1`; this app uses `5`            |
+| `--proxy-wifi-band`     | Optional band hint, `2g4` or `5g`; accepted only with `wifipaf`             |
+
+Example — commission device node 1999 onto network "MyNetwork" via proxy 1998:
+
+```bash
+./chip-tool pairing proxy 1999 "MyNetwork" "MyPassword" 20202021 3840 1998 0 wifipaf \
+    --proxy-endpoint 5 --proxy-wifi-band 2g4
+```
+
+<hr>
+
+## 9. How Wi-Fi PAF is wired into the CP device
+
+The Wi-Fi PAF driver, `CommissioningProxyPafTransport`, ships with the cluster
+as the separate `paf-transport` target, so a build that proxies over BLE only —
+or a platform with no Wi-Fi PAF stack — can leave it out. Its design, the
+transport methods it implements and the shared-scanner rules are documented in
+[`src/app/clusters/commissioning-proxy-server/README.md`](../../../../../../src/app/clusters/commissioning-proxy-server/README.md).
+
+### What this app has to supply
+
+Session setup and message tunneling are portable. Discovery is not: scanning for
+commissionable devices, and recovering the NAN subscribe id the platform
+assigned, both need platform code. That is the `CommissioningProxyPafAdapter`
+interface, which this app implements in
+[`posix/linux/CommissioningProxyPafAdapter.cpp`](../../../../posix/linux/CommissioningProxyPafAdapter.cpp):
+
+| Adapter method                | Linux implementation                                   |
+| ----------------------------- | ------------------------------------------------------ |
+| `StartForegroundScan()`       | `ConnectivityMgrImpl().WiFiPAFScan()`                  |
+| `StartBackgroundScan()`       | `ConnectivityMgrImpl().WiFiPAFStartBackgroundScan()`   |
+| `StopBackgroundScan()`        | `ConnectivityMgrImpl().WiFiPAFStopBackgroundScan()`    |
+| `PendingConnectSubscribeId()` | `ConnectivityMgrImpl().GetPendingConnectSubscribeId()` |
+
+The adapter is also where the platform's peer descriptor is unpacked.
+`NanPeerInfo` is Linux-only and owns heap storage for its extended data, so the
+adapter reports each peer as plain scalars and that type never reaches the
+cluster.
+
+Adapter and driver are both constructed in
+`posix/linux/DeviceFactoryPlatformOverride.cpp`, which composes the driver onto
+the single `CommissioningProxyDevice` with `AddTransport()` — a build with BLE
+adds that driver the same way — and derives the advertised `WiFiBand` from
+`--wifipaf freq_list=`, since the device itself reads no command line. The same
+parsed list reaches the radio from `posix/main.cpp`.
+
+<hr>
+
+## 10. Troubleshooting
+
+### Proxy fails to start with a NAN error
+
+-   Confirm the USB Wi-Fi dongle is present (`lsusb`) and its interface exists
+    (`ip link`).
+-   Confirm the patched wpa_supplicant is installed and running:
+    `systemctl status wpa_supplicant` shows `active (running)`, and
+    `strings /usr/sbin/wpa_supplicant | grep -c nan_usd` returns > 0.
+-   Do not use the on-board RPi Wi-Fi — it does not support NAN USD.
+-   Ensure `net-tools` and `wireless-tools` are installed (see section 1); a
+    missing `iwconfig` surfaces as `CHIP Error 0x00000003: Incorrect state`.
+
+### Proxy connect times out (Commissioner gets `Status::Timeout`)
+
+The proxy waited for the connect timeout on the NAN session and gave up. Common
+causes:
+
+-   The End Device is not running or is on a different NAN channel — confirm
+    both sides use the same `freq_list`.
+-   The End Device host also needs a NAN-capable USB Wi-Fi dongle.
+-   The NAN frequency is not allowed by the regulatory domain. `freq_list=2437`
+    (channel 6, 2.4 GHz) is permitted everywhere.
+
+### PAF session closes mid-commissioning
+
+Look for `WiFiPAFCloseSession` in the proxy log — the PAFTP ack-receive timer
+fired. The most common cause is the End Device's radio going off-channel while
+it scans for and joins the Wi-Fi network. Retrying usually succeeds.
+
+### `ConnectNetwork` is slow
+
+`ConnectNetwork` can take 10–15 s while the End Device scans for and joins the
+Wi-Fi AP. This is normal; the proxy extends the Commissioner's exchange timeout
+for this step.
+
+### `chip-tool pairing proxy` command not found
+
+You are running a chip-tool build without the Commissioning Proxy support. Build
+chip-tool from this repository.

--- a/examples/all-devices-app/posix/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/AppOptions.cpp
@@ -22,6 +22,7 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 
@@ -58,10 +59,57 @@ constexpr uint16_t kOptionGroupcast     = 0xffda;
 constexpr uint16_t kOptionAppPipe       = 0xffdb;
 constexpr uint16_t kOptionTraceTo       = 0xffdc;
 constexpr uint16_t kOptionDacProvider   = 0xffdd;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+constexpr uint16_t kOptionWiFiPAF = 0xffdf;
+#endif
 
 DeviceTypeParser AppOptions::sParser;
 AppOptions::AppConfig AppOptions::mConfig;
 bool AppOptions::sIsConfigValidated = false;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+std::vector<uint16_t> AppOptions::ParseWiFiPafFreqList(const std::string & extCmds)
+{
+    static constexpr char kFreqListKey[] = "freq_list=";
+
+    std::vector<uint16_t> freqs;
+    const auto pos = extCmds.find(kFreqListKey);
+    if (pos == std::string::npos)
+    {
+        return freqs;
+    }
+
+    const char * p = extCmds.c_str() + pos + strlen(kFreqListKey);
+    while (*p != '\0' && *p != ' ')
+    {
+        char * end              = nullptr;
+        const unsigned long val = strtoul(p, &end, 10);
+        if (end == p)
+        {
+            // Stop rather than spin, but say so: silently keeping a prefix of what was
+            // asked for would leave the proxy advertising bands it was not told to use.
+            ChipLogError(AppServer, "--wifipaf freq_list: ignoring unparsable frequency at \"%s\"", p);
+            break;
+        }
+        if (val == 0 || val > UINT16_MAX)
+        {
+            ChipLogError(AppServer, "--wifipaf freq_list: ignoring out-of-range frequency %lu", val);
+        }
+        else
+        {
+            freqs.push_back(static_cast<uint16_t>(val));
+        }
+        p = end;
+        if (*p != ',')
+        {
+            break;
+        }
+        ++p;
+    }
+
+    return freqs;
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 
 const AppOptions::AppConfig & AppOptions::GetConfig()
 {
@@ -177,6 +225,12 @@ bool AppOptions::AllDevicesAppOptionHandler(const char * program, OptionSet * op
         mConfig.dacProvider = value;
         ChipLogProgress(AppServer, "DAC provider file set to %s", value);
         return true;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    case kOptionWiFiPAF:
+        mConfig.wifipafExtCmds  = value ? value : "";
+        mConfig.wifipafFreqList = ParseWiFiPafFreqList(mConfig.wifipafExtCmds);
+        return true;
+#endif
     default:
         ChipLogError(Support, "%s: INTERNAL ERROR: Unhandled option: %s\n", program, name);
         return false;
@@ -205,6 +259,9 @@ OptionSet * AppOptions::GetOptions()
         { "app-pipe", kArgumentRequired, kOptionAppPipe },
         { "trace-to", kArgumentRequired, kOptionTraceTo },
         { "dac_provider", kArgumentRequired, kOptionDacProvider },
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        { "wifipaf", kArgumentRequired, kOptionWiFiPAF },
+#endif
         {}, // need empty terminator
     };
 
@@ -269,6 +326,15 @@ OptionSet * AppOptions::GetOptions()
 
         result += "  --dac_provider <path>\n";
         result += "       Path to JSON file containing device attestation credentials\n\n";
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        result += "  --wifipaf freq_list=<freq_1>,<freq_2>...\n";
+        result += "       Enable Wi-Fi PAF via wpa_supplicant, on these NAN frequencies in MHz.\n";
+        result += "       2437 is channel 6, the default publish channel. The list sets the\n";
+        result += "       advertised WiFiBand and the channels published on; scans and connects\n";
+        result += "       subscribe on 2437 when listed, otherwise on the first frequency given.\n";
+        result += "       Give an empty string if not setting freq_list: \"\"\n\n";
+#endif
 
         return result;
     }();

--- a/examples/all-devices-app/posix/app_options/AppOptions.h
+++ b/examples/all-devices-app/posix/app_options/AppOptions.h
@@ -46,11 +46,25 @@ public:
         std::optional<std::string> dacProvider;
         bool enableWiFi        = false;
         uint32_t bleController = 0;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        std::string wifipafExtCmds;
+        // Frequencies in MHz parsed out of "--wifipaf freq_list=", in the order given.
+        std::vector<uint16_t> wifipafFreqList;
+#endif
     };
 
     static chip::ArgParser::OptionSet * GetOptions();
 
     static const AppConfig & GetConfig();
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    /// Parse the frequencies out of a "--wifipaf" argument of the form
+    /// "freq_list=<freq_1>,<freq_2>...".  Returns an empty list when the key is absent
+    /// or carries nothing parsable, and skips entries outside a uint16_t.
+    static std::vector<uint16_t> ParseWiFiPafFreqList(const std::string & extCmds);
+#endif
+
+    static const AppConfig * TryGetConfig() { return sIsConfigValidated ? &mConfig : nullptr; }
     static const std::vector<DeviceTypeParser::Entry> & GetDeviceTypeEntries() { return GetConfig().deviceTypeEntries; }
     static CHIP_ERROR ValidateConfig();
 

--- a/examples/all-devices-app/posix/app_options/tests/BUILD.gn
+++ b/examples/all-devices-app/posix/app_options/tests/BUILD.gn
@@ -21,7 +21,10 @@ if (chip_build_tests) {
   chip_test_suite("tests") {
     output_name = "TestDeviceTypeParser"
 
-    test_sources = [ "TestDeviceTypeParser.cpp" ]
+    test_sources = [
+      "TestAppOptions.cpp",
+      "TestDeviceTypeParser.cpp",
+    ]
 
     cflags = [ "-Wconversion" ]
 

--- a/examples/all-devices-app/posix/app_options/tests/TestAppOptions.cpp
+++ b/examples/all-devices-app/posix/app_options/tests/TestAppOptions.cpp
@@ -1,0 +1,88 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app_options/AppOptions.h>
+#include <platform/CHIPDeviceConfig.h>
+#include <pw_unit_test/framework.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
+namespace {
+
+using FreqList = std::vector<uint16_t>;
+
+TEST(TestAppOptionsWiFiPafFreqList, NoFreqListKey)
+{
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList(""), FreqList{});
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("2437"), FreqList{});
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("other_key=2437"), FreqList{});
+}
+
+TEST(TestAppOptionsWiFiPafFreqList, SingleFrequency)
+{
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list=2437"), FreqList{ 2437 });
+}
+
+TEST(TestAppOptionsWiFiPafFreqList, MultipleFrequenciesKeepTheirOrder)
+{
+    // Order matters: the subscribe channel falls back to the first entry when the
+    // default publish channel is not listed.
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list=5745,2412,2437"), (FreqList{ 5745, 2412, 2437 }));
+}
+
+TEST(TestAppOptionsWiFiPafFreqList, KeyFoundAfterOtherArguments)
+{
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("some_key=1 freq_list=2412,2437"), (FreqList{ 2412, 2437 }));
+}
+
+TEST(TestAppOptionsWiFiPafFreqList, ParsingStopsAtASpace)
+{
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list=2437,2412 other_key=5745"), (FreqList{ 2437, 2412 }));
+}
+
+TEST(TestAppOptionsWiFiPafFreqList, NonNumericValueYieldsNothing)
+{
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list=abc"), FreqList{});
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list="), FreqList{});
+}
+
+TEST(TestAppOptionsWiFiPafFreqList, ParsingStopsAtTheFirstNonNumericEntry)
+{
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list=2437,abc,2412"), FreqList{ 2437 });
+}
+
+TEST(TestAppOptionsWiFiPafFreqList, TrailingCommaIsTolerated)
+{
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list=2437,"), FreqList{ 2437 });
+}
+
+TEST(TestAppOptionsWiFiPafFreqList, OutOfRangeEntriesAreSkipped)
+{
+    // 0 is not a frequency, and anything past a uint16_t cannot be sent to
+    // wpa_supplicant; neither should displace the valid entries around it.
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list=0,2437"), FreqList{ 2437 });
+    EXPECT_EQ(AppOptions::ParseWiFiPafFreqList("freq_list=70000,2437"), FreqList{ 2437 });
+}
+
+} // namespace
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF

--- a/examples/all-devices-app/posix/linux/BUILD.gn
+++ b/examples/all-devices-app/posix/linux/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 import("${chip_root}/src/app/common_flags.gni")
 import("${chip_root}/src/ble/ble.gni")
+import("${chip_root}/src/platform/device.gni")
 
 config("includes") {
   include_dirs = [
@@ -40,6 +41,13 @@ source_set("linux") {
     ]
   }
 
+  if (chip_device_config_enable_wifipaf) {
+    sources += [
+      "CommissioningProxyPafAdapter.cpp",
+      "CommissioningProxyPafAdapter.h",
+    ]
+  }
+
   deps = [
     "${chip_root}/examples/all-devices-app/all-devices-common/device-factory",
     "${chip_root}/examples/all-devices-app/all-devices-common/device/api:device-interface",
@@ -55,16 +63,28 @@ source_set("linux") {
 
   deps += [ "${chip_root}/third_party/jsoncpp" ]
 
+  # The proxy device itself is here rather than in the unconditional list because a
+  # build with no transport does not register it with the factory, and linking the
+  # cluster into a binary that cannot reach it only costs flash. Either transport is
+  # enough to make it reachable, so this tracks both.
+  if (chip_config_network_layer_ble || chip_device_config_enable_wifipaf) {
+    deps += [ "${chip_root}/examples/all-devices-app/all-devices-common/device/types/commissioning-proxy" ]
+  }
+
   if (chip_config_network_layer_ble) {
     # CommissioningProxyBleAdapter implements the cluster's BLE adapter interface, and
     # this target owns the BLE transport driver it is composed onto the proxy device with.
-    #
-    # The proxy device itself is here rather than in the unconditional list because a
-    # build with no transport does not register it with the factory, and linking the
-    # cluster into a binary that cannot reach it only costs flash.
     deps += [
-      "${chip_root}/examples/all-devices-app/all-devices-common/device/types/commissioning-proxy",
       "${chip_root}/src/app/clusters/commissioning-proxy-server:ble-transport",
+    ]
+  }
+
+  if (chip_device_config_enable_wifipaf) {
+    # CommissioningProxyPafAdapter implements the cluster's PAF adapter interface, and
+    # the band the proxy advertises is derived here from the app's command line.
+    deps += [
+      "${chip_root}/examples/all-devices-app/posix/app_options:app-options",
+      "${chip_root}/src/app/clusters/commissioning-proxy-server:paf-transport",
     ]
   }
 

--- a/examples/all-devices-app/posix/linux/CommissioningProxyPafAdapter.cpp
+++ b/examples/all-devices-app/posix/linux/CommissioningProxyPafAdapter.cpp
@@ -1,0 +1,135 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "CommissioningProxyPafAdapter.h"
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/ConnectivityManager.h>
+#include <platform/Linux/ConnectivityManagerImpl.h>
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR CommissioningProxyPafAdapter::StartForegroundScan(System::Clock::Seconds16 window, DiscoveryCallback onDevice,
+                                                             ScanCompleteCallback onDone, void * context)
+{
+    VerifyOrReturnError(onDevice != nullptr && onDone != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mForegroundCallback = onDevice;
+    mForegroundDone     = onDone;
+    mForegroundContext  = context;
+
+    // WiFiPAFScan takes the window as uint8 seconds. The cluster's ScanMaxTime attribute
+    // is itself a uint8, so the value cannot exceed what the platform call accepts.
+    CHIP_ERROR err =
+        DeviceLayer::ConnectivityMgrImpl().WiFiPAFScan(static_cast<uint8_t>(window.count()), OnPlatformScanComplete, this);
+    if (err != CHIP_NO_ERROR)
+    {
+        // Leave nothing armed on failure, so a later stray platform callback cannot reach
+        // a caller that believes its scan never started.
+        mForegroundCallback = nullptr;
+        mForegroundDone     = nullptr;
+        mForegroundContext  = nullptr;
+    }
+    return err;
+}
+
+void CommissioningProxyPafAdapter::StopForegroundScan()
+{
+    // ConnectivityManagerImpl exposes no way to abort a one-shot WiFiPAFScan early - the
+    // window is owned by wpa_supplicant and FinishWiFiPAFScan is private. Detaching the
+    // callbacks is therefore the whole of what this can promise, and is what the caller
+    // actually needs: a scan that lands after teardown is dropped here rather than
+    // reaching a destroyed transport.
+    mForegroundCallback = nullptr;
+    mForegroundDone     = nullptr;
+    mForegroundContext  = nullptr;
+}
+
+CHIP_ERROR CommissioningProxyPafAdapter::StartBackgroundScan(DiscoveryCallback cb, void * context)
+{
+    VerifyOrReturnError(cb != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mBackgroundCallback = cb;
+    mBackgroundContext  = context;
+
+    CHIP_ERROR err = DeviceLayer::ConnectivityMgrImpl().WiFiPAFStartBackgroundScan(OnPlatformBgScanDiscovery, this);
+    if (err != CHIP_NO_ERROR)
+    {
+        mBackgroundCallback = nullptr;
+        mBackgroundContext  = nullptr;
+    }
+    return err;
+}
+
+void CommissioningProxyPafAdapter::StopBackgroundScan()
+{
+    DeviceLayer::ConnectivityMgrImpl().WiFiPAFStopBackgroundScan();
+    mBackgroundCallback = nullptr;
+    mBackgroundContext  = nullptr;
+}
+
+uint32_t CommissioningProxyPafAdapter::PendingConnectSubscribeId() const
+{
+    return DeviceLayer::ConnectivityMgrImpl().GetPendingConnectSubscribeId();
+}
+
+void CommissioningProxyPafAdapter::ReportPeer(DiscoveryCallback cb, void * context, const DeviceLayer::NanPeerInfo & peer)
+{
+    // The platform keeps extended data in a heap buffer; hand it across as a span that is
+    // only valid for this call, which is what the interface promises.
+    ByteSpan extendedData;
+    if (peer.hasExtendedData && !peer.storage.empty())
+    {
+        extendedData = ByteSpan(peer.storage.data(), peer.storage.size());
+    }
+    cb(context, ByteSpan(peer.mac, sizeof(peer.mac)), peer.discriminator, peer.vid, peer.pid, extendedData, peer.band);
+}
+
+void CommissioningProxyPafAdapter::OnPlatformScanComplete(void * context, const std::vector<DeviceLayer::NanPeerInfo> & peers)
+{
+    auto * self = static_cast<CommissioningProxyPafAdapter *>(context);
+    VerifyOrReturn(self != nullptr && self->mForegroundCallback != nullptr && self->mForegroundDone != nullptr);
+
+    // The platform reports the whole result set at the end of the window; the interface
+    // reports device-by-device and then signals completion, so fan the batch out here.
+    for (const auto & peer : peers)
+    {
+        ReportPeer(self->mForegroundCallback, self->mForegroundContext, peer);
+    }
+
+    ScanCompleteCallback onDone = self->mForegroundDone;
+    void * doneContext          = self->mForegroundContext;
+    self->mForegroundCallback   = nullptr;
+    self->mForegroundDone       = nullptr;
+    self->mForegroundContext    = nullptr;
+    onDone(doneContext);
+}
+
+void CommissioningProxyPafAdapter::OnPlatformBgScanDiscovery(void * context, const DeviceLayer::NanPeerInfo & peer)
+{
+    auto * self = static_cast<CommissioningProxyPafAdapter *>(context);
+    VerifyOrReturn(self != nullptr && self->mBackgroundCallback != nullptr);
+
+    ReportPeer(self->mBackgroundCallback, self->mBackgroundContext, peer);
+}
+
+} // namespace app
+} // namespace chip

--- a/examples/all-devices-app/posix/linux/CommissioningProxyPafAdapter.h
+++ b/examples/all-devices-app/posix/linux/CommissioningProxyPafAdapter.h
@@ -1,0 +1,76 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyPafAdapter.h>
+#include <lib/core/CHIPError.h>
+#include <system/SystemClock.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace chip {
+namespace DeviceLayer {
+// Declared in platform/Linux/ConnectivityManagerImpl.h. Forward-declared here so this
+// header stays free of the platform implementation header; the .cpp includes it.
+struct NanPeerInfo;
+} // namespace DeviceLayer
+
+namespace app {
+
+/**
+ * @brief Linux implementation of the commissioning proxy's Wi-Fi PAF discovery hooks.
+ *
+ * Forwards to ConnectivityManagerImpl, which owns the wpa_supplicant NAN interface and
+ * the single subscribe slot. This is also where the platform's peer descriptor is
+ * translated: NanPeerInfo is Linux-only and owns heap storage for its extended data, so
+ * it is unpacked into the interface's scalars here and never crosses into the cluster.
+ *
+ * The platform scan APIs hand back one void*, so this holds the caller's callbacks and
+ * context and passes itself instead.
+ */
+class CommissioningProxyPafAdapter : public Clusters::CommissioningProxy::CommissioningProxyPafAdapter
+{
+public:
+    CHIP_ERROR StartForegroundScan(System::Clock::Seconds16 window, DiscoveryCallback onDevice, ScanCompleteCallback onDone,
+                                   void * context) override;
+    void StopForegroundScan() override;
+    CHIP_ERROR StartBackgroundScan(DiscoveryCallback cb, void * context) override;
+    void StopBackgroundScan() override;
+    uint32_t PendingConnectSubscribeId() const override;
+
+private:
+    /// Trampolines matching the platform callback shapes; they re-report each peer in the
+    /// interface's own terms.
+    static void OnPlatformScanComplete(void * context, const std::vector<DeviceLayer::NanPeerInfo> & peers);
+    static void OnPlatformBgScanDiscovery(void * context, const DeviceLayer::NanPeerInfo & peer);
+
+    /// Unpack one platform peer descriptor and hand it to @p cb.
+    static void ReportPeer(DiscoveryCallback cb, void * context, const DeviceLayer::NanPeerInfo & peer);
+
+    DiscoveryCallback mForegroundCallback = nullptr;
+    ScanCompleteCallback mForegroundDone  = nullptr;
+    void * mForegroundContext             = nullptr;
+
+    DiscoveryCallback mBackgroundCallback = nullptr;
+    void * mBackgroundContext             = nullptr;
+};
+
+} // namespace app
+} // namespace chip

--- a/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
+++ b/examples/all-devices-app/posix/linux/DeviceFactoryPlatformOverride.cpp
@@ -18,51 +18,144 @@
 #include <PosixAudioManager.h>
 #include <PosixChime.h>
 #include <PosixSpeaker.h>
+#include <app/server/Server.h>
 #include <app_config/enabled_devices.h>
 #include <device-factory/DeviceFactory.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+// The commissioning-proxy device target in BUILD.gn is conditional on either
+// transport being enabled, which gn check cannot evaluate, hence the nogncheck.
+#if CONFIG_NETWORK_LAYER_BLE || CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#include <device/types/commissioning-proxy/CommissioningProxyDevice.h> // nogncheck
+#endif
 #if CONFIG_NETWORK_LAYER_BLE
 #include <CommissioningProxyBleAdapter.h>
-// The commissioning-proxy and ble-transport dependencies in BUILD.gn are conditional on
-// chip_config_network_layer_ble, which gn check cannot evaluate, hence the nogncheck.
+// The ble-transport / paf-transport dependencies in BUILD.gn are conditional on
+// chip_config_network_layer_ble and chip_device_config_enable_wifipaf, which gn check
+// cannot evaluate, hence the nogncheck on the transport includes below.
 #include <app/clusters/commissioning-proxy-server/CommissioningProxyBleTransport.h> // nogncheck
-#include <device/types/commissioning-proxy/CommissioningProxyDevice.h>              // nogncheck
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#include <CommissioningProxyPafAdapter.h>
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyPafTransport.h> // nogncheck
+#include <app_options/AppOptions.h>
 #endif
 
 namespace chip {
 namespace app {
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+namespace {
+
+/// Derive the Wi-Fi bands the proxy advertises from the "--wifipaf freq_list=" the app
+/// was started with.  This lives here rather than in the device because it reads the
+/// app's command line; the device takes the resulting bands injected.
+BitMask<Clusters::CommissioningProxy::WiFiBandBitmap> ProxyWiFiBands()
+{
+    using Clusters::CommissioningProxy::WiFiBandBitmap;
+
+    BitMask<WiFiBandBitmap> bands;
+
+    const AppOptions::AppConfig * cfg = AppOptions::TryGetConfig();
+    if (cfg != nullptr)
+    {
+        for (uint16_t freq : cfg->wifipafFreqList)
+        {
+            if (freq >= 2412 && freq <= 2484)
+            {
+                bands.Set(WiFiBandBitmap::k2g4);
+            }
+            else if (freq >= 5035 && freq <= 5980)
+            {
+                bands.Set(WiFiBandBitmap::k5g);
+            }
+        }
+    }
+
+    // With no valid frequency in the freq_list, advertise 2.4 GHz rather than an empty
+    // bitmap, so a Wi-Fi-PAF-capable proxy does not report supporting no bands at all.
+    if (!bands.HasAny())
+    {
+        bands.Set(WiFiBandBitmap::k2g4);
+    }
+
+    return bands;
+}
+
+/// Stop advertising this device's own commissioning window over Wi-Fi PAF, from the point
+/// it joins a fabric onwards. Publishing uses the same NAN radio the proxy needs for the
+/// subscribes it makes on a commissionee's behalf.
+void SuppressProxyWiFiPafAdvertising()
+{
+    Server::GetInstance().GetCommissioningWindowManager().SetWiFiPAFAdvertisingAllowed(false);
+}
+
+void OnProxyDeviceEvent(const DeviceLayer::ChipDeviceEvent * event, intptr_t)
+{
+    // Two ways to arrive on a fabric. kCommissioningComplete: the proxy has just joined
+    // one. kServerReady: the fabric table has been loaded, which is the first point a
+    // proxy commissioned before this boot can be recognised -- the device factory runs
+    // before Server::Init(), so the fabric count is always zero when the device is
+    // created and cannot be tested there.
+    const bool joinedNow = event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete;
+    const bool alreadyOnAFabric =
+        event->Type == DeviceLayer::DeviceEventType::kServerReady && Server::GetInstance().GetFabricTable().FabricCount() > 0;
+    VerifyOrReturn(joinedNow || alreadyOnAFabric);
+
+    SuppressProxyWiFiPafAdvertising();
+}
+
+} // namespace
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
 void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, FabricTable & fabricTable,
                                     PersistentStorageDelegate * storageDelegate, PosixAudioManager & audioManager)
 {
     // Registered only when a transport is compiled in.
-#if CONFIG_NETWORK_LAYER_BLE
+#if CONFIG_NETWORK_LAYER_BLE || CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     if constexpr (ALL_DEVICES_ENABLE_COMMISSIONING_PROXY)
     {
         const CommissioningProxyDevice::Context proxyContext{ fabricTable, timerDelegate };
 
-        // The adapter and its transport driver outlive every device the factory creates,
-        // because a registered transport holds a pointer back to the device's cluster.
-        // Only one commissioning proxy device is ever created, so one instance of each
-        // serves it.
+        // The adapters and their transport drivers outlive every device the factory
+        // creates, because a registered transport holds a pointer back to the device's
+        // cluster. Only one commissioning proxy device is ever created, so one instance
+        // of each serves it.
+        //
+        // Adding a technology here is one more block like these plus one more
+        // AddTransport() call below; no new device type is involved.
         BitMask<Clusters::CommissioningProxy::Feature> proxyFeatures;
+        BitMask<Clusters::CommissioningProxy::WiFiBandBitmap> proxyBands;
 
+#if CONFIG_NETWORK_LAYER_BLE
         static CommissioningProxyBleAdapter sBleProxyAdapter;
         static Clusters::CommissioningProxy::CommissioningProxyBleTransport sBleProxyTransport(sBleProxyAdapter, timerDelegate);
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        static CommissioningProxyPafAdapter sPafProxyAdapter;
+        static Clusters::CommissioningProxy::CommissioningProxyPafTransport sPafProxyTransport(sPafProxyAdapter, timerDelegate);
+#endif
 
+#if CONFIG_NETWORK_LAYER_BLE || CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
         // Every transport driver implements ProxyBackgroundScanStart/Stop, so the
         // feature follows from having any transport at all.
         proxyFeatures.Set(Clusters::CommissioningProxy::Feature::kBackgroundScan);
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        // Wi-Fi PAF makes this a Wi-Fi device, which is what makes WiFiBand present.
+        proxyFeatures.Set(Clusters::CommissioningProxy::Feature::kWiFiNetworkInterface);
+        proxyBands = ProxyWiFiBands();
+#endif
 
-        const Clusters::CommissioningProxy::CommissioningProxyCluster::Config proxyConfig(proxyFeatures);
+        const Clusters::CommissioningProxy::CommissioningProxyCluster::Config proxyConfig(proxyFeatures, proxyBands);
 
         DeviceFactory::GetInstance().RegisterCreator(
             "commissioning-proxy", [proxyContext, proxyConfig]() -> std::unique_ptr<DeviceInterface> {
-                // Refuse a second proxy. The driver above is a single instance because
-                // the radio it drives is: one BLE scanner. Handing it to a second device
-                // would take it over from the first, leaving it registered but
-                // unreachable, and two proxies could not both work on one radio anyway.
+                // Refuse a second proxy. The drivers above are single instances because
+                // the radios they drive are: one BLE scanner, one NAN subscribe slot.
+                // Handing them to a second device would take them over from the first,
+                // leaving it registered but unreachable, and two proxies could not both
+                // work on one radio anyway.
                 static bool sProxyDeviceCreated = false;
                 if (sProxyDeviceCreated)
                 {
@@ -71,12 +164,25 @@ void RegisterDeviceFactoryOverrides(TimerDelegate & timerDelegate, FabricTable &
                 }
                 sProxyDeviceCreated = true;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                // A proxy needs its NAN radio to subscribe on a commissionee's behalf, so
+                // it must not publish its own commissioning window once it is on a fabric
+                // and can be asked to proxy. Until then it does advertise over Wi-Fi PAF,
+                // so the proxy itself can be commissioned that way.
+                LogErrorOnFailure(DeviceLayer::PlatformMgr().AddEventHandler(OnProxyDeviceEvent, 0));
+#endif
+
                 auto device = std::make_unique<CommissioningProxyDevice>(proxyContext, proxyConfig);
+#if CONFIG_NETWORK_LAYER_BLE
                 device->AddTransport(sBleProxyTransport);
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                device->AddTransport(sPafProxyTransport);
+#endif
                 return device;
             });
     }
-#endif // CONFIG_NETWORK_LAYER_BLE
+#endif // CONFIG_NETWORK_LAYER_BLE || CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 
     if constexpr (ALL_DEVICES_ENABLE_SPEAKER)
     {

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -45,6 +45,7 @@
 #include <device/api/allocator/DynamicEndpointIdAllocator.h>
 #include <oob-accessors/OOBAccessor.h>
 #include <oob-accessors/OOBAccessorRegistry.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/DiagnosticDataProvider.h>
@@ -64,6 +65,10 @@
 #include <device/types/boolean-state-sensor/BooleanStateSensor.h>
 #include <device/types/occupancy-sensor/OccupancySensor.h>
 #include <device/types/on-off-light/impl/LoggingOnOffLight.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
 
 using namespace chip;
 using namespace chip::app;
@@ -507,6 +512,38 @@ void EventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
     }
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+// Apply "--wifipaf freq_list=" to the Wi-Fi PAF radio.  Without this the frequencies
+// would only reach the CommissioningProxy cluster's advertised WiFiBand, leaving the
+// publish, scan and connect paths on the compile-time default channel.
+void ConfigureWiFiPaf(const std::vector<uint16_t> & freqList)
+{
+    if (freqList.empty())
+    {
+        return;
+    }
+
+    // A commissionable device advertises on the default publish channel and additionally
+    // on the channels in this list. The proxy stops publishing once it is on a fabric.
+    DeviceLayer::ConnectivityManager::WiFiPAFAdvertiseParam advertiseParam;
+    advertiseParam.freq_list_len = static_cast<uint16_t>(freqList.size());
+    advertiseParam.freq_list     = std::make_unique<uint16_t[]>(freqList.size());
+    std::copy(freqList.begin(), freqList.end(), advertiseParam.freq_list.get());
+    DeviceLayer::ConnectivityMgr().WiFiPAFSetParam(advertiseParam);
+
+    // A subscribe instance is created on a single channel, and a commissioner should use
+    // the default publish channel wherever it can, so only fall back to the first
+    // frequency listed when the default is not among them.
+    constexpr uint16_t kDefaultPublishChannel = CHIP_DEVICE_CONFIG_WIFIPAF_24G_DEFAUTL_CHNL;
+    const bool defaultListed     = std::find(freqList.begin(), freqList.end(), kDefaultPublishChannel) != freqList.end();
+    const uint16_t subscribeFreq = defaultListed ? kDefaultPublishChannel : freqList.front();
+    DeviceLayer::ConnectivityMgr().WiFiPafSetApFreq(subscribeFreq);
+
+    ChipLogProgress(AppServer, "Wi-Fi PAF: publishing on %u frequencies, subscribing on %u MHz",
+                    static_cast<unsigned>(freqList.size()), subscribeFreq);
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
 CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & provider, const AppOptions::AppConfig & config)
 {
     auto discriminator = config.discriminator.value_or(static_cast<uint16_t>(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR));
@@ -560,6 +597,10 @@ CHIP_ERROR Initialize(int argc, char * argv[])
     ConfigurationMgr().LogDeviceConfig();
 
     ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().AddEventHandler(EventHandler, 0));
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    ConfigureWiFiPaf(config.wifipafFreqList);
+#endif
 
     ReturnErrorOnFailure(chip::app::InitBle(AppOptions::GetConfig().bleController));
 

--- a/src/app/clusters/commissioning-proxy-server/BUILD.gn
+++ b/src/app/clusters/commissioning-proxy-server/BUILD.gn
@@ -74,3 +74,23 @@ if (chip_config_network_layer_ble) {
     ]
   }
 }
+
+# Wi-Fi PAF (PAFTP) transport driver. Split out for the same reason as ble-transport: an
+# application that proxies over BLE only - or a platform with no Wi-Fi PAF stack - can
+# depend on commissioning-proxy-server without pulling in src/wifipaf. The platform
+# discovery hooks it needs come from CommissioningProxyPafAdapter, which the application
+# implements.
+source_set("paf-transport") {
+  sources = [
+    "CommissioningProxyPafAdapter.h",
+    "CommissioningProxyPafTransport.cpp",
+    "CommissioningProxyPafTransport.h",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    ":commissioning-proxy-server",
+    "${chip_root}/src/wifipaf",
+  ]
+}

--- a/src/app/clusters/commissioning-proxy-server/CommissioningProxyCluster.cpp
+++ b/src/app/clusters/commissioning-proxy-server/CommissioningProxyCluster.cpp
@@ -338,15 +338,21 @@ CommissioningProxyCluster::HandleProxyDisconnectRequest(const DataModel::InvokeR
         {
             mTransports[i]->OnAllSessionsClosed();
         }
-
-        CHIP_ERROR stateErr = SetCPState(kState_CPDisconnected);
-        if (stateErr != CHIP_NO_ERROR)
-        {
-            ChipLogError(Zcl, "HandleProxyDisconnectRequest: SetCPState failed: %" CHIP_ERROR_FORMAT, stateErr.Format());
-        }
     }
+    SetDisconnectedIfLastSession();
 
     return Status::Success;
+}
+
+void CommissioningProxyCluster::SetDisconnectedIfLastSession()
+{
+    VerifyOrReturn(GetActiveSessionCount() == 0);
+
+    CHIP_ERROR stateErr = SetCPState(kState_CPDisconnected);
+    if (stateErr != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "SetDisconnectedIfLastSession: SetCPState failed: %" CHIP_ERROR_FORMAT, stateErr.Format());
+    }
 }
 
 std::optional<DataModel::ActionReturnStatus>

--- a/src/app/clusters/commissioning-proxy-server/CommissioningProxyCluster.h
+++ b/src/app/clusters/commissioning-proxy-server/CommissioningProxyCluster.h
@@ -174,6 +174,16 @@ public:
     CommissioningProxyCluster::State GetCPState();
 
     /**
+     * @brief Report the proxy disconnected once no session remains, anywhere.
+     *
+     * For a transport whose peer closed the connection: the ProxyDisconnectRequest path
+     * sets the state itself. A transport must not decide this from its own sessions --
+     * with more than one transport configured, the last session on one of them is not the
+     * last session on the proxy.
+     */
+    void SetDisconnectedIfLastSession();
+
+    /**
      * @brief Current ScanMaxTime / CacheTimeout attribute values.
      *
      * These writable attributes are stored and change-reported by the cluster.

--- a/src/app/clusters/commissioning-proxy-server/CommissioningProxyPafAdapter.h
+++ b/src/app/clusters/commissioning-proxy-server/CommissioningProxyPafAdapter.h
@@ -1,0 +1,129 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+#include <system/SystemClock.h>
+
+#include <cstdint>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace CommissioningProxy {
+
+/**
+ * @brief The Wi-Fi PAF operations a commissioning proxy needs that have no portable form.
+ *
+ * Opening, sending over and closing a PAF session is already portable: it goes through
+ * chip::WiFiPAF::WiFiPAFLayer and the generic ConnectivityManager facade
+ * (WiFiPAFSubscribe / WiFiPAFCancelSubscribe / WiFiPAFCancelIncompleteSubscribe).
+ * Discovery is not — scanning for commissionable devices, and recovering the subscribe
+ * id the platform assigned, both need the platform implementation. Those live here so
+ * CommissioningProxyPafTransport stays free of any platform header, and so a test can
+ * drive it against a fake.
+ *
+ * One implementation per platform. The application owns the instance and passes it to
+ * the transport, which keeps a reference and never takes ownership.
+ */
+class CommissioningProxyPafAdapter
+{
+public:
+    /**
+     * Fired once per discovered commissionable device, on the Matter event loop, with
+     * @p context passed back unchanged. Used by both the foreground and the background
+     * scan, so a device looks the same whichever scan found it.
+     *
+     * Reported as scalars rather than as a platform type: a NAN peer descriptor is
+     * platform-specific and typically owns heap storage for its extended data, neither
+     * of which belongs in the cluster.
+     *
+     * @param address       peer NAN MAC.
+     * @param extendedData  empty when the advertisement carried none.
+     * @param wiFiBand      WiFiBandBitmap value the peer was found on; 0 when unknown.
+     *
+     * Both spans are only valid for the duration of the call.
+     */
+    using DiscoveryCallback = void (*)(void * context, ByteSpan address, uint16_t discriminator, uint16_t vendorId,
+                                       uint16_t productId, ByteSpan extendedData, uint16_t wiFiBand);
+
+    /// Fired once when a foreground scan started by StartForegroundScan has finished
+    /// reporting devices, so the transport knows the result set is complete.
+    using ScanCompleteCallback = void (*)(void * context);
+
+    virtual ~CommissioningProxyPafAdapter() = default;
+
+    /**
+     * Run a one-shot discovery scan lasting @p window, reporting each peer through
+     * @p onDevice and then calling @p onDone exactly once.
+     *
+     * Unlike BLE, the platform owns the scan window here, so the transport arms no timer
+     * of its own and relies on @p onDone to close the scan out.
+     *
+     * A NAN radio has a single subscribe slot shared with the background scan and with
+     * connect. This reports CHIP_ERROR_BUSY only when a background scan holds the slot,
+     * and even that is a backstop: the transport pauses a running background scan before
+     * calling. A connect holding the slot is not reported here.
+     */
+    virtual CHIP_ERROR StartForegroundScan(System::Clock::Seconds16 window, DiscoveryCallback onDevice, ScanCompleteCallback onDone,
+                                           void * context) = 0;
+
+    /**
+     * Guarantee no further callbacks from a scan started by StartForegroundScan.
+     *
+     * The platform owns the scan window and may have no way to abort it early, so this is
+     * not required to stop the radio — it is required to detach the callbacks, so a scan
+     * that completes after the caller has gone cannot reach it. Called from the
+     * transport's Shutdown(). A no-op when no foreground scan is outstanding.
+     */
+    virtual void StopForegroundScan() = 0;
+
+    /**
+     * Start a continuous discovery scan, reporting each peer as it is seen — including
+     * re-discoveries, so the cluster's cache can refresh a TTL rather than treat the
+     * peer as new.
+     *
+     * Reports CHIP_ERROR_BUSY when a foreground scan holds the single subscribe slot.
+     * A connect holding it is caught before this is reached, by the transport hook the
+     * registry calls to start the hardware scan. Either way the registry treats
+     * CHIP_ERROR_BUSY as "defer and retry later".
+     */
+    virtual CHIP_ERROR StartBackgroundScan(DiscoveryCallback cb, void * context) = 0;
+
+    /**
+     * Stop a scan started by StartBackgroundScan. A no-op when none is running, so
+     * teardown paths can call it unconditionally.
+     */
+    virtual void StopBackgroundScan() = 0;
+
+    /**
+     * The subscribe id the platform assigned to the most recent subscribe request, which
+     * the portable WiFiPAFSubscribe() call does not return. The transport needs it to
+     * cancel that specific subscribe if the connect fails or is abandoned.
+     *
+     * Valid only immediately after a successful subscribe; 0 when there is none.
+     */
+    virtual uint32_t PendingConnectSubscribeId() const = 0;
+};
+
+} // namespace CommissioningProxy
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/commissioning-proxy-server/CommissioningProxyPafTransport.cpp
+++ b/src/app/clusters/commissioning-proxy-server/CommissioningProxyPafTransport.cpp
@@ -1,0 +1,929 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyPafTransport.h>
+
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyCluster.h>
+#include <clusters/CommissioningProxy/Commands.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/ConnectivityManager.h>
+#include <wifipaf/WiFiPAFLayer.h>
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace CommissioningProxy {
+
+using Protocols::InteractionModel::Status;
+
+CommissioningProxyPafTransport::CommissioningProxyPafTransport(CommissioningProxyPafAdapter & adapter,
+                                                               TimerDelegate & timerDelegate) :
+    mAdapter(adapter),
+    mTimerDelegate(timerDelegate), mBgScan(mBgScanHardware, timerDelegate)
+{}
+
+CommissioningProxyPafTransport::~CommissioningProxyPafTransport()
+{
+    // Safe to run twice, and required if the owner never called it: the connect timer and
+    // the installed WiFiPAF delegate would otherwise outlive this object.
+    Shutdown();
+}
+
+// ==================================================================
+// Small helpers
+// ==================================================================
+
+CommissioningProxyPafTransport::SessionSlot * CommissioningProxyPafTransport::FindSlot(uint16_t sessionId)
+{
+    for (auto & slot : mSessions)
+    {
+        if (slot.inUse && slot.sessionId == sessionId)
+        {
+            return &slot;
+        }
+    }
+    return nullptr;
+}
+
+CommissioningProxyPafTransport::SessionSlot * CommissioningProxyPafTransport::FindSlotByPeer(uint32_t peerId)
+{
+    for (auto & slot : mSessions)
+    {
+        if (slot.inUse && slot.pafSession.peer_id == peerId)
+        {
+            return &slot;
+        }
+    }
+    return nullptr;
+}
+
+CommissioningProxyPafTransport::SessionSlot * CommissioningProxyPafTransport::ClaimSlot()
+{
+    for (auto & slot : mSessions)
+    {
+        if (!slot.inUse)
+        {
+            return &slot;
+        }
+    }
+    return nullptr;
+}
+
+bool CommissioningProxyPafTransport::AnySessionOpen() const
+{
+    for (const auto & slot : mSessions)
+    {
+        if (slot.inUse)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+CommissioningProxyPafTransport::ScanResultT CommissioningProxyPafTransport::MakeScanResult(ByteSpan address, uint16_t discriminator,
+                                                                                           uint16_t vendorId, uint16_t productId,
+                                                                                           ByteSpan extendedData, uint16_t wiFiBand)
+{
+    ScanResultT r{};
+    r.address.SetNonNull(address);
+    r.transport     = BitMask<CapabilitiesBitmap>(CapabilitiesBitmap::kWiFiPAF);
+    r.discriminator = discriminator;
+    r.vendorID      = static_cast<VendorId>(vendorId);
+    r.productID     = productId;
+    if (!extendedData.empty())
+    {
+        r.extendedData.SetNonNull(extendedData);
+    }
+    else
+    {
+        r.extendedData.SetNull();
+    }
+    if (wiFiBand != 0)
+    {
+        r.wiFiBand.SetValue(static_cast<WiFiBandBitmap>(wiFiBand));
+    }
+    else
+    {
+        r.wiFiBand.ClearValue();
+    }
+    return r;
+}
+
+// ==================================================================
+// ProxyPafDelegate
+// ==================================================================
+
+void CommissioningProxyPafTransport::ProxyPafDelegate::Install()
+{
+    auto & layer = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
+    if (layer.mWiFiPAFTransport == this)
+    {
+        return;
+    }
+    mOriginalTransport      = layer.mWiFiPAFTransport;
+    layer.mWiFiPAFTransport = this;
+    ChipLogProgress(AppServer, "ProxyPafDelegate: installed (original=%p)", (void *) mOriginalTransport);
+}
+
+void CommissioningProxyPafTransport::ProxyPafDelegate::Uninstall()
+{
+    auto & layer = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
+    if (layer.mWiFiPAFTransport == this)
+    {
+        layer.mWiFiPAFTransport = mOriginalTransport;
+        ChipLogProgress(AppServer, "ProxyPafDelegate: uninstalled");
+    }
+    mOriginalTransport = nullptr;
+}
+
+CHIP_ERROR CommissioningProxyPafTransport::ProxyPafDelegate::WiFiPAFMessageReceived(WiFiPAF::WiFiPAFSession & rxInfo,
+                                                                                    System::PacketBufferHandle && msg)
+{
+    if (SessionSlot * slot = mOwner.FindSlotByPeer(rxInfo.peer_id))
+    {
+        // DispatchMessageResponse copies the payload into the IM ProxyMessageResponse
+        // synchronously, so msg can be released when this scope returns.
+        if (mOwner.mHost != nullptr)
+        {
+            mOwner.mHost->Sessions().DispatchMessageResponse(slot->sessionId, msg->Start(), msg->DataLength());
+        }
+        return CHIP_NO_ERROR;
+    }
+    if (mOriginalTransport != nullptr)
+    {
+        return mOriginalTransport->WiFiPAFMessageReceived(rxInfo, std::move(msg));
+    }
+    ChipLogError(AppServer, "ProxyPafDelegate: no original transport for non-proxy session");
+    return CHIP_ERROR_INCORRECT_STATE;
+}
+
+CHIP_ERROR CommissioningProxyPafTransport::ProxyPafDelegate::WiFiPAFMessageSend(WiFiPAF::WiFiPAFSession & txInfo,
+                                                                                System::PacketBufferHandle && msg)
+{
+    if (mOriginalTransport != nullptr)
+    {
+        return mOriginalTransport->WiFiPAFMessageSend(txInfo, std::move(msg));
+    }
+    return CHIP_ERROR_INCORRECT_STATE;
+}
+
+CHIP_ERROR CommissioningProxyPafTransport::ProxyPafDelegate::WiFiPAFCloseSession(WiFiPAF::WiFiPAFSession & sessionInfo)
+{
+    // The PAF session closed on its own — e.g. the ED dropped NAN when ConnectNetwork
+    // switched it to infrastructure Wi-Fi, so the PAFTP ack-received timer fired and the
+    // layer is closing the session here. There is no ProxyDisconnectRequest, so this
+    // handler runs the same teardown the cluster would on disconnect: fail any in-flight
+    // ProxyMessage, drop the session, terminate the NAN subscribe, and resume a
+    // background scan that was paused for the connect. (Mirrors the BLE transport's
+    // OnEndPointConnectionClosed handler.)
+    if (SessionSlot * slot = mOwner.FindSlotByPeer(sessionInfo.peer_id))
+    {
+        const uint16_t sid                 = slot->sessionId;
+        WiFiPAF::WiFiPAFSession pafSession = slot->pafSession;
+
+        ChipLogError(AppServer, "WiFiPAFCloseSession: PAF session for proxy session %u closed by peer — cleaning up", sid);
+
+        // Free the slot before notifying, so a re-entrant callback cannot find it.
+        *slot = SessionSlot{};
+
+        // Resolve any in-flight ProxyMessageRequest so the commissioner gets a timely
+        // error instead of waiting out its 30 s timeout.
+        if (mOwner.mHost != nullptr)
+        {
+            mOwner.mHost->Sessions().DispatchMessageFailure(sid, Status::Failure);
+        }
+
+        WiFiPAF::WiFiPAFLayer & layer = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
+        LogErrorOnFailure(layer.RmPafSession(WiFiPAF::PafInfoAccess::kAccSessionId, pafSession));
+        // Terminate the NAN subscribe (for a subscriber session the WiFiPAFSession id IS
+        // the subscribe_id) so it does not linger in wpa_supplicant — the same leak the
+        // ProxyDisconnect path guards against. Do NOT CloseEndPoint here: the layer is
+        // already closing the endpoint, which is why we were called.
+        if (pafSession.id != 0)
+        {
+            (void) DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(pafSession.id);
+        }
+        if (mOwner.mHost != nullptr)
+        {
+            mOwner.mHost->Sessions().RemoveSession(sid);
+
+            // The cluster owns this decision: it can see the sessions of every transport.
+            mOwner.mHost->SetDisconnectedIfLastSession();
+        }
+
+        // This path does not run through the cluster's OnAllSessionsClosed(), so resume a
+        // background scan paused for the connect once the last session is gone and no
+        // connect is mid-flight.
+        if (!mOwner.AnySessionOpen() && !mOwner.mPendingConnect.has_value())
+        {
+            mOwner.OnAllSessionsClosed();
+        }
+    }
+    if (mOriginalTransport != nullptr)
+    {
+        return mOriginalTransport->WiFiPAFCloseSession(sessionInfo);
+    }
+    return CHIP_NO_ERROR;
+}
+
+bool CommissioningProxyPafTransport::ProxyPafDelegate::WiFiPAFResourceAvailable()
+{
+    if (mOriginalTransport != nullptr)
+    {
+        return mOriginalTransport->WiFiPAFResourceAvailable();
+    }
+    return true;
+}
+
+// ==================================================================
+// Background-scan hardware hooks
+// ==================================================================
+
+CHIP_ERROR CommissioningProxyPafTransport::BgScanHardware::StartHardwareScan()
+{
+    if (mOwner.mPendingConnect.has_value())
+    {
+        // A ProxyConnect owns the single NAN subscribe slot; defer.
+        return CHIP_ERROR_BUSY;
+    }
+    return mOwner.mAdapter.StartBackgroundScan(HandleBackgroundScanResult, &mOwner);
+}
+
+void CommissioningProxyPafTransport::BgScanHardware::StopHardwareScan()
+{
+    mOwner.mAdapter.StopBackgroundScan();
+}
+
+void CommissioningProxyPafTransport::BgScanHardware::ClearCachedResults(BitMask<WiFiBandBitmap> bands)
+{
+    // bands == 0 means the transport itself stopped; otherwise only those bands did, and
+    // only their results go. PAFTP results are the only ones carrying a band.
+    if (mOwner.mHost != nullptr)
+    {
+        mOwner.mHost->ScanCache().ClearTransport(CapabilitiesBitmap::kWiFiPAF, bands);
+    }
+}
+
+// ==================================================================
+// Adapter discovery callbacks
+// ==================================================================
+
+void CommissioningProxyPafTransport::HandleBackgroundScanResult(void * context, ByteSpan address, uint16_t discriminator,
+                                                                uint16_t vendorId, uint16_t productId, ByteSpan extendedData,
+                                                                uint16_t wiFiBand)
+{
+    auto * self = static_cast<CommissioningProxyPafTransport *>(context);
+    // Result cache, TTL and the combined MaxCachedResults cap all live in the cluster's
+    // scan cache; this just builds the kWiFiPAF result and reports it.
+    if (self != nullptr && self->mHost != nullptr)
+    {
+        self->mHost->ScanCache().Report(MakeScanResult(address, discriminator, vendorId, productId, extendedData, wiFiBand));
+    }
+}
+
+void CommissioningProxyPafTransport::HandleForegroundScanResult(void * context, ByteSpan address, uint16_t discriminator,
+                                                                uint16_t vendorId, uint16_t productId, ByteSpan extendedData,
+                                                                uint16_t wiFiBand)
+{
+    auto * self = static_cast<CommissioningProxyPafTransport *>(context);
+    VerifyOrReturn(self != nullptr);
+
+    // ProxyScanResponse spec rule (CommissioningProxy.adoc, ProxyScanResult field):
+    // "Each found device SHALL be reported once based on discriminator/VendorID/
+    // ProductID per transport." Transport is fixed to kWiFiPAF here, so dedupe on the
+    // remaining three.
+    for (size_t i = 0; i < self->mScanResultCount; i++)
+    {
+        const ScanRecord & existing = self->mScanResults[i];
+        if (existing.discriminator == discriminator && existing.vendorId == vendorId && existing.productId == productId)
+        {
+            return;
+        }
+    }
+
+    // Bounded at insert rather than truncated at emit: the store is exactly
+    // MaxCachedResults deep, which is also the cap the ProxyScanResponse must respect.
+    if (self->mScanResultCount >= kMaxScanResults)
+    {
+        ChipLogProgress(AppServer, "Paf::Scan: result store full (%u); dropping discriminator=%u",
+                        static_cast<unsigned>(kMaxScanResults), discriminator);
+        return;
+    }
+
+    ScanRecord & r = self->mScanResults[self->mScanResultCount];
+    r              = ScanRecord{};
+    // Copy the variable-length fields: the adapter's spans die when this returns, while
+    // the record lives until the scan completes.
+    if (!address.empty() && address.size() <= sizeof(r.address))
+    {
+        memcpy(r.address, address.data(), address.size());
+        r.addressLen = static_cast<uint8_t>(address.size());
+    }
+    if (!extendedData.empty() && extendedData.size() <= sizeof(r.extendedData))
+    {
+        memcpy(r.extendedData, extendedData.data(), extendedData.size());
+        r.extendedDataLen = static_cast<uint8_t>(extendedData.size());
+    }
+    else if (extendedData.size() > sizeof(r.extendedData))
+    {
+        // Dropped rather than truncated: a partial blob reported as complete would be
+        // worse than none. The device itself is still reported.
+        ChipLogProgress(AppServer, "Paf::Scan: discriminator=%u ExtendedData is %u bytes, max %u - omitting it", discriminator,
+                        static_cast<unsigned>(extendedData.size()), static_cast<unsigned>(sizeof(r.extendedData)));
+    }
+    r.discriminator = discriminator;
+    r.vendorId      = vendorId;
+    r.productId     = productId;
+    r.wiFiBand      = wiFiBand;
+    self->mScanResultCount++;
+
+    ChipLogProgress(AppServer, "Paf::Scan: discovered discriminator=%u vid=0x%04x pid=0x%04x band=%u", discriminator, vendorId,
+                    productId, wiFiBand);
+}
+
+void CommissioningProxyPafTransport::HandleForegroundScanDone(void * context)
+{
+    auto * self = static_cast<CommissioningProxyPafTransport *>(context);
+    VerifyOrReturn(self != nullptr);
+
+    self->mScanInProgress = false;
+
+    // Hand the results to the cluster's scan aggregator; it owns the command handle and
+    // emits the combined ProxyScanResponse once every transport's sub-scan has reported.
+    if (self->mHost != nullptr)
+    {
+        // Clamp to the cluster's advertised cap as well as the store's own bound, so the
+        // aggregator's numberOfResults field (uint8_t) cannot overflow even if the two
+        // ever diverge.
+        const size_t count = std::min<size_t>(self->mScanResultCount, self->mHost->GetMaxCachedResults());
+        ScanResultT out[kMaxScanResults];
+        for (size_t i = 0; i < count; i++)
+        {
+            const ScanRecord & d = self->mScanResults[i];
+            out[i]               = MakeScanResult(ByteSpan(d.address, d.addressLen), d.discriminator, d.vendorId, d.productId,
+                                                  ByteSpan(d.extendedData, d.extendedDataLen), d.wiFiBand);
+        }
+        self->mHost->ScanAggregator().Contribute(Span<const ScanResultT>(out, count));
+    }
+    self->mScanResultCount = 0;
+
+    // The one-shot scan has released the NAN subscribe slot; resume a background scan
+    // that was paused to make room for it.
+    self->OnAllSessionsClosed();
+}
+
+// ==================================================================
+// Connect
+// ==================================================================
+
+void CommissioningProxyPafTransport::RemovePafSessionAndCloseEndpoint(uint16_t discriminator)
+{
+    WiFiPAF::WiFiPAFLayer & pafLayer = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
+    WiFiPAF::WiFiPAFSession key{};
+    key.discriminator = discriminator;
+
+    // Capture the session before RmPafSession clears the slot so we can close any PAFTP
+    // endpoint the handshake created; otherwise it leaks from the 2-slot pool until its
+    // own timer self-closes. CloseEndPoint is a no-op if there is none.
+    WiFiPAF::WiFiPAFSession endpointSession{};
+    bool haveEndpoint               = false;
+    WiFiPAF::WiFiPAFSession * pInfo = pafLayer.GetPAFInfo(WiFiPAF::PafInfoAccess::kAccDisc, key);
+    if (pInfo != nullptr)
+    {
+        endpointSession = *pInfo;
+        haveEndpoint    = true;
+    }
+
+    CHIP_ERROR rmErr = pafLayer.RmPafSession(WiFiPAF::PafInfoAccess::kAccDisc, key);
+    if (rmErr != CHIP_NO_ERROR)
+    {
+        ChipLogDetail(AppServer, "RemovePafSessionAndCloseEndpoint: RmPafSession: %" CHIP_ERROR_FORMAT, rmErr.Format());
+    }
+    if (haveEndpoint)
+    {
+        pafLayer.CloseEndPoint(endpointSession);
+    }
+}
+
+void CommissioningProxyPafTransport::FailPendingConnect(Status status, bool cancelTimer)
+{
+    // Every caller has already verified a connect is pending; the check is repeated here
+    // because bugprone-unchecked-optional-access does not reason across functions, and
+    // the dereference below would otherwise fail the clang-tidy gate.
+    VerifyOrReturn(mPendingConnect.has_value());
+
+    if (cancelTimer)
+    {
+        mTimerDelegate.CancelTimer(&mConnectTimer);
+    }
+
+    // Move out and reset before answering, so a re-entrant callback sees no pending
+    // connect.
+    ConnectCtx ctx = std::move(*mPendingConnect);
+    mPendingConnect.reset();
+
+    // Null the platform connect callbacks before cancelling the subscribe so the
+    // cancel-connect event posted by the platform does not re-enter HandleConnectError.
+    CHIP_ERROR cancelIncompleteErr = DeviceLayer::ConnectivityMgr().WiFiPAFCancelIncompleteSubscribe();
+    if (cancelIncompleteErr != CHIP_NO_ERROR)
+    {
+        ChipLogDetail(AppServer, "FailPendingConnect: WiFiPAFCancelIncompleteSubscribe: %" CHIP_ERROR_FORMAT,
+                      cancelIncompleteErr.Format());
+    }
+
+    RemovePafSessionAndCloseEndpoint(ctx.discriminator);
+
+    if (ctx.subscribeId != 0)
+    {
+        CHIP_ERROR cancelErr = DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(ctx.subscribeId);
+        if (cancelErr != CHIP_NO_ERROR)
+        {
+            ChipLogDetail(AppServer, "FailPendingConnect: WiFiPAFCancelSubscribe(%u): %" CHIP_ERROR_FORMAT, ctx.subscribeId,
+                          cancelErr.Format());
+        }
+    }
+
+    if (app::CommandHandler * cmd = ctx.handle.Get())
+    {
+        cmd->AddStatus(ctx.path, status);
+    }
+
+    // The connect freed the NAN subscribe slot; resume a background scan that was
+    // deferred or paused for it (a failed connect registers no session, so the cluster's
+    // OnAllSessionsClosed path does not run).
+    OnAllSessionsClosed();
+}
+
+void CommissioningProxyPafTransport::OnConnectTimeout()
+{
+    if (!mPendingConnect.has_value())
+    {
+        return; // Success or error callback already fired first; nothing to do.
+    }
+    ChipLogError(AppServer, "ProxyConnectRequest: timeout waiting for WiFiPAF connect (disc %u)", mPendingConnect->discriminator);
+    FailPendingConnect(Status::Timeout, /*cancelTimer=*/false);
+}
+
+void CommissioningProxyPafTransport::HandleConnectSuccess(void * context)
+{
+    auto * self = static_cast<CommissioningProxyPafTransport *>(context);
+    VerifyOrReturn(self != nullptr);
+
+    if (!self->mPendingConnect.has_value())
+    {
+        ChipLogProgress(AppServer, "OnConnectSuccess: no pending connect ctx; ignoring stale callback");
+        return;
+    }
+    self->mTimerDelegate.CancelTimer(&self->mConnectTimer);
+
+    const uint16_t discriminator = self->mPendingConnect->discriminator;
+
+    WiFiPAF::WiFiPAFSession keyInfo{};
+    keyInfo.discriminator              = discriminator;
+    WiFiPAF::WiFiPAFLayer & layer      = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
+    WiFiPAF::WiFiPAFSession * pPafInfo = layer.GetPAFInfo(WiFiPAF::PafInfoAccess::kAccDisc, keyInfo);
+
+    app::CommandHandler * cmd = self->mPendingConnect->handle.Get();
+    if (cmd == nullptr || pPafInfo == nullptr)
+    {
+        ChipLogError(AppServer, "OnConnectSuccess: cmd=%p pPafInfo=%p for disc %u", (void *) cmd, (void *) pPafInfo, discriminator);
+        // The connect completed but the session cannot be handed to the commissioner
+        // (originating exchange gone, or the PAF session vanished). Run the full teardown
+        // so an established-but-untracked session does not leak its PAF pool slot, PAFTP
+        // endpoint and NAN subscribe. The timeout timer was already cancelled above.
+        self->FailPendingConnect(Status::Failure, /*cancelTimer=*/false);
+        return;
+    }
+
+    if (self->mPendingConnect->cluster == nullptr)
+    {
+        ChipLogError(AppServer, "OnConnectSuccess: cluster gone at connect complete; tearing down PAF session");
+        self->FailPendingConnect(Status::Failure, /*cancelTimer=*/false);
+        return;
+    }
+
+    SessionSlot * slot = self->ClaimSlot();
+    if (slot == nullptr)
+    {
+        // The cluster's MaxSessions gate should have rejected the ProxyConnectRequest
+        // before it reached the driver, so this means the two disagree.
+        ChipLogError(AppServer, "OnConnectSuccess: no free session slot; tearing down PAF session");
+        self->FailPendingConnect(Status::ResourceExhausted, /*cancelTimer=*/false);
+        return;
+    }
+
+    ConnectCtx ctx = std::move(*self->mPendingConnect);
+    self->mPendingConnect.reset();
+
+    const uint16_t sessionId = ctx.cluster->Sessions().AllocSessionId();
+    slot->inUse              = true;
+    slot->sessionId          = sessionId;
+    slot->pafSession         = *pPafInfo;
+    ctx.cluster->Sessions().RegisterSession(sessionId, CapabilitiesBitmap::kWiFiPAF, ctx.fabricIndex);
+
+    ChipLogProgress(AppServer, "ProxyConnectRequest: WiFiPAF connected, proxy session %u (disc %u peer_id %u)", sessionId,
+                    ctx.discriminator, pPafInfo->peer_id);
+
+    CHIP_ERROR stateErr = ctx.cluster->SetCPState(CommissioningProxyCluster::kState_CPConnected);
+    if (stateErr != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "OnConnectSuccess: SetCPState failed: %" CHIP_ERROR_FORMAT, stateErr.Format());
+    }
+
+    Commands::ProxyConnectResponse::Type response;
+    response.sessionID = sessionId;
+    cmd->AddResponse(ctx.path, response);
+}
+
+void CommissioningProxyPafTransport::HandleConnectError(void * context, CHIP_ERROR err)
+{
+    auto * self = static_cast<CommissioningProxyPafTransport *>(context);
+    VerifyOrReturn(self != nullptr);
+
+    if (!self->mPendingConnect.has_value())
+    {
+        ChipLogProgress(AppServer,
+                        "OnConnectError: ignoring stale callback after successful connect "
+                        "(err: %" CHIP_ERROR_FORMAT ")",
+                        err.Format());
+        return;
+    }
+    ChipLogError(AppServer, "ProxyConnectRequest: WiFiPAF connect failed: %" CHIP_ERROR_FORMAT, err.Format());
+    self->FailPendingConnect(Status::Failure, /*cancelTimer=*/true);
+}
+
+// ==================================================================
+// CommissioningProxyTransport
+// ==================================================================
+
+void CommissioningProxyPafTransport::SetHost(CommissioningProxyCluster * host)
+{
+    mHost = host;
+}
+
+Status CommissioningProxyPafTransport::Connect(app::CommandHandler * commandObj, const DataModel::InvokeRequest & request,
+                                               uint16_t discriminator, System::Clock::Seconds16 timeout)
+{
+    // Only one PAF connect can be in flight at a time. Reject a second one up front,
+    // before pausing the background scan or touching the PAF session pool, so a refused
+    // connect leaves no side effects behind.
+    if (mPendingConnect.has_value())
+    {
+        ChipLogError(AppServer, "ProxyConnectRequest: a PAF connect is already in progress");
+        return Status::Busy;
+    }
+
+    // Pause any background scan so the NAN subscribe slot can be reused for the PAF
+    // connect subscribe; the registry resumes it on OnAllSessionsClosed().
+    mBgScan.Pause();
+
+    // The WiFiPAF layer is initialized once by the platform ConnectivityManager at
+    // startup. Do NOT call Init() here: it memset()s the shared endpoint pool, which
+    // would wipe a live PAFTP session while leaving its scheduled ack/retransmit timers
+    // pointing at the zeroed slot.
+
+    // Install the proxy receive delegate so messages arriving from the commissionee over
+    // WiFiPAF are forwarded to the commissioner as ProxyMessageResponse rather than being
+    // injected into the application's own Matter transport stack.
+    mProxyDelegate.Install();
+
+    // Register a PAF session so the platform's discovery result can locate the right
+    // entry by discriminator.
+    WiFiPAF::WiFiPAFSession pafSessionInfo{};
+    pafSessionInfo.role          = WiFiPAF::kWiFiPafRole_Subscriber;
+    pafSessionInfo.discriminator = discriminator;
+    CHIP_ERROR addErr = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().AddPafSession(WiFiPAF::PafInfoAccess::kAccDisc, pafSessionInfo);
+    if (addErr != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "ProxyConnectRequest: AddPafSession failed: %" CHIP_ERROR_FORMAT, addErr.Format());
+        OnAllSessionsClosed();
+        return (addErr == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED) ? Status::ResourceExhausted : Status::Failure;
+    }
+
+    // Per spec a Timeout of 0 indicates no timeout: the connect runs until it succeeds,
+    // fails, or is cancelled via ProxyDisconnectRequest(null).
+    const bool hasTimeout = (timeout.count() > 0);
+
+    ConnectCtx & ctx  = mPendingConnect.emplace();
+    ctx.handle        = app::CommandHandler::Handle(commandObj);
+    ctx.path          = request.path;
+    ctx.discriminator = discriminator;
+    ctx.subscribeId   = 0;
+    ctx.cluster       = mHost;
+    ctx.fabricIndex   = request.subjectDescriptor.fabricIndex;
+    commandObj->FlushAcksRightAwayOnSlowCommand();
+
+    if (auto * exchange = commandObj->GetExchangeContext())
+    {
+        // Keep the exchange open until just past the connect timeout, or disable the
+        // response timer entirely (kZero) when there is no timeout. Clamp the +5 s margin
+        // so a near-max timeout cannot wrap the uint16 seconds field.
+        const uint16_t timeoutSecs = timeout.count();
+        const uint16_t responseSecs =
+            (timeoutSecs > static_cast<uint16_t>(0xFFFF - 5)) ? 0xFFFF : static_cast<uint16_t>(timeoutSecs + 5);
+        exchange->SetResponseTimeout(hasTimeout ? System::Clock::Seconds16(responseSecs) : System::Clock::kZero);
+    }
+
+    CHIP_ERROR err = DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, this, HandleConnectSuccess, HandleConnectError);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "ProxyConnectRequest: WiFiPAFSubscribe failed: %" CHIP_ERROR_FORMAT, err.Format());
+        CHIP_ERROR rmErr = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().RmPafSession(WiFiPAF::PafInfoAccess::kAccDisc, pafSessionInfo);
+        if (rmErr != CHIP_NO_ERROR)
+        {
+            ChipLogDetail(AppServer, "ProxyConnectRequest cleanup: RmPafSession: %" CHIP_ERROR_FORMAT, rmErr.Format());
+        }
+        mPendingConnect.reset();
+        OnAllSessionsClosed();
+        return Status::Failure;
+    }
+
+    // WiFiPAFSubscribe does not return the id the platform assigned, so recover it from
+    // the adapter; the transport needs it to cancel this specific subscribe.
+    mPendingConnect->subscribeId = mAdapter.PendingConnectSubscribeId();
+
+    if (hasTimeout)
+    {
+        CHIP_ERROR timerErr = mTimerDelegate.StartTimer(&mConnectTimer, timeout);
+        if (timerErr != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "ProxyConnectRequest: StartTimer failed: %" CHIP_ERROR_FORMAT, timerErr.Format());
+            CHIP_ERROR rmErr2 =
+                WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().RmPafSession(WiFiPAF::PafInfoAccess::kAccDisc, pafSessionInfo);
+            if (rmErr2 != CHIP_NO_ERROR)
+            {
+                ChipLogDetail(AppServer, "ProxyConnectRequest cleanup: RmPafSession: %" CHIP_ERROR_FORMAT, rmErr2.Format());
+            }
+            if (mPendingConnect->subscribeId != 0)
+            {
+                (void) DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(mPendingConnect->subscribeId);
+            }
+            mPendingConnect.reset();
+            OnAllSessionsClosed();
+            return Status::Failure;
+        }
+    }
+
+    ChipLogProgress(AppServer, "ProxyConnectRequest: WiFiPAFSubscribe started for discriminator %u (subscribe_id %u)",
+                    discriminator, mPendingConnect->subscribeId);
+
+    return Status::Success;
+}
+
+Status CommissioningProxyPafTransport::CancelPendingConnect(FabricIndex fabricIndex)
+{
+    if (!mPendingConnect.has_value())
+    {
+        return Status::InvalidInState;
+    }
+
+    if (fabricIndex != mPendingConnect->fabricIndex)
+    {
+        ChipLogProgress(AppServer, "CancelPendingConnect: pending PAF connect owned by fabric %u, rejected fabric %u",
+                        mPendingConnect->fabricIndex, fabricIndex);
+        return Status::NotFound;
+    }
+
+    ChipLogProgress(AppServer, "CancelPendingConnect: cancelling pending PAF connect for fabric %u", fabricIndex);
+    FailPendingConnect(Status::Failure, /*cancelTimer=*/true);
+
+    return Status::Success;
+}
+
+Status CommissioningProxyPafTransport::Disconnect(uint16_t sessionId)
+{
+    SessionSlot * slot = FindSlot(sessionId);
+    if (slot == nullptr)
+    {
+        return Status::NotFound;
+    }
+
+    WiFiPAF::WiFiPAFSession pafSession = slot->pafSession;
+    *slot                              = SessionSlot{};
+
+    CHIP_ERROR rmErr = WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().RmPafSession(WiFiPAF::PafInfoAccess::kAccSessionId, pafSession);
+    if (rmErr != CHIP_NO_ERROR)
+    {
+        ChipLogDetail(AppServer, "ProxyDisconnectRequest: RmPafSession for session %u: %" CHIP_ERROR_FORMAT, sessionId,
+                      rmErr.Format());
+    }
+
+    // Explicitly close the PAFTP endpoint so its ack-received timer does not fire 30 s
+    // later.
+    WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().CloseEndPoint(pafSession);
+
+    // Terminate the NAN subscribe instance that backed this session. For a subscriber
+    // session the WiFiPAFSession id IS the wpa_supplicant subscribe_id, so cancelling it
+    // tears down the PAFTP session. Without this the subscribe is left registered in the
+    // long-lived wpa_supplicant and keeps firing discovery callbacks for the rest of the
+    // proxy's lifetime.
+    if (pafSession.id != 0)
+    {
+        CHIP_ERROR cancelErr = DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(pafSession.id);
+        if (cancelErr != CHIP_NO_ERROR)
+        {
+            ChipLogDetail(AppServer, "ProxyDisconnectRequest: WiFiPAFCancelSubscribe(%u): %" CHIP_ERROR_FORMAT, pafSession.id,
+                          cancelErr.Format());
+        }
+    }
+
+    return Status::Success;
+}
+
+CHIP_ERROR CommissioningProxyPafTransport::SendMessage(uint16_t sessionId, System::PacketBufferHandle && buf)
+{
+    SessionSlot * slot = FindSlot(sessionId);
+    if (slot == nullptr)
+    {
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+    // MUST use WiFiPAFLayer::SendMessage (not the platform's raw WiFiPAFSend):
+    // WiFiPAFSend is the low-level NAN transmit used internally by PAFTP; calling it
+    // directly bypasses PAFTP framing and the end device cannot parse the frame.
+    // SendMessage goes through the PAFTP endpoint, which fragments and frames the
+    // message before calling WiFiPAFSend.
+    return WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().SendMessage(slot->pafSession, std::move(buf));
+}
+
+Status CommissioningProxyPafTransport::Scan(System::Clock::Seconds16 scanMaxTime)
+{
+    if (mScanInProgress)
+    {
+        ChipLogProgress(AppServer, "ProxyScanRequest: PAF scan already in progress — returning Busy");
+        return Status::Busy;
+    }
+
+    // The one-shot scan and the background scan share the single NAN subscribe slot.
+    // Pause any running background scan so the scan below does not fail with BUSY; the
+    // scan-done callback resumes it when the foreground scan completes.
+    mBgScan.Pause();
+
+    mScanResultCount = 0;
+    mScanInProgress  = true;
+
+    // The platform owns the scan window here, so unlike BLE there is no timer to arm:
+    // HandleForegroundScanDone closes the scan out.
+    CHIP_ERROR err = mAdapter.StartForegroundScan(scanMaxTime, HandleForegroundScanResult, HandleForegroundScanDone, this);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "Paf::Scan: StartForegroundScan failed: %" CHIP_ERROR_FORMAT, err.Format());
+        mScanInProgress = false;
+        OnAllSessionsClosed();
+        return Status::Failure;
+    }
+
+    ChipLogProgress(AppServer, "Paf::Scan: started, scanMaxTime=%us", scanMaxTime.count());
+    return Status::Success;
+}
+
+Status CommissioningProxyPafTransport::BgScanStart(System::Clock::Seconds16 timeout, BitMask<WiFiBandBitmap> wiFiBands,
+                                                   FabricIndex fabricIndex, NodeId nodeId)
+{
+    // This driver services the kWiFiPAF transport. The registry starts or defers the
+    // hardware scan (StartHardwareScan reports BUSY while a ProxyConnect holds the single
+    // NAN subscribe slot) and records the requested bands per fabric.
+    return mBgScan.Start(fabricIndex, nodeId, BitMask<CapabilitiesBitmap>(CapabilitiesBitmap::kWiFiPAF), wiFiBands, timeout);
+}
+
+Status CommissioningProxyPafTransport::BgScanStop(BitMask<CapabilitiesBitmap> transport, BitMask<WiFiBandBitmap> wiFiBands,
+                                                  FabricIndex fabricIndex, NodeId nodeId)
+{
+    // The registry applies the spec transport/band overlap semantics (NOT_FOUND for an
+    // unknown fabric, SUCCESS for a non-overlapping request, keep-scanning while any
+    // fabric still covers the transport, stop+clear on the last fabric).
+    return mBgScan.Stop(fabricIndex, nodeId, transport, wiFiBands);
+}
+
+void CommissioningProxyPafTransport::OnFabricRemoved(FabricIndex fabricIndex)
+{
+    // The cluster has already dropped the fabric's sessions; this drops its background
+    // scans so nothing survives into a reused FabricIndex.
+    mBgScan.RemoveFabric(fabricIndex);
+}
+
+void CommissioningProxyPafTransport::OnAllSessionsClosed()
+{
+    if (mBgScan.IsPaused() && !mBgScan.IsEmpty())
+    {
+        // Zero delay: still dispatched from the event loop rather than inline, but
+        // cancellable in Shutdown() so it cannot fire against a destroyed transport. The
+        // registry re-checks whether a connect is now pending and stays paused if so.
+        mTimerDelegate.CancelTimer(&mResumeBgScanTimer);
+        CHIP_ERROR err = mTimerDelegate.StartTimer(&mResumeBgScanTimer, System::Clock::Timeout(0));
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "OnAllSessionsClosed: could not defer bg-scan resume: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+    }
+}
+
+bool CommissioningProxyPafTransport::IsConnectPending() const
+{
+    return mPendingConnect.has_value();
+}
+
+void CommissioningProxyPafTransport::Shutdown()
+{
+    // Close any active PAF sessions: fail in-flight messages, close PAFTP endpoints,
+    // cancel NAN subscribes, and remove them from the cluster's session manager. Take the
+    // sessions out first so the slots are free if a close fires a callback synchronously.
+    WiFiPAF::WiFiPAFSession closing[kMaxSessions] = {};
+    uint16_t closingIds[kMaxSessions]             = {};
+    size_t closingCount                           = 0;
+    for (auto & slot : mSessions)
+    {
+        if (slot.inUse)
+        {
+            closingIds[closingCount] = slot.sessionId;
+            closing[closingCount]    = slot.pafSession;
+            closingCount++;
+        }
+        slot = SessionSlot{};
+    }
+    for (size_t i = 0; i < closingCount; i++)
+    {
+        if (mHost != nullptr)
+        {
+            mHost->Sessions().DispatchMessageFailure(closingIds[i], Status::Failure);
+            mHost->Sessions().RemoveSession(closingIds[i]);
+        }
+        LogErrorOnFailure(WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().RmPafSession(WiFiPAF::PafInfoAccess::kAccSessionId, closing[i]));
+        WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().CloseEndPoint(closing[i]);
+        if (closing[i].id != 0)
+        {
+            (void) DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(closing[i].id);
+        }
+    }
+
+    // Detach an in-flight foreground scan so its completion cannot reach this object
+    // after it is gone; the platform may keep scanning, but nothing is reported.
+    mAdapter.StopForegroundScan();
+    mScanInProgress  = false;
+    mScanResultCount = 0;
+
+    // Drop the deferred bg-scan resume, or it fires against a destroyed transport.
+    mTimerDelegate.CancelTimer(&mResumeBgScanTimer);
+
+    // Tear down an in-flight ProxyConnect: cancel its timeout timer and the NAN
+    // subscribe, and drop the PAF session, so nothing outlives the cluster. Do not call
+    // FailPendingConnect() here — it would invoke OnAllSessionsClosed(), which would
+    // schedule a scan restart just as the cleanup below stops everything.
+    if (mPendingConnect.has_value())
+    {
+        mTimerDelegate.CancelTimer(&mConnectTimer);
+
+        ConnectCtx ctx = std::move(*mPendingConnect);
+        mPendingConnect.reset();
+
+        (void) DeviceLayer::ConnectivityMgr().WiFiPAFCancelIncompleteSubscribe();
+        if (ctx.subscribeId != 0)
+        {
+            (void) DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(ctx.subscribeId);
+        }
+
+        RemovePafSessionAndCloseEndpoint(ctx.discriminator);
+
+        if (app::CommandHandler * cmd = ctx.handle.Get())
+        {
+            cmd->AddStatus(ctx.path, Status::Failure);
+        }
+    }
+
+    // Tear down the background scan: cancel every per-fabric lifetime timer and stop the
+    // hardware scan if the registry currently owns it.
+    mBgScan.Shutdown();
+
+    // Restore WiFiPAFLayer::mWiFiPAFTransport so a later PAF event reaches the
+    // application's own delegate rather than this object after the cluster is gone.
+    mProxyDelegate.Uninstall();
+
+    // Last: the cluster is going away, so drop the pointer to it. Every callback above
+    // null-checks mHost.
+    mHost = nullptr;
+}
+
+} // namespace CommissioningProxy
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/commissioning-proxy-server/CommissioningProxyPafTransport.h
+++ b/src/app/clusters/commissioning-proxy-server/CommissioningProxyPafTransport.h
@@ -1,0 +1,272 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/CommandHandler.h>
+#include <app/ConcreteCommandPath.h>
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyBgScanRegistry.h>
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyPafAdapter.h>
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyScanCache.h>
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyTransport.h>
+#include <app/data-model-provider/OperationTypes.h>
+#include <clusters/CommissioningProxy/Enums.h>
+#include <clusters/CommissioningProxy/Structs.h>
+#include <credentials/FabricTable.h>
+#include <lib/core/CHIPConfig.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/BitMask.h>
+#include <lib/support/TimerDelegate.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <protocols/interaction_model/StatusCode.h>
+#include <system/SystemClock.h>
+#include <system/SystemPacketBuffer.h>
+#include <wifipaf/WiFiPAFLayerDelegate.h>
+#include <wifipaf/WiFiPAFRole.h>
+
+#include <cstdint>
+#include <optional>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace CommissioningProxy {
+
+/**
+ * @brief Wi-Fi PAF (PAFTP) transport driver for the Commissioning Proxy cluster.
+ *
+ * Implements the connect / relay / disconnect flow over chip::WiFiPAF: it drives the
+ * NAN subscribe and PAFTP session against a commissionee, keeps the
+ * sessionId -> WiFiPAFSession mapping, and relays ProxyMessage payloads. All
+ * transport-agnostic bookkeeping — session allocation, ProxyMessage routing, the scan
+ * cache and multi-transport scan aggregation — belongs to the host cluster and is
+ * reached through its subsystem accessors.
+ *
+ * Discovery has no portable form, so scanning and the platform's subscribe id come from
+ * the injected CommissioningProxyPafAdapter; nothing here includes a platform header.
+ *
+ * Not copyable and not relocatable once started: it hands @c this to the WiFiPAF layer,
+ * to the adapter, and to the timer delegate as an opaque context.
+ */
+class CommissioningProxyPafTransport : public CommissioningProxyTransport
+{
+public:
+    /**
+     * @param adapter        platform PAF discovery hooks; must outlive this transport.
+     * @param timerDelegate  drives the connect timeout, and is handed to the
+     *                       background-scan registry.
+     */
+    CommissioningProxyPafTransport(CommissioningProxyPafAdapter & adapter, TimerDelegate & timerDelegate);
+    ~CommissioningProxyPafTransport() override;
+
+    CommissioningProxyPafTransport(const CommissioningProxyPafTransport &)             = delete;
+    CommissioningProxyPafTransport & operator=(const CommissioningProxyPafTransport &) = delete;
+
+    CapabilitiesBitmap GetTransportType() const override { return CapabilitiesBitmap::kWiFiPAF; }
+    void SetHost(CommissioningProxyCluster * host) override;
+
+    Protocols::InteractionModel::Status Connect(app::CommandHandler * commandObj, const DataModel::InvokeRequest & request,
+                                                uint16_t discriminator, System::Clock::Seconds16 timeout) override;
+    Protocols::InteractionModel::Status CancelPendingConnect(FabricIndex fabricIndex) override;
+    Protocols::InteractionModel::Status Disconnect(uint16_t sessionId) override;
+    CHIP_ERROR SendMessage(uint16_t sessionId, System::PacketBufferHandle && buf) override;
+    Protocols::InteractionModel::Status Scan(System::Clock::Seconds16 scanMaxTime) override;
+    Protocols::InteractionModel::Status BgScanStart(System::Clock::Seconds16 timeout, BitMask<WiFiBandBitmap> wiFiBands,
+                                                    FabricIndex fabricIndex, NodeId nodeId) override;
+    Protocols::InteractionModel::Status BgScanStop(BitMask<CapabilitiesBitmap> transport, BitMask<WiFiBandBitmap> wiFiBands,
+                                                   FabricIndex fabricIndex, NodeId nodeId) override;
+    void OnFabricRemoved(FabricIndex fabricIndex) override;
+    void OnAllSessionsClosed() override;
+    bool IsConnectPending() const override;
+    void Shutdown() override;
+
+private:
+    using ScanResultT = Structs::ScanResultStruct::Type;
+
+    static constexpr size_t kMaxSessions    = CHIP_CONFIG_COMMISSIONING_PROXY_MAX_SESSIONS;
+    static constexpr size_t kMaxScanResults = CHIP_CONFIG_COMMISSIONING_PROXY_MAX_CACHED_RESULTS;
+
+    /// Taken from the cache rather than restated, so a result the transport accepts is by
+    /// construction one the cache can also hold.
+    // ScanResultStruct constrains Address to 100 bytes and ExtendedData to 128, so a
+    // scan record holds both inline. Stated here as CommissioningProxyScanAggregator
+    // states them, rather than reaching into another component's bounds.
+    static constexpr size_t kMaxAddressBytes      = 100;
+    static constexpr size_t kMaxExtendedDataBytes = 128;
+
+    /// One live proxy session and the PAF session carrying it. `inUse` false marks a free
+    /// slot, matching the fixed-slot idiom the cluster's own subsystems use.
+    struct SessionSlot
+    {
+        bool inUse                         = false;
+        uint16_t sessionId                 = 0;
+        WiFiPAF::WiFiPAFSession pafSession = {};
+    };
+
+    /// State of the single in-flight ProxyConnectRequest. Held inline (MaxSessions == 1
+    /// makes it unique) rather than heap-allocated.
+    struct ConnectCtx
+    {
+        app::CommandHandler::Handle handle;
+        app::ConcreteCommandPath path;
+        uint16_t discriminator              = 0;
+        uint32_t subscribeId                = 0; ///< NAN subscribe id, from the adapter
+        CommissioningProxyCluster * cluster = nullptr;
+        FabricIndex fabricIndex             = kUndefinedFabricIndex;
+    };
+
+    /// Compact record for foreground-scan dedup, carrying its own copy of the variable
+    /// length fields so nothing points at adapter memory once the callback returns.
+    struct ScanRecord
+    {
+        uint8_t address[kMaxAddressBytes]           = {};
+        uint8_t addressLen                          = 0;
+        uint16_t discriminator                      = 0;
+        uint16_t vendorId                           = 0;
+        uint16_t productId                          = 0;
+        uint8_t extendedData[kMaxExtendedDataBytes] = {};
+        uint8_t extendedDataLen                     = 0;
+        uint16_t wiFiBand                           = 0;
+    };
+
+    /**
+     * Wraps WiFiPAFLayer::mWiFiPAFTransport so PAFTP traffic for proxy sessions is
+     * relayed back to the commissioner, while everything else falls through to the
+     * delegate that was installed before (the application's own PAF commissioning).
+     */
+    class ProxyPafDelegate : public WiFiPAF::WiFiPAFLayerDelegate
+    {
+    public:
+        explicit ProxyPafDelegate(CommissioningProxyPafTransport & owner) : mOwner(owner) {}
+
+        void Install();
+        void Uninstall();
+
+        CHIP_ERROR WiFiPAFMessageReceived(WiFiPAF::WiFiPAFSession & rxInfo, System::PacketBufferHandle && msg) override;
+        CHIP_ERROR WiFiPAFMessageSend(WiFiPAF::WiFiPAFSession & txInfo, System::PacketBufferHandle && msg) override;
+        CHIP_ERROR WiFiPAFCloseSession(WiFiPAF::WiFiPAFSession & sessionInfo) override;
+        bool WiFiPAFResourceAvailable() override;
+
+    private:
+        CommissioningProxyPafTransport & mOwner;
+        WiFiPAF::WiFiPAFLayerDelegate * mOriginalTransport = nullptr;
+    };
+
+    /// Supplies the shared background-scan registry with the PAF start/stop/clear hooks.
+    class BgScanHardware : public CommissioningProxyBgScanRegistry::HardwareControl
+    {
+    public:
+        explicit BgScanHardware(CommissioningProxyPafTransport & owner) : mOwner(owner) {}
+
+        CHIP_ERROR StartHardwareScan() override;
+        void StopHardwareScan() override;
+        void ClearCachedResults(BitMask<WiFiBandBitmap> bands) override;
+
+    private:
+        CommissioningProxyPafTransport & mOwner;
+    };
+
+    class ConnectTimeoutTimer : public TimerContext
+    {
+    public:
+        explicit ConnectTimeoutTimer(CommissioningProxyPafTransport & owner) : mOwner(owner) {}
+        void TimerFired() override { mOwner.OnConnectTimeout(); }
+
+    private:
+        CommissioningProxyPafTransport & mOwner;
+    };
+
+    /// Resuming the background scan has to be deferred: it can be reached from inside a
+    /// PAFTP endpoint-close callstack, and starting a scan makes a blocking D-Bus call, so
+    /// running it inline would re-enter the WiFiPAF layer mid-teardown. A zero-delay timer
+    /// rather than PlatformMgr().ScheduleWork() because a timer can be cancelled - queued
+    /// work cannot, and would outlive this object.
+    class ResumeBgScanTimer : public TimerContext
+    {
+    public:
+        explicit ResumeBgScanTimer(CommissioningProxyPafTransport & owner) : mOwner(owner) {}
+        void TimerFired() override { mOwner.mBgScan.ResumeIfNeeded(); }
+
+    private:
+        CommissioningProxyPafTransport & mOwner;
+    };
+
+    // --- WiFiPAF connect callbacks. context is always `this`. ---
+    static void HandleConnectSuccess(void * context);
+    static void HandleConnectError(void * context, CHIP_ERROR err);
+
+    // --- Adapter discovery callbacks. context is always `this`. ---
+    static void HandleForegroundScanResult(void * context, ByteSpan address, uint16_t discriminator, uint16_t vendorId,
+                                           uint16_t productId, ByteSpan extendedData, uint16_t wiFiBand);
+    static void HandleForegroundScanDone(void * context);
+    static void HandleBackgroundScanResult(void * context, ByteSpan address, uint16_t discriminator, uint16_t vendorId,
+                                           uint16_t productId, ByteSpan extendedData, uint16_t wiFiBand);
+
+    void OnConnectTimeout();
+
+    /// Build the kWiFiPAF ScanResultStruct the cluster stores. Shared by the foreground
+    /// and background paths so the field set cannot drift between them.
+    static ScanResultT MakeScanResult(ByteSpan address, uint16_t discriminator, uint16_t vendorId, uint16_t productId,
+                                      ByteSpan extendedData, uint16_t wiFiBand);
+
+    SessionSlot * FindSlot(uint16_t sessionId);
+    SessionSlot * FindSlotByPeer(uint32_t peerId);
+    SessionSlot * ClaimSlot();
+    bool AnySessionOpen() const;
+
+    /// Drop the PAF session keyed on @p discriminator and close any PAFTP endpoint its
+    /// handshake created. The session is captured before it is removed, because
+    /// RmPafSession clears the slot the endpoint is found by; skipping the close leaks
+    /// the endpoint from the 2-slot pool until its own timer self-closes.
+    void RemovePafSessionAndCloseEndpoint(uint16_t discriminator);
+
+    /// Tear down an in-flight connect that did not succeed: cancel the subscribe, close
+    /// any PAFTP endpoint the handshake created, drop the PAF session, answer the
+    /// originating ProxyConnectRequest with @p status, and release the subscribe slot.
+    /// @p cancelTimer is false only when called from the timeout handler itself.
+    void FailPendingConnect(Protocols::InteractionModel::Status status, bool cancelTimer);
+
+    CommissioningProxyPafAdapter & mAdapter;
+    TimerDelegate & mTimerDelegate;
+
+    ProxyPafDelegate mProxyDelegate{ *this };
+    BgScanHardware mBgScanHardware{ *this };
+    ConnectTimeoutTimer mConnectTimer{ *this };
+    ResumeBgScanTimer mResumeBgScanTimer{ *this };
+
+    /// Declared after mBgScanHardware so the registry is destroyed first: its destructor
+    /// may call back into the hardware hooks.
+    CommissioningProxyBgScanRegistry mBgScan;
+
+    CommissioningProxyCluster * mHost = nullptr;
+
+    /// Drops the publish receive handler as soon as the proxy's own commissioning ends.
+
+    SessionSlot mSessions[kMaxSessions];
+    std::optional<ConnectCtx> mPendingConnect;
+
+    ScanRecord mScanResults[kMaxScanResults];
+    size_t mScanResultCount = 0;
+    bool mScanInProgress    = false;
+};
+
+} // namespace CommissioningProxy
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/commissioning-proxy-server/README.md
+++ b/src/app/clusters/commissioning-proxy-server/README.md
@@ -65,15 +65,15 @@ device advertises on uses the proxy as a tunnel. The flow is:
    by `SessionID`; the proxy forwards it over the transport and returns the
    device's reply in the `ProxyMessageResponse`. The proxy is a dumb relay — the
    PASE session is end-to-end between the Commissioner and the device.
-4. **Disconnect** — the Commissioner sends `ProxyDisconnectRequest` to cancel an
-   in-flight connect; the proxy tears the transport connection down.
+4. **Disconnect** — the Commissioner sends `ProxyDisconnectRequest` with the
+   `SessionID` to close an established session, or with a null `SessionID` to
+   cancel an in-flight connect; the proxy tears the transport connection down.
 
 The cluster server itself is **transport-agnostic**: it validates the requested
 transport against the set it advertises, then dispatches the work to the
 registered `CommissioningProxyTransport` driver whose `GetTransportType()`
-matches the request's transport bit. A **BLE** (BTP) driver ships today; the
-**Wi-Fi PAF** (PAFTP) driver follows in a later PR. See the transport
-integration sections below.
+matches the request's transport bit. Today drivers exist for **BLE** (BTP) and
+**Wi-Fi PAF** (PAFTP) — see the transport integration sections below.
 
 ## Features
 
@@ -241,8 +241,8 @@ void ApplicationInit()
 For a complete working example of the device wiring, see
 `examples/all-devices-app/all-devices-common/device/types/commissioning-proxy/`.
 It registers the cluster's `CommissioningProxyBleTransport` and supplies the
-platform adapter from `examples/all-devices-app/posix/linux/`. The Wi-Fi PAF
-driver joins it in a later PR.
+platform adapters for both transports from
+`examples/all-devices-app/posix/linux/`.
 
 ## Transport driver methods
 
@@ -381,11 +381,13 @@ the "radio freed" path could otherwise re-enter the driver.
 transport callback once the operation completes.
 
 To keep the exchange alive across the async operation, store a
-`CommandHandler::Handle` and extend the exchange response timeout:
+`CommandHandler::Handle` in the driver's pending-operation state — not on the
+stack, which unwinds when `InvokeCommand` returns — and extend the exchange
+response timeout:
 
 ```cpp
-// Store the handle before returning nullopt
-CommandHandler::Handle handle(commandObj);
+// mPending outlives InvokeCommand; the handle must live there, not here
+mPending.handle = CommandHandler::Handle(commandObj);
 if (auto * ec = commandObj->GetExchangeContext())
 {
     ec->SetResponseTimeout(chip::System::Clock::Seconds16(responseTimeout + 10));
@@ -393,7 +395,7 @@ if (auto * ec = commandObj->GetExchangeContext())
 // … return std::nullopt from InvokeCommand …
 
 // Later, in your transport callback:
-auto * handler = handle.Get();
+auto * handler = mPending.handle.Get();
 if (handler != nullptr)
 {
     handler->AddResponse(commandPath, response);
@@ -444,28 +446,56 @@ CommissioningProxyBleTransport gBleTransport(gBleAdapter, gTimerDelegate);
 worked implementation over `BLEManagerImpl`, wired up in that app's
 `posix/linux/DeviceFactoryPlatformOverride.cpp`.
 
-## Wi-Fi PAF Transport Integration (planned)
+## Wi-Fi PAF Transport Integration
 
-No Wi-Fi PAF driver ships yet; this section describes the shape the one landing
-in a later PR takes, and is the reference for anyone writing a PAF driver
-against this cluster in the meantime.
+`CommissioningProxyPafTransport` ships with the cluster as the separate
+`paf-transport` target, on the same terms as `ble-transport`: an application
+that proxies over BLE only — or a platform with no Wi-Fi PAF stack — can depend
+on `commissioning-proxy-server` without pulling in `src/wifipaf`. It drives NAN
+and PAFTP sessions through `chip::WiFiPAF::WiFiPAFLayer`:
 
-When the build enables Wi-Fi PAF (`CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF`) the
-driver (`CommissioningProxyPafTransport`) interacts with
-`chip::WiFiPAF::WiFiPAFLayer` to open, send over, receive from, and close PAF
-(NAN) sessions:
-
--   `Connect()` — calls `WiFiPAFLayer::WiFiPAFSubscribe()` to open a PAF session
-    identified by the commissionee discriminator and peer address.
+-   `Connect()` — calls `ConnectivityMgr().WiFiPAFSubscribe()` to open a PAF
+    session to the commissionee discriminator.
 -   `SendMessage()` — calls `WiFiPAFLayer::SendMessage()` to send the tunneled
-    commissioning packet over PAFTP.
--   `Disconnect()` — calls `WiFiPAFLayer::RmPafSession()` to release the PAF
-    session.
+    commissioning packet over PAFTP (the PAFTP endpoint, not the raw NAN
+    transmit, which would bypass framing).
+-   `Disconnect()` — calls `WiFiPAFLayer::RmPafSession()`, closes the PAFTP
+    endpoint, and cancels the NAN subscribe that backed the session.
 
-Incoming PAF messages are routed back to the cluster via a
-`WiFiPAFLayerDelegate` subclass that intercepts `WiFiPAFMessageReceived`,
-matches the peer against the active session map, and calls
+Incoming PAF messages are routed back to the cluster via a `ProxyPafDelegate`
+(`chip::WiFiPAF::WiFiPAFLayerDelegate`) that wraps the original transport,
+matches the peer against the active session slots, and calls
 `host->Sessions().DispatchMessageResponse()`.
+
+### The platform adapter
+
+Session setup and teardown above are portable — they go through the generic
+`ConnectivityManager` facade. Discovery is not, so it is not in the transport:
+scanning for commissionable devices, and recovering the subscribe id the
+platform assigned to a request, both need the platform implementation. The
+application supplies them by implementing `CommissioningProxyPafAdapter`:
+
+```cpp
+class MyPafProxyAdapter : public CommissioningProxyPafAdapter
+{
+    CHIP_ERROR StartForegroundScan(System::Clock::Seconds16 window, DiscoveryCallback onDevice,
+                                   ScanCompleteCallback onDone, void * context) override;
+    CHIP_ERROR StartBackgroundScan(DiscoveryCallback cb, void * context) override;
+    void StopBackgroundScan() override;
+    uint32_t PendingConnectSubscribeId() const override;
+};
+
+MyPafProxyAdapter gPafAdapter;
+CommissioningProxyPafTransport gPafTransport(gPafAdapter, gTimerDelegate);
+```
+
+Unlike BLE, the platform owns the scan window: `StartForegroundScan()` takes the
+duration and the adapter signals completion, so the transport arms no scan timer
+of its own.
+`examples/all-devices-app/posix/linux/CommissioningProxyPafAdapter.cpp` is a
+worked implementation over `ConnectivityManagerImpl`, and is also where the
+platform's peer descriptor is unpacked into the interface's scalars so no
+platform type reaches the cluster.
 
 ## Driving the Proxy from a Commissioner
 
@@ -511,5 +541,22 @@ State transitions:
 
 ```text
 ProxyConnectRequest ──► transport connect success ──► kState_CPConnected
+kState_CPConnected  ──► ProxyDisconnectRequest    ──► kState_CPConnected
+                                                      (sessions remain)
 kState_CPConnected  ──► ProxyDisconnectRequest    ──► kState_CPDisconnected
+                        for the last session
+kState_CPConnected  ──► peer closes the transport ──► kState_CPDisconnected
+                        connection, last session
 ```
+
+With `MaxSessions > 1` several sessions can be open at once, so a
+`ProxyDisconnectRequest` only returns the cluster to `kState_CPDisconnected` —
+and only notifies the transports via `OnAllSessionsClosed()` — once no session
+is left.
+
+A session can also end without a `ProxyDisconnectRequest`, when the commissionee
+closes the transport connection. A transport reports that through
+`SetDisconnectedIfLastSession()` rather than setting the state itself: the
+cluster counts the sessions of every transport, plus any connect still in
+flight, so the last session on one transport is not necessarily the last session
+on the proxy.

--- a/src/app/clusters/commissioning-proxy-server/tests/BUILD.gn
+++ b/src/app/clusters/commissioning-proxy-server/tests/BUILD.gn
@@ -18,6 +18,7 @@ import("//build_overrides/pigweed.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 import("${chip_root}/src/ble/ble.gni")
+import("${chip_root}/src/platform/device.gni")
 
 chip_test_suite("tests") {
   output_name = "TestCommissioningProxyCluster"
@@ -63,6 +64,16 @@ chip_test_suite("tests") {
     # so the driver is compiled once.
     public_deps += [
       "${chip_root}/src/app/clusters/commissioning-proxy-server:ble-transport",
+    ]
+  }
+
+  # Same for Wi-Fi PAF: the driver and the tests that drive it only exist when the PAF
+  # stack is enabled.
+  if (chip_device_config_enable_wifipaf) {
+    test_sources += [ "TestCommissioningProxyPafTransport.cpp" ]
+
+    public_deps += [
+      "${chip_root}/src/app/clusters/commissioning-proxy-server:paf-transport",
     ]
   }
 }

--- a/src/app/clusters/commissioning-proxy-server/tests/TestCommissioningProxyCluster.cpp
+++ b/src/app/clusters/commissioning-proxy-server/tests/TestCommissioningProxyCluster.cpp
@@ -954,6 +954,40 @@ TEST_F(TestCommissioningProxyCluster, TestProxyDisconnectRequest_StateTransition
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
+// A transport whose peer closed the connection reports through
+// SetDisconnectedIfLastSession() rather than deciding from its own sessions: with more
+// than one transport configured, the last session on one of them is not the last session
+// on the proxy. Here the BLE session is gone but a PAF connect is still in flight, so the
+// proxy SHALL NOT report itself disconnected. Runs at MaxSessions == 1, unlike the
+// multi-session case above, because a pending connect also counts as activity.
+TEST_F(TestCommissioningProxyCluster, TestSetDisconnectedIfLastSession_OtherTransportStillBusy)
+{
+    TestServerClusterContext context;
+    CommissioningProxyCluster cluster(kTestEndpointId, CommissioningProxyCluster::Config(BitMask<Feature>{}), mockTimer);
+    RegisterMocks(cluster);
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    SKIP_IF_TRANSPORT_UNSUPPORTED(tester, CapabilitiesBitmap::kBle);
+
+    uint16_t sid = OpenSession(tester);
+    EXPECT_EQ(cluster.GetCPState(), CommissioningProxyCluster::kState_CPConnected);
+
+    // The other transport starts connecting, then the BLE peer drops the link.
+    mockPaf.SetConnectPending(true);
+    cluster.Sessions().RemoveSession(sid);
+
+    cluster.SetDisconnectedIfLastSession();
+    EXPECT_EQ(cluster.GetCPState(), CommissioningProxyCluster::kState_CPConnected);
+
+    // Once that connect finishes too, nothing is left and the proxy is disconnected.
+    mockPaf.SetConnectPending(false);
+    cluster.SetDisconnectedIfLastSession();
+    EXPECT_EQ(cluster.GetCPState(), CommissioningProxyCluster::kState_CPDisconnected);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
 // With MaxSessions > 1, disconnecting one of several active sessions SHALL NOT
 // transition the cluster to disconnected; only the final disconnect (no sessions
 // remaining) SHALL do so.

--- a/src/app/clusters/commissioning-proxy-server/tests/TestCommissioningProxyPafTransport.cpp
+++ b/src/app/clusters/commissioning-proxy-server/tests/TestCommissioningProxyPafTransport.cpp
@@ -1,0 +1,445 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// Covers the Commissioning Proxy PAF *driver*: scan result handling, the response cap,
+// and the single-subscribe-slot arbitration between the foreground scan, the background
+// scan and connect.
+//
+// This is distinct from src/wifipaf/tests, which covers the PAF layer and the PAFTP
+// protocol underneath (fragmentation, acks, session pool, endpoint lifecycle) and knows
+// nothing about the cluster. Nothing here re-tests those.
+//
+// Cases that differ from the BLE driver's suite, rather than merely repeating it, are
+// marked "PAF-specific" below.
+
+#include "CommissioningProxyMockTimer.h"
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyCluster.h>
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyPafAdapter.h>
+#include <app/clusters/commissioning-proxy-server/CommissioningProxyPafTransport.h>
+#include <pw_unit_test/framework.h>
+
+#include <app/server-cluster/testing/ClusterTester.h>
+#include <clusters/CommissioningProxy/Attributes.h>
+#include <clusters/CommissioningProxy/Commands.h>
+#include <lib/core/CHIPConfig.h>
+#include <lib/support/Span.h>
+#include <platform/PlatformManager.h>
+#include <system/SystemClock.h>
+
+#include <cstdint>
+#include <cstring>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::CommissioningProxy;
+using namespace chip::app::Clusters::CommissioningProxy::Commands;
+using namespace chip::Testing;
+using chip::Protocols::InteractionModel::Status;
+
+namespace {
+
+constexpr EndpointId kTestEndpointId = 1;
+constexpr size_t kMaxCachedResults   = CHIP_CONFIG_COMMISSIONING_PROXY_MAX_CACHED_RESULTS;
+
+/// Stands in for ConnectivityManagerImpl's NAN discovery surface. Records what the
+/// transport asked for and lets a test play peers back through the registered callbacks.
+class FakePafProxyAdapter : public CommissioningProxyPafAdapter
+{
+public:
+    CHIP_ERROR StartForegroundScan(System::Clock::Seconds16 window, DiscoveryCallback onDevice, ScanCompleteCallback onDone,
+                                   void * context) override
+    {
+        foregroundStartCalls++;
+        lastWindow = window;
+        if (mStartForegroundResult != CHIP_NO_ERROR)
+        {
+            return mStartForegroundResult;
+        }
+        mForegroundCallback = onDevice;
+        mForegroundDone     = onDone;
+        mForegroundContext  = context;
+        return CHIP_NO_ERROR;
+    }
+
+    void StopForegroundScan() override
+    {
+        foregroundStopCalls++;
+        mForegroundCallback = nullptr;
+        mForegroundDone     = nullptr;
+        mForegroundContext  = nullptr;
+    }
+
+    CHIP_ERROR StartBackgroundScan(DiscoveryCallback cb, void * context) override
+    {
+        backgroundStartCalls++;
+        if (mStartBackgroundResult != CHIP_NO_ERROR)
+        {
+            return mStartBackgroundResult;
+        }
+        mBackgroundCallback = cb;
+        mBackgroundContext  = context;
+        backgroundScanning  = true;
+        return CHIP_NO_ERROR;
+    }
+
+    void StopBackgroundScan() override
+    {
+        backgroundStopCalls++;
+        backgroundScanning  = false;
+        mBackgroundCallback = nullptr;
+        mBackgroundContext  = nullptr;
+    }
+
+    uint32_t PendingConnectSubscribeId() const override { return mSubscribeId; }
+
+    /// Report a peer to the in-flight foreground scan.
+    void ReportForeground(uint16_t discriminator, uint16_t vendorId, uint16_t productId, uint8_t addressTag,
+                          ByteSpan extendedData = ByteSpan(), uint16_t wiFiBand = 0)
+    {
+        if (mForegroundCallback == nullptr)
+        {
+            return;
+        }
+        const uint8_t mac[6] = { 0x02, 0x11, 0x22, 0x33, 0x44, addressTag };
+        mForegroundCallback(mForegroundContext, ByteSpan(mac, sizeof(mac)), discriminator, vendorId, productId, extendedData,
+                            wiFiBand);
+    }
+
+    /// Close the foreground scan out, as the platform does when its window expires.
+    void CompleteForegroundScan()
+    {
+        if (mForegroundDone == nullptr)
+        {
+            return;
+        }
+        ScanCompleteCallback onDone = mForegroundDone;
+        void * context              = mForegroundContext;
+        mForegroundCallback         = nullptr;
+        mForegroundDone             = nullptr;
+        mForegroundContext          = nullptr;
+        onDone(context);
+    }
+
+    void ReportBackground(uint16_t discriminator, uint16_t vendorId, uint16_t productId, uint8_t addressTag, uint16_t wiFiBand = 0)
+    {
+        if (mBackgroundCallback == nullptr)
+        {
+            return;
+        }
+        const uint8_t mac[6] = { 0x02, 0x11, 0x22, 0x33, 0x44, addressTag };
+        mBackgroundCallback(mBackgroundContext, ByteSpan(mac, sizeof(mac)), discriminator, vendorId, productId, ByteSpan(),
+                            wiFiBand);
+    }
+
+    void SetStartForegroundResult(CHIP_ERROR err) { mStartForegroundResult = err; }
+    void SetStartBackgroundResult(CHIP_ERROR err) { mStartBackgroundResult = err; }
+
+    unsigned foregroundStartCalls = 0;
+    unsigned foregroundStopCalls  = 0;
+    unsigned backgroundStartCalls = 0;
+    unsigned backgroundStopCalls  = 0;
+
+    bool backgroundScanning = false;
+    System::Clock::Seconds16 lastWindow{ 0 };
+
+private:
+    DiscoveryCallback mForegroundCallback = nullptr;
+    ScanCompleteCallback mForegroundDone  = nullptr;
+    void * mForegroundContext             = nullptr;
+    DiscoveryCallback mBackgroundCallback = nullptr;
+    void * mBackgroundContext             = nullptr;
+    CHIP_ERROR mStartForegroundResult     = CHIP_NO_ERROR;
+    CHIP_ERROR mStartBackgroundResult     = CHIP_NO_ERROR;
+    uint32_t mSubscribeId                 = 0;
+};
+
+struct TestCommissioningProxyPafTransport : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+    /// Declaration order matters: the transport is destroyed before the adapter and the
+    /// timer it holds references to.
+    CommissioningProxyMockTimer mockTimer;
+    FakePafProxyAdapter adapter;
+    CommissioningProxyPafTransport transport{ adapter, mockTimer };
+};
+
+/// A cluster with the PAF transport registered, so command-driven paths run end to end.
+struct HostedTransport
+{
+    HostedTransport(CommissioningProxyMockTimer & timer, CommissioningProxyPafTransport & transport) :
+        cluster(kTestEndpointId,
+                CommissioningProxyCluster::Config(BitMask<Feature>(Feature::kBackgroundScan, Feature::kWiFiNetworkInterface),
+                                                  BitMask<WiFiBandBitmap>(WiFiBandBitmap::k2g4)),
+                timer)
+    {
+        cluster.RegisterTransport(transport);
+    }
+
+    CommissioningProxyCluster cluster;
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Foreground scan: the platform owns the window (PAF-specific)
+// ---------------------------------------------------------------------------
+
+TEST_F(TestCommissioningProxyPafTransport, ScanPassesTheWindowToThePlatformAndArmsNoTimer)
+{
+    EXPECT_EQ(transport.Scan(System::Clock::Seconds16(20)), Status::Success);
+    EXPECT_EQ(adapter.foregroundStartCalls, 1u);
+    // PAF-specific: the platform times the window, so unlike the BLE driver this one must
+    // arm no scan timer of its own — and it must hand the duration across intact.
+    EXPECT_EQ(adapter.lastWindow.count(), 20u);
+    EXPECT_EQ(mockTimer.ActiveCount(), 0u);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, SecondScanWhileRunningIsBusy)
+{
+    ASSERT_EQ(transport.Scan(System::Clock::Seconds16(10)), Status::Success);
+    EXPECT_EQ(transport.Scan(System::Clock::Seconds16(10)), Status::Busy);
+    EXPECT_EQ(adapter.foregroundStartCalls, 1u);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, ScanReportsFailureWhenThePlatformCannotStart)
+{
+    adapter.SetStartForegroundResult(CHIP_ERROR_BUSY);
+    EXPECT_EQ(transport.Scan(System::Clock::Seconds16(10)), Status::Failure);
+    // A failed start must leave no scan in progress, or every later scan returns Busy.
+    EXPECT_EQ(transport.Scan(System::Clock::Seconds16(10)), Status::Failure);
+    EXPECT_EQ(adapter.foregroundStartCalls, 2u);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, ScanCompletionReleasesTheSubscribeSlot)
+{
+    ASSERT_EQ(transport.Scan(System::Clock::Seconds16(10)), Status::Success);
+    // PAF-specific: completion arrives from the platform, not from a local timer.
+    adapter.CompleteForegroundScan();
+    EXPECT_EQ(transport.Scan(System::Clock::Seconds16(10)), Status::Success);
+}
+
+// ---------------------------------------------------------------------------
+// Foreground scan results, driven through the cluster so the real aggregator
+// builds the ProxyScanResponse
+// ---------------------------------------------------------------------------
+
+TEST_F(TestCommissioningProxyPafTransport, ScanResponseDedupesOnDiscriminatorVendorProduct)
+{
+    HostedTransport host{ mockTimer, transport };
+    ClusterTester tester(host.cluster);
+
+    ProxyScanRequest::Type request;
+    request.transport             = BitMask<CapabilitiesBitmap>(CapabilitiesBitmap::kWiFiPAF);
+    [[maybe_unused]] auto pending = tester.Invoke(request);
+    ASSERT_FALSE(tester.GetCommandHandler().HasResponse());
+
+    adapter.ReportForeground(0x123, 0xFFF1, 0x8000, 1);
+    adapter.ReportForeground(0x123, 0xFFF1, 0x8000, 2); // duplicate
+    adapter.ReportForeground(0x123, 0xFFF1, 0x8001, 3); // differs by productID
+    adapter.CompleteForegroundScan();
+
+    ASSERT_TRUE(tester.GetCommandHandler().HasResponse());
+    ProxyScanResponse::DecodableType response;
+    ASSERT_EQ(tester.GetCommandHandler().DecodeResponse(response), CHIP_NO_ERROR);
+    EXPECT_EQ(response.numberOfResults, 2);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, ScanResponseIsCappedAtMaxCachedResults)
+{
+    HostedTransport host{ mockTimer, transport };
+    ClusterTester tester(host.cluster);
+
+    ProxyScanRequest::Type request;
+    request.transport             = BitMask<CapabilitiesBitmap>(CapabilitiesBitmap::kWiFiPAF);
+    [[maybe_unused]] auto pending = tester.Invoke(request);
+
+    for (size_t i = 0; i < kMaxCachedResults + 2; i++)
+    {
+        adapter.ReportForeground(static_cast<uint16_t>(0x200 + i), 0xFFF1, 0x8000, static_cast<uint8_t>(i));
+    }
+    adapter.CompleteForegroundScan();
+
+    ASSERT_TRUE(tester.GetCommandHandler().HasResponse());
+    ProxyScanResponse::DecodableType response;
+    ASSERT_EQ(tester.GetCommandHandler().DecodeResponse(response), CHIP_NO_ERROR);
+    EXPECT_EQ(response.numberOfResults, static_cast<uint8_t>(kMaxCachedResults));
+}
+
+TEST_F(TestCommissioningProxyPafTransport, ScanResultCarriesExtendedDataAndBand)
+{
+    // PAF-specific: BLE advertisements carry neither, so this copy-into-fixed-storage path
+    // exists only here.
+    HostedTransport host{ mockTimer, transport };
+    ClusterTester tester(host.cluster);
+
+    ProxyScanRequest::Type request;
+    request.transport             = BitMask<CapabilitiesBitmap>(CapabilitiesBitmap::kWiFiPAF);
+    [[maybe_unused]] auto pending = tester.Invoke(request);
+
+    const uint8_t extended[] = { 0xde, 0xad, 0xbe, 0xef };
+    adapter.ReportForeground(0x321, 0xFFF1, 0x8000, 1, ByteSpan(extended, sizeof(extended)),
+                             static_cast<uint16_t>(WiFiBandBitmap::k2g4));
+    adapter.CompleteForegroundScan();
+
+    ASSERT_TRUE(tester.GetCommandHandler().HasResponse());
+    ProxyScanResponse::DecodableType response;
+    ASSERT_EQ(tester.GetCommandHandler().DecodeResponse(response), CHIP_NO_ERROR);
+    EXPECT_EQ(response.numberOfResults, 1);
+
+    auto iter = response.proxyScanResult.begin();
+    ASSERT_TRUE(iter.Next());
+    const auto & result = iter.GetValue();
+    EXPECT_EQ(iter.GetStatus(), CHIP_NO_ERROR);
+    ASSERT_FALSE(result.extendedData.IsNull());
+    ASSERT_TRUE(result.extendedData.Value().data_equal(ByteSpan(extended, sizeof(extended))));
+    ASSERT_TRUE(result.wiFiBand.HasValue());
+    EXPECT_EQ(result.wiFiBand.Value(), WiFiBandBitmap::k2g4);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, OversizedExtendedDataIsDroppedNotTruncated)
+{
+    // PAF-specific: the record's extended-data buffer is fixed, so an advertisement
+    // claiming more than it holds must not be copied in partially — a truncated blob
+    // would be reported to the commissioner as if it were complete.
+    HostedTransport host{ mockTimer, transport };
+    ClusterTester tester(host.cluster);
+
+    ProxyScanRequest::Type request;
+    request.transport             = BitMask<CapabilitiesBitmap>(CapabilitiesBitmap::kWiFiPAF);
+    [[maybe_unused]] auto pending = tester.Invoke(request);
+
+    uint8_t oversized[200] = {};
+    memset(oversized, 0xa5, sizeof(oversized));
+    adapter.ReportForeground(0x400, 0xFFF1, 0x8000, 1, ByteSpan(oversized, sizeof(oversized)));
+    adapter.CompleteForegroundScan();
+
+    ASSERT_TRUE(tester.GetCommandHandler().HasResponse());
+    ProxyScanResponse::DecodableType response;
+    ASSERT_EQ(tester.GetCommandHandler().DecodeResponse(response), CHIP_NO_ERROR);
+    // The device is still reported; only the extended data it could not hold is absent.
+    EXPECT_EQ(response.numberOfResults, 1);
+    auto iter = response.proxyScanResult.begin();
+    ASSERT_TRUE(iter.Next());
+    EXPECT_TRUE(iter.GetValue().extendedData.IsNull());
+}
+
+// ---------------------------------------------------------------------------
+// Background scan and the single subscribe slot
+// ---------------------------------------------------------------------------
+
+TEST_F(TestCommissioningProxyPafTransport, BackgroundScanStartDrivesTheAdapter)
+{
+    EXPECT_EQ(transport.BgScanStart(System::Clock::Seconds16(30), BitMask<WiFiBandBitmap>(WiFiBandBitmap::k2g4),
+                                    /*fabricIndex=*/1, /*nodeId=*/0x11),
+              Status::Success);
+    EXPECT_EQ(adapter.backgroundStartCalls, 1u);
+    EXPECT_TRUE(adapter.backgroundScanning);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, BackgroundScanStartSucceedsWhileTheSlotIsBusy)
+{
+    adapter.SetStartBackgroundResult(CHIP_ERROR_BUSY);
+    EXPECT_EQ(transport.BgScanStart(System::Clock::Seconds16(30), BitMask<WiFiBandBitmap>(WiFiBandBitmap::k2g4),
+                                    /*fabricIndex=*/1, /*nodeId=*/0x11),
+              Status::Success);
+    EXPECT_FALSE(adapter.backgroundScanning);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, BackgroundScanReportsIntoTheClusterCache)
+{
+    HostedTransport host{ mockTimer, transport };
+
+    ASSERT_EQ(transport.BgScanStart(System::Clock::Seconds16(30), BitMask<WiFiBandBitmap>(WiFiBandBitmap::k2g4),
+                                    /*fabricIndex=*/1, /*nodeId=*/0x11),
+              Status::Success);
+
+    adapter.ReportBackground(0x321, 0xFFF1, 0x8000, 1, static_cast<uint16_t>(WiFiBandBitmap::k2g4));
+    adapter.ReportBackground(0x322, 0xFFF1, 0x8000, 2, static_cast<uint16_t>(WiFiBandBitmap::k2g4));
+    // Re-discovery refreshes the cached entry rather than adding a second one.
+    adapter.ReportBackground(0x321, 0xFFF1, 0x8000, 1, static_cast<uint16_t>(WiFiBandBitmap::k2g4));
+
+    EXPECT_EQ(host.cluster.ScanCache().Count(), 2);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, ForegroundScanTakesTheSubscribeSlotFromTheBackgroundScan)
+{
+    ASSERT_EQ(transport.BgScanStart(System::Clock::Seconds16(30), BitMask<WiFiBandBitmap>(WiFiBandBitmap::k2g4),
+                                    /*fabricIndex=*/1, /*nodeId=*/0x11),
+              Status::Success);
+    ASSERT_EQ(adapter.backgroundStartCalls, 1u);
+
+    // One NAN subscribe slot: the foreground scan must stop the background one before
+    // claiming it.
+    ASSERT_EQ(transport.Scan(System::Clock::Seconds16(10)), Status::Success);
+    EXPECT_EQ(adapter.backgroundStopCalls, 1u);
+    EXPECT_FALSE(adapter.backgroundScanning);
+}
+
+// ---------------------------------------------------------------------------
+// Session-keyed operations with no session, and teardown
+// ---------------------------------------------------------------------------
+
+TEST_F(TestCommissioningProxyPafTransport, DisconnectUnknownSessionIsNotFound)
+{
+    EXPECT_EQ(transport.Disconnect(/*sessionId=*/7), Status::NotFound);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, SendMessageOnUnknownSessionFails)
+{
+    EXPECT_EQ(transport.SendMessage(/*sessionId=*/7, System::PacketBufferHandle::New(16)), CHIP_ERROR_KEY_NOT_FOUND);
+}
+
+TEST_F(TestCommissioningProxyPafTransport, CancelPendingConnectWithNothingPendingIsInvalidInState)
+{
+    EXPECT_EQ(transport.CancelPendingConnect(/*fabricIndex=*/1), Status::InvalidInState);
+    EXPECT_FALSE(transport.IsConnectPending());
+}
+
+TEST_F(TestCommissioningProxyPafTransport, ShutdownDetachesAnInFlightForegroundScan)
+{
+    // The platform owns the scan window and cannot always abort it, so Shutdown must
+    // detach the callbacks: a completion arriving afterwards would otherwise reach a
+    // destroyed transport.
+    ASSERT_EQ(transport.Scan(System::Clock::Seconds16(10)), Status::Success);
+
+    transport.Shutdown();
+    EXPECT_EQ(adapter.foregroundStopCalls, 1u);
+
+    // Nothing is delivered even if the platform reports late.
+    adapter.ReportForeground(0x555, 0xFFF1, 0x8000, 1);
+    adapter.CompleteForegroundScan();
+}
+
+TEST_F(TestCommissioningProxyPafTransport, ShutdownStopsTheBackgroundScanAndIsIdempotent)
+{
+    ASSERT_EQ(transport.BgScanStart(System::Clock::Seconds16(30), BitMask<WiFiBandBitmap>(WiFiBandBitmap::k2g4),
+                                    /*fabricIndex=*/1, /*nodeId=*/0x11),
+              Status::Success);
+    ASSERT_TRUE(adapter.backgroundScanning);
+
+    transport.Shutdown();
+    EXPECT_FALSE(adapter.backgroundScanning);
+    EXPECT_EQ(mockTimer.ActiveCount(), 0u);
+
+    const unsigned stopsAfterFirstShutdown = adapter.backgroundStopCalls;
+    transport.Shutdown();
+    EXPECT_EQ(adapter.backgroundStopCalls, stopsAfterFirstShutdown);
+}

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -218,7 +218,10 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
         mAppDelegate->OnCommissioningSessionStarted();
     }
 
-    TEMPORARY_RETURN_IGNORED StopAdvertisement(/* aShuttingDown = */ false);
+    // Stop accepting new PASE attempts, but keep the WiFi-PAF publisher alive: the
+    // PAFTP session that just completed PASE is the data path for the rest of
+    // commissioning, and cancelling publish here tears it down mid-flow.
+    TEMPORARY_RETURN_IGNORED StopAdvertisement(/* aShuttingDown = */ false, /* aKeepPAFPublish = */ true);
 
     auto & failSafeContext = Server::GetInstance().GetFailSafeContext();
     // This should never be armed because we don't allow CASE sessions to arm the failsafe when the commissioning window is open and
@@ -339,7 +342,7 @@ CHIP_ERROR CommissioningWindowManager::OpenBasicCommissioningWindow(Seconds32 co
     SetBLE(false);
 #endif // CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    SetWiFiPAF(advertisementMode == chip::CommissioningWindowAdvertisement::kAllSupported);
+    SetWiFiPAF(advertisementMode == chip::CommissioningWindowAdvertisement::kAllSupported && mWiFiPAFAdvertisingAllowed);
 #endif
 
     mFailedCommissioningAttempts = 0;
@@ -547,7 +550,7 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CommissioningWindowManager::StopAdvertisement(bool aShuttingDown)
+CHIP_ERROR CommissioningWindowManager::StopAdvertisement(bool aShuttingDown, bool aKeepPAFPublish)
 {
     TEMPORARY_RETURN_IGNORED RestoreDiscriminator();
 
@@ -575,8 +578,14 @@ CHIP_ERROR CommissioningWindowManager::StopAdvertisement(bool aShuttingDown)
     }
 #endif // CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    // Cancel PAF advertisement if PAF is selected and publishId is valid
-    if ((mIsWiFiPAF) && (aShuttingDown) && (mPublishId != 0) && (mPublishId != WiFiPAF::kUndefinedWiFiPafSessionId))
+    // Cancel PAF advertisement whenever the commissioning window closes, not only on
+    // shutdown: a publisher left running holds a NAN session slot, so a device acting as
+    // a commissioning proxy would keep advertising itself while it needs the radio to
+    // subscribe on a commissionee's behalf.
+    //
+    // Skipped when aKeepPAFPublish is set (OnSessionEstablished), where the PAFTP session
+    // is still carrying the remainder of commissioning.
+    if (!aKeepPAFPublish && (mIsWiFiPAF) && (mPublishId != 0) && (mPublishId != WiFiPAF::kUndefinedWiFiPafSessionId))
     {
         ChipLogProgress(WiFiPAF, "Canceling Wi-Fi PAF publish");
         TEMPORARY_RETURN_IGNORED DeviceLayer::ConnectivityMgr().SetWiFiPAFAdvertisingEnabled(false, mPublishId);

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -68,6 +68,16 @@ public:
 
     void SetAppDelegate(AppDelegate * delegate) { mAppDelegate = delegate; }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    /**
+     * Allow or forbid advertising this device's own commissioning window over Wi-Fi PAF.
+     * Allowed by default.  A device that needs the NAN radio for something else while a
+     * window is open — a commissioning proxy subscribing on a commissionee's behalf — sets
+     * this false, so opening a window advertises on the other supported transports only.
+     */
+    void SetWiFiPAFAdvertisingAllowed(bool allowed) { mWiFiPAFAdvertisingAllowed = allowed; }
+#endif
+
     /**
      * Open the pairing window using default configured parameters.
      */
@@ -153,7 +163,11 @@ private:
 
     CHIP_ERROR StartAdvertisement();
 
-    CHIP_ERROR StopAdvertisement(bool aShuttingDown);
+    // aKeepPAFPublish: leave the WiFi-PAF publisher running.  Used by
+    // OnSessionEstablished so the PAFTP session that just established PASE
+    // stays alive for post-PASE commissioning traffic.  The publisher is
+    // cancelled instead when the commissioning window closes, or on shutdown.
+    CHIP_ERROR StopAdvertisement(bool aShuttingDown, bool aKeepPAFPublish = false);
 
     // Start a timer that will call HandleCommissioningWindowTimeout, and then
     // start advertising and listen for PASE.
@@ -213,6 +227,9 @@ private:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     bool mIsWiFiPAF = false;
+    // Sticky: set once by the application, and not reset by Init() or ResetState(), so it
+    // survives every open/close cycle of the commissioning window.
+    bool mWiFiPAFAdvertisingAllowed = true;
     // Both 0 and kUndefinedWiFiPafSessionId are invalid publish-id.
     // Use 0 as the default value so that the PAF definition does not need to be included.
     uint32_t mPublishId = 0;

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -1706,13 +1706,14 @@ static_assert(CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN <= CHIP_DEVICE
 #define CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY 0
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
 
-// NOTE: the BLE proxy transport has no dedicated CP-side enable flag.  The
-// Commissioning Proxy cluster source itself is only compiled when
-// CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY is on (the build system pulls
-// it in via app_config_dependent_sources.gni only for those apps), so the
-// transport is gated purely on its own existing compile flag:
-//   BLE: CONFIG_NETWORK_LAYER_BLE (the BLE-wide GN arg
-//        chip_config_network_layer_ble)
+// NOTE: this macro gates the platform-side proxy transport entry points (the
+// WiFi-PAF and BLE hooks in ConnectivityManagerImpl / BLEManagerImpl), not the
+// cluster sources — those are listed unconditionally in the cluster's BUILD.gn.
+// The WiFi-PAF and BLE proxy transports have no dedicated CP-side enable flags,
+// so each transport is gated purely on its own existing compile flag:
+//   WiFi-PAF: CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+//   BLE:      CONFIG_NETWORK_LAYER_BLE (the BLE-wide GN arg
+//             chip_config_network_layer_ble)
 
 /**
  * CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -43,6 +43,17 @@
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.ipp>
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
+#if __has_include(<app-common/zap-generated/cluster-objects.h>)
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
+#else
+// Some builds expose the generated headers under zzz_generated
+#include <zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h>
+#include <zzz_generated/app-common/app-common/zap-generated/cluster-objects.h>
+#endif
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
+
 #include "ConnectivityManagerImpl.h"
 #include "ConnectivityUtils.h"
 
@@ -51,6 +62,10 @@ using namespace ::chip::DeviceLayer::NetworkCommissioning;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 using namespace ::chip::WiFiPAF;
 #endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
+using chip::app::DataModel::List;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <lib/core/CHIPConfig.h>
 #include <lib/support/FixedBuffer.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/GenericConnectivityManagerImpl.h>
@@ -49,6 +50,7 @@
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
 #include <atomic>
+#include <cstring>
 #include <platform/Linux/NetworkCommissioningDriver.h>
 #include <platform/NetworkCommissioning.h>
 #include <vector>
@@ -59,6 +61,34 @@
 
 namespace chip {
 namespace DeviceLayer {
+
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
+struct NanPeerInfo
+{
+    uint8_t mac[6]{};
+    uint16_t vid           = 0;
+    uint16_t pid           = 0;
+    uint16_t discriminator = 0;
+    uint8_t opcode         = 0;
+    uint16_t srvProtoType  = 0;
+
+    std::vector<uint8_t> storage; // ExtendedData storage
+    bool hasExtendedData = false;
+    uint16_t band        = 0; // WiFiBandBitmap value derived from scan frequency; 0 = unknown
+
+    /// Two reports are the same peer when the MAC and discriminator match.
+    bool operator==(const NanPeerInfo & o) const
+    {
+        return memcmp(mac, o.mac, sizeof(mac)) == 0 && discriminator == o.discriminator;
+    }
+};
+
+struct ScanTimerCtx
+{
+    chip::DeviceLayer::ConnectivityManagerImpl * self = nullptr;
+    guint subscribe_id;
+};
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 // Records when the radio can carry Wi-Fi PAF frames
@@ -126,6 +156,7 @@ public:
                                  OnConnectionErrorFunct onError);
     CHIP_ERROR _WiFiPAFCancelSubscribe(uint32_t SubscribeId);
     CHIP_ERROR _WiFiPAFCancelIncompleteSubscribe();
+    uint32_t GetPendingConnectSubscribeId() const { return mPendingConnectSubscribeId; }
     void OnDiscoveryResult(GVariant * obj);
     void OnReplied(GVariant * obj);
     void OnNanReceive(GVariant * obj);
@@ -153,6 +184,66 @@ public:
     CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & wiFiVersion);
     CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & network);
     CHIP_ERROR StartWiFiScan(ByteSpan ssid, NetworkCommissioning::WiFiDriver::ScanCallback * callback);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF && CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
+public:
+    void ScanNanReceive(GVariant * obj);
+    void ScanNanSubscribeTerminated(guint subscribe_id, gchar * reason);
+    void ScanDiscoveryResult(GVariant * discov_info);
+    using PafScanResultsCallback = void (*)(void * context, const std::vector<NanPeerInfo> & results);
+    CHIP_ERROR WiFiPAFScan(uint8_t scanMaxTime, PafScanResultsCallback cb, void * cbContext);
+    /** Per-peer callback fired each time a new NAN discovery result arrives
+     *  during a background scan (including re-discoveries, to allow TTL reset). */
+    using BgScanDiscoveryCallback = void (*)(void * ctx, const NanPeerInfo & peer);
+
+    /**
+     * Start a continuous background NAN discovery scan.
+     * @param cb      Called on every discovery result (including duplicates).
+     * @param cbCtx   Passed unchanged to cb.
+     * @return CHIP_ERROR_BUSY if a one-shot scan is already running.
+     */
+    CHIP_ERROR WiFiPAFStartBackgroundScan(BgScanDiscoveryCallback cb, void * cbCtx);
+
+    /**
+     * Stop the background scan started by WiFiPAFStartBackgroundScan.
+     * No-op if no background scan is active.
+     */
+    void WiFiPAFStopBackgroundScan();
+
+private:
+    /// Peers seen by the current scan, as a rolling window. Bounded at the same value the
+    /// CommissioningProxy cluster caps a ProxyScanResponse.
+    static constexpr size_t kMaxScanPeers = CHIP_CONFIG_COMMISSIONING_PROXY_MAX_CACHED_RESULTS;
+    std::vector<NanPeerInfo> mNanScanPeers;
+    /// Index of the oldest entry, overwritten next once the window is full.
+    size_t mNanScanPeersNext        = 0;
+    PafScanResultsCallback mScanCb  = nullptr;
+    void * mScanCbContext           = nullptr;
+    uint32_t mActiveScanSubscribeId = 0; // subscribe_id of the current one-shot scan
+    void FinishWiFiPAFScan(ScanTimerCtx * ctx);
+
+    BgScanDiscoveryCallback mBgScanCb = nullptr;
+    void * mBgScanCbCtx               = nullptr;
+    uint32_t mBgScanSubscribeId       = 0;
+    uint32_t mScanFreq                = 0; // freq (MHz) used for the current scan (one-shot or background)
+
+    // Handler IDs for the three scan GLib signals (nandiscovery-result, nanreceive,
+    // nansubscribe-terminated).  Stored so DisconnectScanSignals() can remove exactly
+    // the scan handlers without disturbing PAF connect-path handlers on the same signals.
+    gulong mScanSignalIds[3] = {};
+
+    /** Connect the scan GLib signal handlers.  Must be called before NANSubscribe;
+     *  see the definition for why.  Caller must hold mWpaSupplicantMutex. */
+    void ConnectScanSignals() CHIP_REQUIRES(mWpaSupplicantMutex);
+
+    /** Disconnect the scan GLib signal handlers registered by ConnectScanSignals().
+     *  Uses stored handler IDs so it does not accidentally remove connect-path
+     *  handlers on the same signals. */
+    void DisconnectScanSignals();
+
+    /** As DisconnectScanSignals(), for callers that already hold mWpaSupplicantMutex. */
+    void DisconnectScanSignalsLocked() CHIP_REQUIRES(mWpaSupplicantMutex);
+#endif
 
 private:
     CHIP_ERROR _ConnectWiFiNetworkAsync(GVariant * networkArgs,
@@ -234,6 +325,7 @@ private:
     WiFiPAF::WiFiPAFEndPoint mWiFiPAFEndPoint;
     void * mAppState;
     uint16_t mApFreq;
+    uint32_t mPendingConnectSubscribeId = 0; // set by _WiFiPAFSubscribe, read by app layer on timeout
     CHIP_ERROR _WiFiPAFPublish(WiFiPAFAdvertiseParam & args);
     CHIP_ERROR _WiFiPAFCancelPublish(uint32_t PublishId);
     // The resource checking is needed right before sending data packets that they are initialized and connected.

--- a/src/platform/Linux/ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_WiFiPafWpaSupplicant.cpp
@@ -17,12 +17,14 @@
  *    limitations under the License.
  */
 
+#include <algorithm>
 #include <mutex>
 
 #include <stdint.h>
 
 #include <glib.h>
 
+#include <lib/support/BytesToHex.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -185,8 +187,9 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
     dataValue.reset(value);
     g_variant_get(dataValue.get(), "&s", &paddr);
     chip::Platform::CopyString(addr_str, paddr);
-    sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2], &peer_addr[3],
-           &peer_addr[4], &peer_addr[5]);
+    VerifyOrReturn(sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2],
+                          &peer_addr[3], &peer_addr[4], &peer_addr[5]) == 6,
+                   ChipLogError(DeviceLayer, "WiFi-PAF: OnDiscoveryResult: malformed peer_addr '%s'", addr_str));
 
     value = g_variant_lookup_value(discov_info, "srv_proto_type", G_VARIANT_TYPE_UINT32);
     dataValue.reset(value);
@@ -217,10 +220,24 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
         ChipLogError(DeviceLayer, "WiFi-PAF: DiscoveryResult received for non-subscriber session");
         return;
     }
-    if ((pPafInfo->id == subscribe_id) && (pPafInfo->peer_id != UINT32_MAX))
+    // The connect and background-scan discovery handlers are both connected to the
+    // shared "nandiscovery-result" signal, so GLib delivers every discovery to both.
+    // Act only on discovery for THIS session's own subscribe (pPafInfo->id was set to
+    // the connect subscribe_id in _WiFiPAFSubscribe); a (possibly stale) background-
+    // scan subscribe cross-fires here and must not hijack or overwrite the connect
+    // session — before or after it is established.  Matching on subscribe_id rather
+    // than on "peer_id already set" keeps a legitimate re-discovery on the connect's
+    // own (re)subscribe working for the controller path.
+    if (pPafInfo->id != subscribe_id)
     {
-        // Reentrance, depends on wpa_supplicant behaviors
-        ChipLogError(DeviceLayer, "WiFi-PAF: DiscoveryResult, reentrance, subscribe_id: %u ", subscribe_id);
+        ChipLogDetail(DeviceLayer, "WiFi-PAF: DiscoveryResult, subscribe_id=%u not for this session (id=%u), ignoring",
+                      subscribe_id, pPafInfo->id);
+        return;
+    }
+    if (pPafInfo->peer_id != UINT32_MAX)
+    {
+        // Reentrance: a duplicate discovery for our own, already-established session.
+        ChipLogError(DeviceLayer, "WiFi-PAF: DiscoveryResult, reentrance, subscribe_id: %u", subscribe_id);
         return;
     }
     if (srv_proto_type != nan_service_protocol_type::NAN_SRV_PROTO_CSA_MATTER)
@@ -286,8 +303,9 @@ void ConnectivityManagerImpl::OnReplied(GVariant * reply_info)
     dataValue.reset(value);
     g_variant_get(dataValue.get(), "&s", &paddr);
     chip::Platform::CopyString(addr_str, paddr);
-    sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2], &peer_addr[3],
-           &peer_addr[4], &peer_addr[5]);
+    VerifyOrReturn(sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2],
+                          &peer_addr[3], &peer_addr[4], &peer_addr[5]) == 6,
+                   ChipLogError(DeviceLayer, "WiFi-PAF: OnReplied: malformed peer_addr '%s'", addr_str));
 
     value = g_variant_lookup_value(reply_info, "srv_proto_type", G_VARIANT_TYPE_UINT32);
     dataValue.reset(value);
@@ -377,8 +395,9 @@ void ConnectivityManagerImpl::OnNanReceive(GVariant * obj)
     dataValue.reset(value);
     g_variant_get(dataValue.get(), "&s", &paddr);
     chip::Platform::CopyString(addr_str, paddr);
-    sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &RxInfo.peer_addr[0], &RxInfo.peer_addr[1], &RxInfo.peer_addr[2],
-           &RxInfo.peer_addr[3], &RxInfo.peer_addr[4], &RxInfo.peer_addr[5]);
+    VerifyOrReturn(sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &RxInfo.peer_addr[0], &RxInfo.peer_addr[1],
+                          &RxInfo.peer_addr[2], &RxInfo.peer_addr[3], &RxInfo.peer_addr[4], &RxInfo.peer_addr[5]) == 6,
+                   ChipLogError(DeviceLayer, "WiFi-PAF: OnNanReceive: malformed peer_addr '%s'", addr_str));
 
     // Read the rx_data
     gsize bufferLen;
@@ -518,8 +537,9 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSubscribe(const uint16_t & connDiscr
     wpa_supplicant_1_interface_call_nansubscribe_sync(mWpaSupplicant.iface.get(), args, &subscribe_id, nullptr, &err.GetReceiver());
 
     ChipLogProgress(DeviceLayer, "WiFi-PAF: subscribe_id: [%u], freq: %u", subscribe_id, freq);
-    mOnPafSubscribeComplete = onSuccess;
-    mOnPafSubscribeError    = onError;
+    mPendingConnectSubscribeId = subscribe_id;
+    mOnPafSubscribeComplete    = onSuccess;
+    mOnPafSubscribeError       = onError;
 
     WiFiPAFSession sessionInfo  = { .discriminator = PafPublish_ssi.DevInfo };
     WiFiPAFLayer & WiFiPafLayer = WiFiPAFLayer::GetWiFiPAFLayer();
@@ -629,6 +649,576 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFShutdown(uint32_t id, WiFiPAF::WiFiP
     }
     return CHIP_ERROR_INTERNAL;
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
+
+static uint16_t FreqToBand(uint32_t freq)
+{
+    // 2.4 GHz: channels 1–13 (2412–2472 MHz) plus channel 14 (2484 MHz).
+    if ((freq >= 2412 && freq <= 2472) || freq == 2484)
+        return static_cast<uint16_t>(0x0001u); // k2g4
+    // 5 GHz: main range plus the two additional channels above the main range.
+    if ((freq >= 5035 && freq <= 5945) || freq == 5960 || freq == 5980)
+        return static_cast<uint16_t>(0x0004u); // k5g
+    return 0;
+}
+
+// Context for dispatching background-scan discovery results onto the CHIP event loop.
+namespace {
+struct BgScanWorkCtx
+{
+    chip::DeviceLayer::ConnectivityManagerImpl::BgScanDiscoveryCallback cb;
+    void * cbCtx;
+    chip::DeviceLayer::NanPeerInfo peer;
+};
+} // namespace
+
+void ConnectivityManagerImpl::ConnectScanSignals()
+{
+    // Connected before NANSubscribe, not after: discovery is dispatched on the GLib
+    // main-loop thread, which runs while this thread blocks inside the synchronous
+    // NANSubscribe call, so a fast responder can emit nandiscovery-result before that
+    // call returns and a handler connected afterwards would never see it.  The caller
+    // holds mWpaSupplicantMutex across the subscribe and ScanDiscoveryResult takes the
+    // same mutex, so an early result waits until the new subscribe_id has been stored.
+    if (!mWpaSupplicant.iface)
+        return;
+
+    mScanSignalIds[0] = g_signal_connect(mWpaSupplicant.iface.get(), "nandiscovery-result",
+                                         G_CALLBACK(+[](WpaSupplicant1Interface * proxy, GVariant * obj,
+                                                        ConnectivityManagerImpl * self) { return self->ScanDiscoveryResult(obj); }),
+                                         this);
+    mScanSignalIds[1] = g_signal_connect(mWpaSupplicant.iface.get(), "nanreceive",
+                                         G_CALLBACK(+[](WpaSupplicant1Interface * proxy, GVariant * obj,
+                                                        ConnectivityManagerImpl * self) { return self->ScanNanReceive(obj); }),
+                                         this);
+    mScanSignalIds[2] = g_signal_connect(
+        mWpaSupplicant.iface.get(), "nansubscribe-terminated",
+        G_CALLBACK(+[](WpaSupplicant1Interface * proxy, guint term_subscribe_id, gchar * reason, ConnectivityManagerImpl * self) {
+            return self->ScanNanSubscribeTerminated(term_subscribe_id, reason);
+        }),
+        this);
+}
+
+void ConnectivityManagerImpl::DisconnectScanSignalsLocked()
+{
+    if (!mWpaSupplicant.iface)
+        return;
+
+    GObject * obj = G_OBJECT(mWpaSupplicant.iface.get());
+    for (gulong & id : mScanSignalIds)
+    {
+        if (id != 0)
+        {
+            g_signal_handler_disconnect(obj, id);
+            id = 0;
+        }
+    }
+}
+
+void ConnectivityManagerImpl::DisconnectScanSignals()
+{
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+    DisconnectScanSignalsLocked();
+}
+
+// Scan for Matter PAF devices, but don't connect
+void ConnectivityManagerImpl::ScanDiscoveryResult(GVariant * discov_info)
+{
+    uint32_t peer_publish_id;
+    uint8_t peer_addr[6];
+    uint32_t srv_proto_type;
+    uint32_t subscribe_id;
+
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+    if (g_variant_n_children(discov_info) == 0)
+    {
+        return;
+    }
+
+    // Read the data from dbus
+    GAutoPtr<GVariant> dataValue;
+    GVariant * value;
+
+    value = g_variant_lookup_value(discov_info, "subscribe_id", G_VARIANT_TYPE_UINT32);
+    dataValue.reset(value);
+    g_variant_get(dataValue.get(), "u", &subscribe_id);
+    ChipLogDetail(DeviceLayer, "ScanDiscoveryResult: subscribe_id=%u", subscribe_id);
+
+    // Ignore results from orphaned wpa_supplicant subscriptions (e.g. from
+    // previous process runs that weren't cancelled). Only accept results from
+    // the currently active scan subscription.
+    {
+        uint32_t expected = (mBgScanCb != nullptr) ? mBgScanSubscribeId : mActiveScanSubscribeId;
+        if (expected == 0 || subscribe_id != expected)
+        {
+            ChipLogProgress(DeviceLayer, "ScanDiscoveryResult: ignoring stale subscribe_id=%u (expected=%u)", subscribe_id,
+                            expected);
+            return;
+        }
+    }
+
+    value = g_variant_lookup_value(discov_info, "publish_id", G_VARIANT_TYPE_UINT32);
+    dataValue.reset(value);
+    g_variant_get(dataValue.get(), "u", &peer_publish_id);
+    char addr_str[20];
+    char * paddr;
+    value = g_variant_lookup_value(discov_info, "peer_addr", G_VARIANT_TYPE_STRING);
+    dataValue.reset(value);
+    g_variant_get(dataValue.get(), "&s", &paddr);
+    chip::Platform::CopyString(addr_str, paddr);
+    VerifyOrReturn(sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2],
+                          &peer_addr[3], &peer_addr[4], &peer_addr[5]) == 6,
+                   ChipLogError(DeviceLayer, "WiFi-PAF: ScanDiscoveryResult: malformed peer_addr '%s'", addr_str));
+    value = g_variant_lookup_value(discov_info, "srv_proto_type", G_VARIANT_TYPE_UINT32);
+    dataValue.reset(value);
+    g_variant_get(dataValue.get(), "u", &srv_proto_type);
+
+    // Read the variable length Extended data from the SSI, as per R1.5 Section 5.4.2.6.3
+    size_t bufferLen;
+    value = g_variant_lookup_value(discov_info, "ssi", G_VARIANT_TYPE_BYTESTRING);
+    dataValue.reset(value);
+    auto ssibuf = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
+    VerifyOrReturn(bufferLen >= sizeof(PAFPublishSSI), ChipLogError(DeviceLayer, "WiFi-PAF: ScanDiscoveryResult SSI too short"));
+    auto pPublishSSI = reinterpret_cast<const PAFPublishSSI *>(ssibuf);
+
+    NanPeerInfo peer;
+    peer.vid           = pPublishSSI->VendorId;
+    peer.pid           = pPublishSSI->ProductId;
+    peer.opcode        = pPublishSSI->DevOpCode;
+    peer.discriminator = pPublishSSI->DevInfo;
+    std::memcpy(peer.mac, peer_addr, sizeof(peer_addr));
+    // ExtendedData (optional, core R1.4.2 5.4.2.6.3) follows the mandatory
+    // PAFPublishSSI struct.
+    if (bufferLen > sizeof(PAFPublishSSI))
+    {
+        const auto * bytes = static_cast<const uint8_t *>(ssibuf);
+        peer.storage.assign(bytes + sizeof(PAFPublishSSI), bytes + bufferLen);
+        peer.hasExtendedData = true;
+    }
+
+    // Set WiFiBand from the frequency used when the scan was started.
+    peer.band = FreqToBand(mScanFreq);
+
+    // The bg-scan callback uses SystemLayer and cluster APIs which require
+    // the CHIP stack lock.  ScanDiscoveryResult runs on a GLib/dbus thread,
+    // so schedule the callback on the CHIP event loop instead of calling directly.
+    if (mBgScanCb != nullptr)
+    {
+        auto * workCtx      = new BgScanWorkCtx{ mBgScanCb, mBgScanCbCtx, peer };
+        CHIP_ERROR schedErr = chip::DeviceLayer::PlatformMgr().ScheduleWork(
+            +[](intptr_t arg) {
+                auto * w = reinterpret_cast<BgScanWorkCtx *>(arg);
+                w->cb(w->cbCtx, w->peer);
+                delete w;
+            },
+            reinterpret_cast<intptr_t>(workCtx));
+        if (schedErr != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "ScanDiscoveryResult: ScheduleWork failed: %" CHIP_ERROR_FORMAT, schedErr.Format());
+            delete workCtx;
+        }
+    }
+
+    // A peer already in the window is not logged again: a single device produces a
+    // discovery event every few hundred ms
+    if (std::find(mNanScanPeers.begin(), mNanScanPeers.end(), peer) != mNanScanPeers.end())
+    {
+        return;
+    }
+
+    // Rolling window. A background scan runs with no timeout, so the window is bounded.
+    // Once full, a new peer overwrites the oldest rather than being dropped, so a device.
+    if (mNanScanPeers.size() < kMaxScanPeers)
+    {
+        mNanScanPeers.push_back(peer);
+    }
+    else
+    {
+        mNanScanPeers[mNanScanPeersNext] = peer;
+        mNanScanPeersNext                = (mNanScanPeersNext + 1) % kMaxScanPeers;
+    }
+
+    ChipLogProgress(DeviceLayer, "Discovered Device: %s() Subscribe_id:%u peer_publish_id:%u srv_proto_type:%u", __func__,
+                    subscribe_id, peer_publish_id, srv_proto_type);
+    ChipLogProgress(DeviceLayer, "\tDiscriminator:%u Opcode:%u PID:0x%X VID:0x%X", pPublishSSI->DevInfo, pPublishSSI->DevOpCode,
+                    pPublishSSI->ProductId, pPublishSSI->VendorId);
+    ChipLogProgress(DeviceLayer, "\tpeer_addr: [%02x:%02x:%02x:%02x:%02x:%02x]", peer_addr[0], peer_addr[1], peer_addr[2],
+                    peer_addr[3], peer_addr[4], peer_addr[5]);
+    ChipLogProgress(DeviceLayer, "\tSSI Buffer Len:%lu", bufferLen);
+
+    if (peer.hasExtendedData && !peer.storage.empty())
+    {
+        chip::ByteSpan s(peer.storage.data(), peer.storage.size());
+        constexpr size_t kMaxBytesToPrint     = 20;
+        const size_t bytesToPrint             = (s.size() > kMaxBytesToPrint) ? kMaxBytesToPrint : s.size();
+        char hexBuf[2 * kMaxBytesToPrint + 1] = { 0 };
+        CHIP_ERROR err =
+            chip::Encoding::BytesToHex(s.data(), bytesToPrint, hexBuf, sizeof(hexBuf), chip::Encoding::HexFlags::kUppercase);
+        if (err == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(DeviceLayer, "\tExtendedData (%lu bytes, showing %lu): %s", static_cast<unsigned long>(s.size()),
+                            static_cast<unsigned long>(bytesToPrint), hexBuf);
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "\tExtendedData, BytesToHex failed: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "\tNo Extended Data");
+    }
+}
+
+void ConnectivityManagerImpl::ScanNanReceive(GVariant * obj)
+{
+    ChipLogError(DeviceLayer, "Commissioning Proxy: Unexpected ScanNanReceive");
+}
+
+void ConnectivityManagerImpl::ScanNanSubscribeTerminated(guint subscribe_id, gchar * reason)
+{
+    ChipLogProgress(DeviceLayer, "Commissioning Proxy: Subscription terminated (%u, %s)", subscribe_id, reason);
+    // This handler shares the "nansubscribe-terminated" signal with the connect
+    // path (OnNanSubscribeTerminated).  Act only on a subscribe_id that belongs to
+    // a scan; otherwise a terminating connect subscribe would remove the connect
+    // session's PAF entry out from under an in-flight ProxyConnect.
+    {
+        std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+        if (subscribe_id != mActiveScanSubscribeId && subscribe_id != mBgScanSubscribeId)
+        {
+            return;
+        }
+    }
+    WiFiPAFSession sessionInfo  = { .id = subscribe_id };
+    WiFiPAFLayer & WiFiPafLayer = WiFiPAFLayer::GetWiFiPAFLayer();
+    TEMPORARY_RETURN_IGNORED WiFiPafLayer.RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::WiFiPAFScan(uint8_t scanMaxTime, PafScanResultsCallback cb, void * cbContext)
+{
+    // Read/modify the shared scan-callback state under the lock; ScanDiscoveryResult
+    // reads these members on the GLib/D-Bus thread under the same lock.
+    {
+        std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+        // Cannot start a one-shot scan while a background scan is running.
+        VerifyOrReturnError(mBgScanCb == nullptr, CHIP_ERROR_BUSY);
+        mScanCb        = cb;
+        mScanCbContext = cbContext;
+        // Drop peers left over from a previous scan so this one-shot response
+        // reports only devices discovered within this scan window.
+        mNanScanPeers.clear();
+        mNanScanPeersNext = 0;
+    }
+
+    CHIP_ERROR result = StartWiFiManagementSync();
+    if (result != CHIP_NO_ERROR)
+    {
+        // Reset the scan-callback state set above so a transient WiFi-management
+        // startup failure does not leave mScanCb non-null forever, which would wedge
+        // every subsequent background scan into CHIP_ERROR_BUSY for the process life.
+        std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+        mScanCb        = nullptr;
+        mScanCbContext = nullptr;
+        return result;
+    }
+
+    ChipLogProgress(DeviceLayer, "WiFiPAFScan: starting one-shot NAN discovery (maxTime=%us)", scanMaxTime);
+
+    guint subscribe_id;
+    GAutoPtr<GError> err;
+    enum nan_service_protocol_type srv_proto_type = nan_service_protocol_type::NAN_SRV_PROTO_CSA_MATTER;
+    uint8_t is_active                             = false; // passive subscribe = discovery mode
+    // Set the NAN TTL to match the chip-level scan window.  A longer TTL leaves
+    // subscribe_id alive in wpa_supplicant after FinishWiFiPAFScan cancels it,
+    // causing stale nandiscovery-result events during the next scan that mask
+    // results from the new subscribe_id (wpa_supplicant is edge-triggered).
+    unsigned int ttl  = scanMaxTime;
+    unsigned int freq = (mApFreq == 0) ? CHIP_DEVICE_CONFIG_WIFIPAF_24G_DEFAUTL_CHNL : mApFreq;
+
+    // Scoped so the failure handling after the block can call DisconnectScanSignals() /
+    // _WiFiPAFCancelSubscribe(), which take mWpaSupplicantMutex themselves.
+    CHIP_ERROR addErr = CHIP_NO_ERROR;
+    {
+        std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+        mScanFreq = static_cast<uint32_t>(freq);
+        ConnectScanSignals();
+        GVariantBuilder builder;
+        GVariant * args = nullptr;
+        g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+        g_variant_builder_add(&builder, "{sv}", "srv_name", g_variant_new_string(srv_name));
+        g_variant_builder_add(&builder, "{sv}", "srv_proto_type", g_variant_new_byte(srv_proto_type));
+        g_variant_builder_add(&builder, "{sv}", "active", g_variant_new_boolean(is_active));
+        g_variant_builder_add(&builder, "{sv}", "ttl", g_variant_new_uint16(ttl));
+        g_variant_builder_add(&builder, "{sv}", "freq", g_variant_new_uint16(freq));
+        g_variant_builder_add(&builder, "{sv}", "discovery_only", g_variant_new_boolean(TRUE));
+        args = g_variant_builder_end(&builder);
+        wpa_supplicant_1_interface_call_nansubscribe_sync(mWpaSupplicant.iface.get(), args, &subscribe_id, nullptr,
+                                                          &err.GetReceiver());
+
+        if (err.get() != nullptr)
+        {
+            ChipLogError(DeviceLayer, "WiFiPAFScan: nansubscribe failed: %s", err->message);
+            ChipLogError(DeviceLayer, "WiFiPAFScan: Check wpa_supplicant supports discovery_only flag");
+            DisconnectScanSignalsLocked();
+            mScanCb        = nullptr;
+            mScanCbContext = nullptr;
+            return CHIP_ERROR_INTERNAL;
+        }
+
+        ChipLogProgress(DeviceLayer, "WiFiPAFScan: subscribe_id=%u freq=%u", subscribe_id, freq);
+        mActiveScanSubscribeId      = static_cast<uint32_t>(subscribe_id);
+        WiFiPAFSession sessionInfo  = { .role = WiFiPafRole::kWiFiPafRole_Subscriber, .id = subscribe_id };
+        WiFiPAFLayer & WiFiPafLayer = WiFiPAFLayer::GetWiFiPAFLayer();
+        addErr                      = WiFiPafLayer.AddPafSession(PafInfoAccess::kAccSessionId, sessionInfo);
+        if (addErr != CHIP_NO_ERROR)
+        {
+            // The subscribe is already live in wpa_supplicant.  Reset the scan state here
+            // and cancel the subscribe after the lock is released; leaving mScanCb set
+            // would wedge every later background scan into CHIP_ERROR_BUSY for the life of
+            // the process, and the orphaned subscribe would keep emitting
+            // nandiscovery-result events.
+            ChipLogError(DeviceLayer, "WiFiPAFScan: AddPafSession failed: %" CHIP_ERROR_FORMAT, addErr.Format());
+            DisconnectScanSignalsLocked();
+            mActiveScanSubscribeId = 0;
+            mScanFreq              = 0;
+            mScanCb                = nullptr;
+            mScanCbContext         = nullptr;
+        }
+        else
+        {
+            auto pPafInfo = WiFiPafLayer.GetPAFInfo(PafInfoAccess::kAccSessionId, sessionInfo);
+            if (pPafInfo != nullptr)
+            {
+                pPafInfo->id   = subscribe_id;
+                pPafInfo->role = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber;
+            }
+        }
+    }
+
+    if (addErr != CHIP_NO_ERROR)
+    {
+        CHIP_ERROR cancelErr = _WiFiPAFCancelSubscribe(subscribe_id);
+        if (cancelErr != CHIP_NO_ERROR)
+        {
+            ChipLogDetail(DeviceLayer, "WiFiPAFScan: CancelSubscribe(%u): %" CHIP_ERROR_FORMAT, subscribe_id, cancelErr.Format());
+        }
+        return addErr;
+    }
+
+    ChipLogProgress(DeviceLayer, "WiFiPAFScan: timeout in %d seconds on subscribe_id %u", scanMaxTime, subscribe_id);
+    auto * ctx          = new ScanTimerCtx{ this, subscribe_id };
+    CHIP_ERROR timerErr = SystemLayer().StartTimer(
+        System::Clock::Milliseconds32(scanMaxTime * 1000),
+        +[](System::Layer *, void * context) {
+            auto * timerCtx = static_cast<ScanTimerCtx *>(context);
+            timerCtx->self->FinishWiFiPAFScan(timerCtx);
+            delete timerCtx;
+        },
+        ctx);
+    if (timerErr != CHIP_NO_ERROR)
+    {
+        // Nothing would ever call FinishWiFiPAFScan, so the subscribe, the signal handlers
+        // and mScanCb would all outlive this call.  Tear the scan down here and free the
+        // context the timer would have owned.
+        ChipLogError(DeviceLayer, "WiFiPAFScan: StartTimer failed: %" CHIP_ERROR_FORMAT, timerErr.Format());
+        delete ctx;
+        {
+            std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+            mActiveScanSubscribeId = 0;
+            mScanFreq              = 0;
+            mScanCb                = nullptr;
+            mScanCbContext         = nullptr;
+        }
+        DisconnectScanSignals();
+        CHIP_ERROR cancelErr = _WiFiPAFCancelSubscribe(subscribe_id);
+        if (cancelErr != CHIP_NO_ERROR)
+        {
+            ChipLogDetail(DeviceLayer, "WiFiPAFScan: CancelSubscribe(%u): %" CHIP_ERROR_FORMAT, subscribe_id, cancelErr.Format());
+        }
+        WiFiPAFSession failedSession = { .role = WiFiPafRole::kWiFiPafRole_Subscriber, .id = subscribe_id };
+        CHIP_ERROR rmErr             = WiFiPAFLayer::GetWiFiPAFLayer().RmPafSession(PafInfoAccess::kAccSessionId, failedSession);
+        if (rmErr != CHIP_NO_ERROR)
+        {
+            ChipLogDetail(DeviceLayer, "WiFiPAFScan: RmPafSession: %" CHIP_ERROR_FORMAT, rmErr.Format());
+        }
+        return timerErr;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl::FinishWiFiPAFScan(ScanTimerCtx * ctx)
+{
+    ChipLogProgress(DeviceLayer, "FinishWiFiPAFScan: subscribe_id %u", ctx->subscribe_id);
+    DisconnectScanSignals();
+    TEMPORARY_RETURN_IGNORED _WiFiPAFCancelSubscribe(ctx->subscribe_id);
+    // NOTE: do not call _WiFiPAFCancelIncompleteSubscribe() here.  That clears the
+    // connect-path subscribe-complete/error callbacks (mOnPafSubscribe*), which may
+    // belong to a ProxyConnectRequest subscribe still in flight.  Cancelling this
+    // scan's subscribe_id above is sufficient to tear down the scan.
+
+    WiFiPAFSession sessionInfo  = { .role = WiFiPafRole::kWiFiPafRole_Subscriber, .id = ctx->subscribe_id };
+    WiFiPAFLayer & WiFiPafLayer = WiFiPAFLayer::GetWiFiPAFLayer();
+    TEMPORARY_RETURN_IGNORED WiFiPafLayer.RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo);
+
+    // Hold the mutex while collecting and clearing mNanScanPeers so that a
+    // ScanDiscoveryResult running concurrently on the GLib/D-Bus thread cannot
+    // write to the set at the same time.  Moving mActiveScanSubscribeId = 0
+    // inside the lock ensures any ScanDiscoveryResult that acquires the lock
+    // after us sees expected == 0 and correctly discards the late event.
+    std::vector<NanPeerInfo> results;
+    {
+        std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+        results.reserve(mNanScanPeers.size());
+        for (auto & p : mNanScanPeers)
+            results.push_back(p);
+        mNanScanPeers.clear();
+        mNanScanPeersNext      = 0;
+        mActiveScanSubscribeId = 0;
+        mScanFreq              = 0;
+    }
+
+    if (mScanCb != nullptr)
+        mScanCb(mScanCbContext, results);
+
+    mScanCb        = nullptr;
+    mScanCbContext = nullptr;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::WiFiPAFStartBackgroundScan(BgScanDiscoveryCallback cb, void * cbCtx)
+{
+    VerifyOrReturnError(cb != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Read/modify the shared scan-callback state under the lock; ScanDiscoveryResult
+    // reads these members on the GLib/D-Bus thread under the same lock.
+    {
+        std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+        VerifyOrReturnError(mScanCb == nullptr, CHIP_ERROR_BUSY);
+        // Already running — update callback and return success.
+        if (mBgScanCb != nullptr)
+        {
+            mBgScanCb    = cb;
+            mBgScanCbCtx = cbCtx;
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    CHIP_ERROR result = StartWiFiManagementSync();
+    VerifyOrReturnError(result == CHIP_NO_ERROR, result);
+
+    ChipLogProgress(DeviceLayer, "WiFiPAFStartBackgroundScan: starting continuous NAN discovery");
+
+    guint subscribe_id;
+    GAutoPtr<GError> err;
+    enum nan_service_protocol_type srv_proto_type = nan_service_protocol_type::NAN_SRV_PROTO_CSA_MATTER;
+    uint8_t is_active                             = false; // passive subscribe = discovery mode
+    unsigned int ttl                              = 0;     // 0 = infinite in wpa_supplicant
+    unsigned int freq                             = (mApFreq == 0) ? CHIP_DEVICE_CONFIG_WIFIPAF_24G_DEFAUTL_CHNL : mApFreq;
+
+    // Scoped so the failure handling after the block can call _WiFiPAFCancelSubscribe(),
+    // which takes mWpaSupplicantMutex itself.
+    CHIP_ERROR addErr = CHIP_NO_ERROR;
+    {
+        std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+        mScanFreq = static_cast<uint32_t>(freq);
+        ConnectScanSignals();
+        GVariantBuilder builder;
+        g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+        g_variant_builder_add(&builder, "{sv}", "srv_name", g_variant_new_string(srv_name));
+        g_variant_builder_add(&builder, "{sv}", "srv_proto_type", g_variant_new_byte(srv_proto_type));
+        g_variant_builder_add(&builder, "{sv}", "active", g_variant_new_boolean(is_active));
+        g_variant_builder_add(&builder, "{sv}", "ttl", g_variant_new_uint16(ttl));
+        g_variant_builder_add(&builder, "{sv}", "freq", g_variant_new_uint16(freq));
+        g_variant_builder_add(&builder, "{sv}", "discovery_only", g_variant_new_boolean(TRUE));
+        GVariant * args = g_variant_builder_end(&builder);
+        wpa_supplicant_1_interface_call_nansubscribe_sync(mWpaSupplicant.iface.get(), args, &subscribe_id, nullptr,
+                                                          &err.GetReceiver());
+
+        if (err.get() != nullptr)
+        {
+            ChipLogError(DeviceLayer, "WiFiPAFStartBackgroundScan: nansubscribe failed: %s", err->message);
+            DisconnectScanSignalsLocked();
+            return CHIP_ERROR_INTERNAL;
+        }
+
+        ChipLogProgress(DeviceLayer, "WiFiPAFStartBackgroundScan: subscribe_id=%u freq=%u", subscribe_id, freq);
+
+        WiFiPAFSession sessionInfo  = { .role = WiFiPafRole::kWiFiPafRole_Subscriber, .id = subscribe_id };
+        WiFiPAFLayer & WiFiPafLayer = WiFiPAFLayer::GetWiFiPAFLayer();
+        addErr                      = WiFiPafLayer.AddPafSession(PafInfoAccess::kAccSessionId, sessionInfo);
+        if (addErr != CHIP_NO_ERROR)
+        {
+            // mBgScanCb is still null here, so WiFiPAFStopBackgroundScan() would early-return
+            // and could never cancel this subscribe.  Cancel it after the lock is released or
+            // it is orphaned in wpa_supplicant, where its stale nandiscovery-result events go
+            // on to mask results from the next subscribe_id (wpa_supplicant is edge-triggered).
+            ChipLogError(DeviceLayer, "WiFiPAFStartBackgroundScan: AddPafSession failed: %" CHIP_ERROR_FORMAT, addErr.Format());
+            DisconnectScanSignalsLocked();
+            mScanFreq = 0;
+        }
+        else
+        {
+            mBgScanCb          = cb;
+            mBgScanCbCtx       = cbCtx;
+            mBgScanSubscribeId = static_cast<uint32_t>(subscribe_id);
+        }
+    }
+
+    if (addErr != CHIP_NO_ERROR)
+    {
+        CHIP_ERROR cancelErr = _WiFiPAFCancelSubscribe(subscribe_id);
+        if (cancelErr != CHIP_NO_ERROR)
+        {
+            ChipLogDetail(DeviceLayer, "WiFiPAFStartBackgroundScan: CancelSubscribe(%u): %" CHIP_ERROR_FORMAT, subscribe_id,
+                          cancelErr.Format());
+        }
+        return addErr;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl::WiFiPAFStopBackgroundScan()
+{
+    // Snapshot and clear the shared bg-scan state under the lock so a
+    // ScanDiscoveryResult running on the GLib/D-Bus thread (which reads these
+    // members under the same lock) cannot observe a half-torn-down scan.  Once
+    // mBgScanCb/mBgScanSubscribeId are cleared, a late discovery is discarded.
+    uint32_t subscribeId = 0;
+    {
+        std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+        if (mBgScanCb == nullptr)
+            return;
+        subscribeId        = mBgScanSubscribeId;
+        mBgScanCb          = nullptr;
+        mBgScanCbCtx       = nullptr;
+        mBgScanSubscribeId = 0;
+        mScanFreq          = 0;
+        // Clear accumulated peers so they cannot leak into a subsequent one-shot
+        // scan's ProxyScanResponse (and so a long-lived bg scan does not grow the
+        // set without bound).
+        mNanScanPeers.clear();
+        mNanScanPeersNext = 0;
+    }
+
+    ChipLogProgress(DeviceLayer, "WiFiPAFStopBackgroundScan: stopping subscribe_id=%u", subscribeId);
+
+    // DisconnectScanSignals() and _WiFiPAFCancelSubscribe() each take
+    // mWpaSupplicantMutex internally, so they MUST be called without holding it.
+    DisconnectScanSignals();
+    CHIP_ERROR cancelErr = _WiFiPAFCancelSubscribe(subscribeId);
+    if (cancelErr != CHIP_NO_ERROR)
+        ChipLogDetail(DeviceLayer, "WiFiPAFStopBackgroundScan: CancelSubscribe: %" CHIP_ERROR_FORMAT, cancelErr.Format());
+
+    WiFiPAFSession sessionInfo  = { .role = WiFiPafRole::kWiFiPafRole_Subscriber, .id = subscribeId };
+    WiFiPAFLayer & WiFiPafLayer = WiFiPAFLayer::GetWiFiPAFLayer();
+    CHIP_ERROR rmErr            = WiFiPafLayer.RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo);
+    if (rmErr != CHIP_NO_ERROR)
+        ChipLogDetail(DeviceLayer, "WiFiPAFStopBackgroundScan: RmPafSession: %" CHIP_ERROR_FORMAT, rmErr.Format());
+}
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONING_PROXY
 
 void ConnectivityManagerImpl::PostWpaInterfaceProxyReady()
 {

--- a/src/wifipaf/WiFiPAFLayer.cpp
+++ b/src/wifipaf/WiFiPAFLayer.cpp
@@ -471,6 +471,15 @@ CHIP_ERROR WiFiPAFLayer::AddPafSession(PafInfoAccess accType, WiFiPAFSession & S
                 return CHIP_NO_ERROR;
             }
             break;
+        case PafInfoAccess::kAccDisc:
+            // A free slot carries UINT16_MAX, which is outside the 12-bit discriminator
+            // range, so a valid discriminator cannot alias one.
+            if (pPafSession->discriminator == SessionInfo.discriminator)
+            {
+                // Already exist
+                return CHIP_NO_ERROR;
+            }
+            break;
         default:
             return CHIP_ERROR_NOT_IMPLEMENTED;
         };
@@ -497,6 +506,10 @@ CHIP_ERROR WiFiPAFLayer::AddPafSession(PafInfoAccess accType, WiFiPAFSession & S
             pPafSession->id = SessionInfo.id;
             ChipLogProgress(WiFiPAF, "WiFiPAF: Add session with id: %u", SessionInfo.id);
             return CHIP_NO_ERROR;
+        case PafInfoAccess::kAccDisc:
+            pPafSession->discriminator = SessionInfo.discriminator;
+            ChipLogProgress(WiFiPAF, "WiFiPAF: Add session with disc: %x", SessionInfo.discriminator);
+            return CHIP_NO_ERROR;
         default:
             return CHIP_ERROR_NOT_IMPLEMENTED;
         };
@@ -519,7 +532,14 @@ CHIP_ERROR WiFiPAFLayer::RmPafSession(PafInfoAccess accType, WiFiPAFSession & Se
             if (pPafSession->id == SessionInfo.id)
             {
                 ChipLogProgress(WiFiPAF, "Removing session with id: %u", pPafSession->id);
-                // Clear the slot
+                CleanPafInfo(*pPafSession);
+                return CHIP_NO_ERROR;
+            }
+            break;
+        case PafInfoAccess::kAccDisc:
+            if (pPafSession->discriminator == SessionInfo.discriminator)
+            {
+                ChipLogProgress(WiFiPAF, "Removing session with disc: %x", pPafSession->discriminator);
                 CleanPafInfo(*pPafSession);
                 return CHIP_NO_ERROR;
             }
@@ -530,6 +550,20 @@ CHIP_ERROR WiFiPAFLayer::RmPafSession(PafInfoAccess accType, WiFiPAFSession & Se
     }
     ChipLogError(WiFiPAF, "No PAF session found");
     return CHIP_ERROR_NOT_FOUND;
+}
+
+void WiFiPAFLayer::CloseEndPoint(WiFiPAFSession & SessionInfo)
+{
+    WiFiPAFEndPoint * endPoint = sWiFiPAFEndPointPool.Find(reinterpret_cast<WIFIPAF_CONNECTION_OBJECT>(&SessionInfo));
+    if (endPoint != nullptr)
+    {
+        ChipLogProgress(WiFiPAF, "CloseEndPoint: closing PAFTP endpoint for session id=%u", SessionInfo.id);
+        endPoint->DoClose(kWiFiPAFCloseFlag_AbortTransmission, WIFIPAF_ERROR_APP_CLOSED_CONNECTION);
+    }
+    else
+    {
+        ChipLogDetail(WiFiPAF, "CloseEndPoint: no endpoint found for session id=%u", SessionInfo.id);
+    }
 }
 
 WiFiPAFSession * WiFiPAFLayer::GetPAFInfo(PafInfoAccess accType, WiFiPAFSession & SessionInfo)

--- a/src/wifipaf/WiFiPAFLayer.h
+++ b/src/wifipaf/WiFiPAFLayer.h
@@ -23,6 +23,7 @@
 #include "WiFiPAFRole.h"
 #include <lib/core/CHIPError.h>
 #include <lib/support/DLLUtil.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <system/SystemLayer.h>
 #include <system/SystemPacketBuffer.h>
 
@@ -201,6 +202,12 @@ public:
     CHIP_ERROR AddPafSession(PafInfoAccess accType, WiFiPAFSession & SessionInfo);
     CHIP_ERROR RmPafSession(PafInfoAccess accType, WiFiPAFSession & SessionInfo);
     WiFiPAFSession * GetPAFInfo(PafInfoAccess accType, WiFiPAFSession & SessionInfo);
+
+    /** Close the PAFTP endpoint for a session, cancelling all pending timers.
+     *  Matches by session id, peer_id and peer_addr.  Safe to call after
+     *  RmPafSession since it uses the endpoint's own mSessionInfo, not
+     *  mPafInfoVect. */
+    void CloseEndPoint(WiFiPAFSession & SessionInfo);
 
 private:
     void InitialPafInfo();

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -226,6 +226,41 @@ TEST_F(TestWiFiPAFLayer, CheckPafSession)
     EXPECT_EQ(RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo), CHIP_ERROR_NOT_FOUND);
 }
 
+TEST_F(TestWiFiPAFLayer, CheckPafSessionKeyedOnDiscriminator)
+{
+    // A discriminator of 0 is in range, and it is also the value of kUndefinedNodeId,
+    // so a caller that has only a discriminator must not borrow the nodeId key to
+    // register the session.
+    WiFiPAF::WiFiPAFSession sessionInfo = { .role = kWiFiPafRole_Subscriber, .discriminator = 0 };
+    EXPECT_EQ(AddPafSession(PafInfoAccess::kAccDisc, sessionInfo), CHIP_NO_ERROR);
+
+    // Adding the same discriminator again finds the existing slot rather than taking
+    // a second one.
+    EXPECT_EQ(AddPafSession(PafInfoAccess::kAccDisc, sessionInfo), CHIP_NO_ERROR);
+
+    WiFiPAFSession * pSession = GetPAFInfo(PafInfoAccess::kAccDisc, sessionInfo);
+    ASSERT_NE(pSession, nullptr);
+    EXPECT_EQ(pSession->discriminator, 0);
+    EXPECT_EQ(pSession->role, kWiFiPafRole_Subscriber);
+    EXPECT_EQ(pSession->nodeId, kUndefinedNodeId);
+    EXPECT_EQ(pSession->id, kUndefinedWiFiPafSessionId);
+
+    // A second discriminator takes the other slot, and a third has nowhere to go.
+    WiFiPAF::WiFiPAFSession secondInfo = { .role = kWiFiPafRole_Subscriber, .discriminator = 0xF01 };
+    EXPECT_EQ(AddPafSession(PafInfoAccess::kAccDisc, secondInfo), CHIP_NO_ERROR);
+    WiFiPAF::WiFiPAFSession thirdInfo = { .role = kWiFiPafRole_Subscriber, .discriminator = 0xF02 };
+    EXPECT_EQ(AddPafSession(PafInfoAccess::kAccDisc, thirdInfo), CHIP_ERROR_PROVIDER_LIST_EXHAUSTED);
+
+    // Removing by discriminator frees the slot it was added under.
+    EXPECT_EQ(RmPafSession(PafInfoAccess::kAccDisc, sessionInfo), CHIP_NO_ERROR);
+    EXPECT_EQ(RmPafSession(PafInfoAccess::kAccDisc, sessionInfo), CHIP_ERROR_NOT_FOUND);
+    EXPECT_EQ(GetPAFInfo(PafInfoAccess::kAccDisc, sessionInfo), nullptr);
+
+    EXPECT_EQ(AddPafSession(PafInfoAccess::kAccDisc, thirdInfo), CHIP_NO_ERROR);
+    EXPECT_EQ(RmPafSession(PafInfoAccess::kAccDisc, secondInfo), CHIP_NO_ERROR);
+    EXPECT_EQ(RmPafSession(PafInfoAccess::kAccDisc, thirdInfo), CHIP_NO_ERROR);
+}
+
 // Run under ASan to catch regressions of the heap-buffer-overflow read.
 TEST_F(TestWiFiPAFLayer, GetPktSnRejectsShortFragment)
 {


### PR DESCRIPTION
### Summary

This is a cherrypick from #72818 (master commit `9d5d6b7ccd3`) onto `v1.7-branch`.

Mergify's automatic backport, #74050, committed conflict markers to its branch
instead of leaving the PR unmerged, so every job that builds `all-devices-app` fails
with `error: version control conflict marker in file`. That branch lives in
`project-chip`, so it cannot be replaced by a force-push from a fork; this PR replaces
it.

All 31 files in `v1.7-branch` are exactly as master `9d5d6b7ccd3` , with the exception of the
conflict marker in
`examples/all-devices-app/all-devices-common/device/types/commissioning-proxy/README.md`,
which prettier had reflowed into a paragraph so no linter caught it. This PR keeps the
first of the two alternatives and drops the second.

### Related issues

Backport of #72818. Replaces #74050.

### Testing

No new tests. The unit tests added by #72818 — `TestAppOptions`,
`TestCommissioningProxyPafTransport` and the `TestWiFiPAFLayer` additions — came across
with the cherry-pick and run in CI on this branch.
