### PR TITLE
[Commissioning Proxy] Remove a stray conflict marker from the README

### DIFF
--- a/examples/all-devices-app/all-devices-common/device/types/commissioning-proxy/README.md
+++ b/examples/all-devices-app/all-devices-common/device/types/commissioning-proxy/README.md
@@ -425,11 +425,7 @@ Adapter and driver are both constructed in
 the single `CommissioningProxyDevice` with `AddTransport()` — a build with BLE
 adds that driver the same way — and derives the advertised `WiFiBand` from
 `--wifipaf freq_list=`, since the device itself reads no command line. The same
-<<<<<<< HEAD parsed list reaches the radio from `posix/main.cpp`. ======= parsed
-list reaches the radio from `posix/main.cpp`. Transports are registered before
-`Server::Init()`, so the fabric table is empty at that point and the driver's
-`DisconnectPublishReceiveHandler()` call lands on the commissioning-complete
-event instead.
+parsed list reaches the radio from `posix/main.cpp`.
 
 <hr>
 


### PR DESCRIPTION
### Summary

#72818 left an unresolved conflict in the CommissioningProxy README. Prettier reflowed
the markers into the paragraph and dropped the closing `>>>>>>>` line, so nothing
flagged it.

This keeps the first of the two alternatives. The second names
`DisconnectPublishReceiveHandler()`, which exists nowhere in the tree.

### Related issues

Follow-up to #72818. No backport needed — `v1.7-branch` gets the corrected text
via #74054.

### Testing

Documentation only, no functional change.