### PR TITLE
[Silabs][Zephyr] Implement SiWx917 OTA.

### DIFF
--- a/config/silabs/Kconfig
+++ b/config/silabs/Kconfig
@@ -25,19 +25,24 @@ config CHIP_DEVICE_VENDOR_NAME
 	string "Vendor Name"
 	default "Silicon Laboratories"
 
-# See config/zephyr/Kconfig for full definition
+# See config/zephyr/Kconfig for full definition.
+# SiWx917 uses the NWP/Security Bootloader RPS path (SIWX91X_FIRMWARE_UPGRADE).
+# EFR32 uses MCUboot (slot-based DFU).
 config CHIP_OTA_REQUESTOR
 	bool "Enable OTA Requestor"
 	default n
-	imply BOOTLOADER_MCUBOOT
-	imply IMG_MANAGER
-	imply STREAM_FLASH
-	imply STREAM_FLASH_ERASE
+	select SIWX91X_FIRMWARE_UPGRADE if SOC_SERIES_SIWG917
+	imply REBOOT if SOC_SERIES_SIWG917
+	imply BOOTLOADER_MCUBOOT if !SOC_SERIES_SIWG917
+	imply IMG_MANAGER if !SOC_SERIES_SIWG917
+	imply STREAM_FLASH if !SOC_SERIES_SIWG917
+	imply STREAM_FLASH_ERASE if !SOC_SERIES_SIWG917
 
 config CHIP_OTA_IMAGE_BUILD
 	bool
 	default y if CHIP_OTA_REQUESTOR
-	depends on SIGN_IMAGES
+	# EFR32 OTA images wrap the MCUboot-signed app; SiWx917 wraps zephyr.rps.
+	depends on SIGN_IMAGES || SOC_SERIES_SIWG917
 
 # Sign the application with the MCUboot ECDSA-P256 development key. Only relevant
 # for MCUboot/OTA builds; replace with a private key for production.

--- a/config/silabs/app/zephyr-post-build.cmake
+++ b/config/silabs/app/zephyr-post-build.cmake
@@ -18,18 +18,78 @@ include(${CHIP_ROOT}/config/zephyr/ota-image.cmake)
 
 # ==============================================================================
 # Create the Matter OTA image for Silabs Zephyr targets.
+#
+# EFR32: wrap the MCUboot-signed application .bin.
+# SiWx917: wrap the SoC-generated zephyr.rps (NWP / Security Bootloader path).
 # ==============================================================================
 if(CONFIG_CHIP_OTA_REQUESTOR)
-    if(CONFIG_MCUBOOT_SIGNATURE_KEY_FILE STREQUAL "")
-        set(ZEPHYR_OUTPUT_NAME "zephyr")
-    else()
-        set(ZEPHYR_OUTPUT_NAME "zephyr.signed")
-    endif()
+    set(ZEPHYR_OUTPUT_DIR ${PROJECT_BINARY_DIR}/zephyr)
 
-    if(CONFIG_CHIP_OTA_IMAGE_BUILD)
-        chip_ota_image(chip-ota-image
-            INPUT_FILES ${PROJECT_BINARY_DIR}/zephyr/${ZEPHYR_OUTPUT_NAME}.bin
-            OUTPUT_FILE ${PROJECT_BINARY_DIR}/zephyr/${CONFIG_CHIP_OTA_IMAGE_FILE_NAME}
-        )
-    endif()
-endif()
+    if(CONFIG_SOC_SERIES_SIWG917)
+        # ------------------------------------------------------------------
+        # SiWx917: Matter OTA payload is the RPS produced by SoC post-build.
+        # Depend on zephyr.bin (known CMake output); post-build creates the RPS
+        # in the same step, so it is present when ota_image_tool runs.
+        # Do not use add_custom_command(TARGET zephyr_final) — that target is
+        # not created in this CMakeLists directory.
+        # ------------------------------------------------------------------
+        if(CONFIG_SIWX91X_SIGN_KEY OR CONFIG_SIWX91X_MIC_KEY)
+            set(SIWX_RPS_INPUT ${ZEPHYR_OUTPUT_DIR}/zephyr.signed.rps)
+        else()
+            set(SIWX_RPS_INPUT ${ZEPHYR_OUTPUT_DIR}/zephyr.rps)
+        endif()
+
+        if(CONFIG_CHIP_OTA_IMAGE_BUILD)
+            set(SIWX_OTA_OUTPUT ${ZEPHYR_OUTPUT_DIR}/${CONFIG_CHIP_OTA_IMAGE_FILE_NAME})
+
+            if(DEFINED APPVERSION)
+                set(SIWX_OTA_ARGS
+                    "--vendor-id" ${CONFIG_CHIP_DEVICE_VENDOR_ID}
+                    "--product-id" ${CONFIG_CHIP_DEVICE_PRODUCT_ID}
+                    "--version" ${APPVERSION}
+                    "--version-str" ${APP_VERSION_EXTENDED_STRING}
+                    "--digest-algorithm" "sha256"
+                )
+            else()
+                set(SIWX_OTA_ARGS
+                    "--vendor-id" ${CONFIG_CHIP_DEVICE_VENDOR_ID}
+                    "--product-id" ${CONFIG_CHIP_DEVICE_PRODUCT_ID}
+                    "--version" ${CONFIG_CHIP_DEVICE_SOFTWARE_VERSION}
+                    "--version-str" ${CONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING}
+                    "--digest-algorithm" "sha256"
+                )
+            endif()
+
+            separate_arguments(SIWX_OTA_EXTRA_ARGS NATIVE_COMMAND "${CONFIG_CHIP_OTA_IMAGE_EXTRA_ARGS}")
+            list(APPEND SIWX_OTA_ARGS ${SIWX_OTA_EXTRA_ARGS})
+            list(APPEND SIWX_OTA_ARGS ${SIWX_RPS_INPUT} ${SIWX_OTA_OUTPUT})
+            string(REPLACE ";" "\n" SIWX_OTA_ARGS_FILE "${SIWX_OTA_ARGS}")
+            file(GENERATE OUTPUT ${SIWX_OTA_OUTPUT}.args CONTENT ${SIWX_OTA_ARGS_FILE})
+
+            add_custom_command(
+                OUTPUT ${SIWX_OTA_OUTPUT}
+                COMMAND ${Python3_EXECUTABLE} ${CHIP_ROOT}/src/app/ota_image_tool.py create @${SIWX_OTA_OUTPUT}.args
+                DEPENDS ${ZEPHYR_OUTPUT_DIR}/zephyr.bin ${CHIP_ROOT}/src/app/ota_image_tool.py
+                COMMENT "Generating Matter OTA image from ${SIWX_RPS_INPUT}"
+                VERBATIM
+            )
+            add_custom_target(chip-ota-image ALL DEPENDS ${SIWX_OTA_OUTPUT})
+        endif()
+    else()
+        # ------------------------------------------------------------------
+        # EFR32 / MCUboot: wrap the signed application binary.
+        # ------------------------------------------------------------------
+        if(CONFIG_MCUBOOT_SIGNATURE_KEY_FILE STREQUAL "")
+            set(ZEPHYR_OUTPUT_NAME "zephyr")
+        else()
+            set(ZEPHYR_OUTPUT_NAME "zephyr.signed")
+        endif()
+
+        if(CONFIG_CHIP_OTA_IMAGE_BUILD)
+            chip_ota_image(chip-ota-image
+                INPUT_FILES ${ZEPHYR_OUTPUT_DIR}/${ZEPHYR_OUTPUT_NAME}.bin
+                OUTPUT_FILE ${ZEPHYR_OUTPUT_DIR}/${CONFIG_CHIP_OTA_IMAGE_FILE_NAME}
+            )
+        endif()
+    endif() # CONFIG_SOC_SERIES_SIWG917
+endif() # CONFIG_CHIP_OTA_REQUESTOR

--- a/config/silabs/cmake/common.cmake
+++ b/config/silabs/cmake/common.cmake
@@ -45,6 +45,7 @@ matter_add_gn_arg_bool  ("chip_enable_wifi"                       CONFIG_CHIP_WI
 matter_add_gn_arg_bool  ("chip_system_config_provide_statistics"  CONFIG_CHIP_STATISTICS)
 matter_add_gn_arg_bool  ("chip_enable_icd_server"                 CONFIG_CHIP_ENABLE_ICD_SUPPORT)
 matter_add_gn_arg_bool  ("chip_enable_ota_requestor"              CONFIG_CHIP_OTA_REQUESTOR)
+matter_add_gn_arg_bool  ("chip_enable_siwx_ota"                   CONFIG_SOC_SERIES_SIWG917)
 
 if(CONFIG_DEBUG)
     matter_add_gn_arg_bool("optimize_debug" true)

--- a/config/silabs/cmake/common.cmake
+++ b/config/silabs/cmake/common.cmake
@@ -45,7 +45,12 @@ matter_add_gn_arg_bool  ("chip_enable_wifi"                       CONFIG_CHIP_WI
 matter_add_gn_arg_bool  ("chip_system_config_provide_statistics"  CONFIG_CHIP_STATISTICS)
 matter_add_gn_arg_bool  ("chip_enable_icd_server"                 CONFIG_CHIP_ENABLE_ICD_SUPPORT)
 matter_add_gn_arg_bool  ("chip_enable_ota_requestor"              CONFIG_CHIP_OTA_REQUESTOR)
-matter_add_gn_arg_bool  ("chip_enable_siwx_ota"                   CONFIG_SOC_SERIES_SIWG917)
+
+# SiWx917 uses RPS firmware-upgrade instead of the default Zephyr MCUboot processor.
+if(CONFIG_SOC_SERIES_SIWG917)
+    matter_add_gn_arg_string("chip_zephyr_ota_image_processor"
+                             "//src/platform/silabs/zephyr:ota-image-processor")
+endif()
 
 if(CONFIG_DEBUG)
     matter_add_gn_arg_bool("optimize_debug" true)

--- a/examples/lighting-app/silabs/zephyr/boards/siwx917_rb4338a.overlay
+++ b/examples/lighting-app/silabs/zephyr/boards/siwx917_rb4338a.overlay
@@ -15,22 +15,27 @@
  */
 
 &flash0 {
-        partitions {
-                factory_partition: partition@3e0000 {
-                        reg = <0x003e0000 DT_SIZE_K(4)>;
-                };
+	partitions {
+		/*
+		 * M4 free space ends at 0x400000 (start of SoC ota_swap_partition).
+		 * code (1912) + factory (4) + settings (32) + storage (92) = 2040 KiB.
+		 * Do not place app NVM inside ota_swap — that region is owned by the
+		 * NWP/Security Bootloader for RPS firmware upgrade.
+		 */
+		factory_partition: partition@3e0000 {
+			reg = <0x003e0000 DT_SIZE_K(4)>;
+		};
 
-                settings_partition: partition@3e1000 {
-                        reg = <0x003e1000 DT_SIZE_K(32)>;
-                };
-        };
+		settings_partition: partition@3e1000 {
+			reg = <0x003e1000 DT_SIZE_K(32)>;
+		};
+	};
 };
 
 &code_partition {
-       reg = <0x00202000 DT_SIZE_K(1912)>;
+	reg = <0x00202000 DT_SIZE_K(1912)>;
 };
 
-
 &storage_partition {
-       reg = <0x003e9000 DT_SIZE_K(92)>;
+	reg = <0x003e9000 DT_SIZE_K(92)>;
 };

--- a/examples/lighting-app/silabs/zephyr/boards/siwx917_rb4342a.overlay
+++ b/examples/lighting-app/silabs/zephyr/boards/siwx917_rb4342a.overlay
@@ -15,22 +15,27 @@
  */
 
 &flash0 {
-        partitions {
-                factory_partition: partition@3e0000 {
-                        reg = <0x003e0000 DT_SIZE_K(4)>;
-                };
+	partitions {
+		/*
+		 * M4 free space ends at 0x400000 (start of SoC ota_swap_partition).
+		 * code (1912) + factory (4) + settings (32) + storage (92) = 2040 KiB.
+		 * Do not place app NVM inside ota_swap — that region is owned by the
+		 * NWP/Security Bootloader for RPS firmware upgrade.
+		 */
+		factory_partition: partition@3e0000 {
+			reg = <0x003e0000 DT_SIZE_K(4)>;
+		};
 
-                settings_partition: partition@3e1000 {
-                        reg = <0x003e1000 DT_SIZE_K(32)>;
-                };
-        };
+		settings_partition: partition@3e1000 {
+			reg = <0x003e1000 DT_SIZE_K(32)>;
+		};
+	};
 };
 
 &code_partition {
-       reg = <0x00202000 DT_SIZE_K(1912)>;
+	reg = <0x00202000 DT_SIZE_K(1912)>;
 };
 
-
 &storage_partition {
-       reg = <0x003e9000 DT_SIZE_K(92)>;
+	reg = <0x003e9000 DT_SIZE_K(92)>;
 };

--- a/examples/platform/silabs/zephyr/ota_requestor/include/OTARequestorInitiator.h
+++ b/examples/platform/silabs/zephyr/ota_requestor/include/OTARequestorInitiator.h
@@ -24,7 +24,11 @@
 #include "app/clusters/ota-requestor/DefaultOTARequestorDriver.h"
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 
+#if defined(CONFIG_SOC_SERIES_SIWG917)
+#include <platform/silabs/zephyr/OTAImageProcessorImpl.h>
+#else
 #include <platform/Zephyr/OTAImageProcessorImpl.h>
+#endif
 
 #include <stdint.h>
 

--- a/examples/platform/silabs/zephyr/ota_requestor/source/OTARequestorInitiatorZephyr.cpp
+++ b/examples/platform/silabs/zephyr/ota_requestor/source/OTARequestorInitiatorZephyr.cpp
@@ -18,10 +18,17 @@
 
 #include "OTARequestorInitiator.h"
 
-#include <zephyr/dfu/mcuboot.h>
-#include <zephyr/logging/log.h>
+#if defined(CONFIG_SOC_SERIES_SIWG917)
 
-using namespace chip;
+void chip::Zephyr::App::OTARequestorInitiator::HandleSelfTest()
+{
+    // SiWx917 Security Bootloader installs the RPS from ota_swap on reboot.
+    // There is no MCUboot trial/confirm swap to finalize.
+}
+
+#else
+
+#include <zephyr/dfu/mcuboot.h>
 
 void chip::Zephyr::App::OTARequestorInitiator::HandleSelfTest()
 {
@@ -38,3 +45,5 @@ void chip::Zephyr::App::OTARequestorInitiator::HandleSelfTest()
         }
     }
 }
+
+#endif // CONFIG_SOC_SERIES_SIWG917

--- a/src/platform/Zephyr/BUILD.gn
+++ b/src/platform/Zephyr/BUILD.gn
@@ -106,10 +106,17 @@ static_library("Zephyr") {
   }
 
   if (chip_enable_ota_requestor) {
-    sources += [
-      "OTAImageProcessorImpl.cpp",
-      "OTAImageProcessorImpl.h",
-    ]
+    if (chip_enable_siwx_ota) {
+      sources += [
+        "../silabs/zephyr/OTAImageProcessorImpl.cpp",
+        "../silabs/zephyr/OTAImageProcessorImpl.h",
+      ]
+    } else {
+      sources += [
+        "OTAImageProcessorImpl.cpp",
+        "OTAImageProcessorImpl.h",
+      ]
+    }
     deps += [ "${chip_root}/src/app/clusters/ota-requestor:interface" ]
   }
 

--- a/src/platform/Zephyr/BUILD.gn
+++ b/src/platform/Zephyr/BUILD.gn
@@ -106,11 +106,8 @@ static_library("Zephyr") {
   }
 
   if (chip_enable_ota_requestor) {
-    if (chip_enable_siwx_ota) {
-      sources += [
-        "../silabs/zephyr/OTAImageProcessorImpl.cpp",
-        "../silabs/zephyr/OTAImageProcessorImpl.h",
-      ]
+    if (chip_zephyr_ota_image_processor != "") {
+      deps += [ chip_zephyr_ota_image_processor ]
     } else {
       sources += [
         "OTAImageProcessorImpl.cpp",

--- a/src/platform/Zephyr/OTAImageProcessorImpl.h
+++ b/src/platform/Zephyr/OTAImageProcessorImpl.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    Copyright (c) 2024-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,6 +15,13 @@
  */
 
 #pragma once
+
+#if defined(CONFIG_SOC_SERIES_SIWG917)
+
+// SiWx917 uses NWP RPS firmware upgrade instead of MCUboot DFU.
+#include <platform/silabs/zephyr/OTAImageProcessorImpl.h>
+
+#else
 
 #include <lib/core/OTAImageHeader.h>
 #include <lib/support/Span.h>
@@ -58,3 +65,5 @@ private:
 };
 
 } // namespace chip
+
+#endif // CONFIG_SOC_SERIES_SIWG917

--- a/src/platform/Zephyr/OTAImageProcessorImpl.h
+++ b/src/platform/Zephyr/OTAImageProcessorImpl.h
@@ -16,13 +16,6 @@
 
 #pragma once
 
-#if defined(CONFIG_SOC_SERIES_SIWG917)
-
-// SiWx917 uses NWP RPS firmware upgrade instead of MCUboot DFU.
-#include <platform/silabs/zephyr/OTAImageProcessorImpl.h>
-
-#else
-
 #include <lib/core/OTAImageHeader.h>
 #include <lib/support/Span.h>
 #include <platform/OTAImageProcessor.h>
@@ -65,5 +58,3 @@ private:
 };
 
 } // namespace chip
-
-#endif // CONFIG_SOC_SERIES_SIWG917

--- a/src/platform/Zephyr/args.gni
+++ b/src/platform/Zephyr/args.gni
@@ -3,6 +3,8 @@ chip_device_platform = "zephyr"
 declare_args() {
   chip_malloc_sys_heap = false
 
-  # Use SiWx917 RPS firmware-upgrade OTA path instead of MCUboot DFU.
-  chip_enable_siwx_ota = false
+  # Optional GN label for an alternate OTA image processor source_set.
+  # Empty uses the built-in Zephyr MCUboot OTAImageProcessorImpl.
+  # Platform integrations may set this from CMake to supply their own processor.
+  chip_zephyr_ota_image_processor = ""
 }

--- a/src/platform/Zephyr/args.gni
+++ b/src/platform/Zephyr/args.gni
@@ -2,4 +2,7 @@ chip_device_platform = "zephyr"
 
 declare_args() {
   chip_malloc_sys_heap = false
+
+  # Use SiWx917 RPS firmware-upgrade OTA path instead of MCUboot DFU.
+  chip_enable_siwx_ota = false
 }

--- a/src/platform/silabs/zephyr/BUILD.gn
+++ b/src/platform/silabs/zephyr/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+# SiWx917 RPS Matter OTA image processor.
+# Selected via chip_zephyr_ota_image_processor from Silabs CMake.
+source_set("ota-image-processor") {
+  sources = [
+    "OTAImageProcessorImpl.cpp",
+    "OTAImageProcessorImpl.h",
+  ]
+
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+
+  deps = [ "${chip_root}/src/app/clusters/ota-requestor:interface" ]
+
+  cflags = [ "-Wconversion" ]
+}

--- a/src/platform/silabs/zephyr/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/zephyr/OTAImageProcessorImpl.cpp
@@ -179,8 +179,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
             }
             else
             {
-                ChipLogError(SoftwareUpdate, "HandleFinalize sl_si91x_fwup_load() error 0x%lx",
-                             static_cast<unsigned long>(status));
+                ChipLogError(SoftwareUpdate, "HandleFinalize sl_si91x_fwup_load() error 0x%lx", static_cast<unsigned long>(status));
                 imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
                 return;
             }
@@ -314,8 +313,8 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)
         VerifyOrReturnError(error != CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_NO_ERROR);
         ReturnErrorOnFailure(error);
 
-        ChipLogProgress(SoftwareUpdate, "Image Header software version: %" PRIu32 " payload size: %" PRIu64, header.mSoftwareVersion,
-                        header.mPayloadSize);
+        ChipLogProgress(SoftwareUpdate, "Image Header software version: %" PRIu32 " payload size: %" PRIu64,
+                        header.mSoftwareVersion, header.mPayloadSize);
         mParams.totalFileBytes = header.mPayloadSize;
         mHeaderParser.Clear();
     }

--- a/src/platform/silabs/zephyr/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/zephyr/OTAImageProcessorImpl.cpp
@@ -1,0 +1,369 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <platform/silabs/zephyr/OTAImageProcessorImpl.h>
+
+#include <cinttypes>
+
+#include <app/clusters/ota-requestor/OTADownloader.h>
+#include <app/clusters/ota-requestor/OTARequestorInterface.h>
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/reboot.h>
+
+extern "C" {
+#include "firmware_upgradation.h"
+}
+
+static chip::OTAImageProcessorImpl gImageProcessor;
+
+namespace chip {
+
+using namespace ::chip::DeviceLayer;
+
+uint32_t OTAImageProcessorImpl::mWriteOffset                                            = 0;
+uint16_t OTAImageProcessorImpl::writeBufOffset                                          = 0;
+bool OTAImageProcessorImpl::mReset                                                      = false;
+uint8_t OTAImageProcessorImpl::mFwChunkType                                             = kRpsHeader;
+uint8_t OTAImageProcessorImpl::writeBuffer[kAlignmentBytes] __attribute__((aligned(4))) = { 0 };
+
+CHIP_ERROR OTAImageProcessorImpl::Init(OTADownloader * downloader)
+{
+    VerifyOrReturnError(downloader != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    gImageProcessor.SetOTADownloader(downloader);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
+{
+    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(HandlePrepareDownload, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::Finalize()
+{
+    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(HandleFinalize, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::Apply()
+{
+    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(HandleApply, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::Abort()
+{
+    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(HandleAbort, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
+{
+    if ((block.data() == nullptr) || block.empty())
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    CHIP_ERROR err = SetBlock(block);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(SoftwareUpdate, "Cannot set block data: %" CHIP_ERROR_FORMAT, err.Format());
+        return err;
+    }
+
+    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(HandleProcessBlock, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+bool OTAImageProcessorImpl::IsFirstImageRun()
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor == nullptr)
+    {
+        return false;
+    }
+
+    return requestor->GetCurrentUpdateState() == OTARequestorInterface::OTAUpdateStateEnum::kApplying;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ConfirmCurrentImage()
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "OTARequestorInterface is null");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    uint32_t currentVersion;
+    uint32_t targetVersion = requestor->GetTargetVersion();
+    ReturnErrorOnFailure(ConfigurationMgr().GetSoftwareVersion(currentVersion));
+    if (currentVersion != targetVersion)
+    {
+        ChipLogError(SoftwareUpdate, "Current software version = %" PRIu32 ", expected software version = %" PRIu32, currentVersion,
+                     targetVersion);
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
+{
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+
+    if (imageProcessor == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
+        return;
+    }
+    if (imageProcessor->mDownloader == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "mDownloader is null");
+        return;
+    }
+
+    ChipLogProgress(SoftwareUpdate, "HandlePrepareDownload");
+
+    mReset                                  = false;
+    mFwChunkType                            = kRpsHeader;
+    writeBufOffset                          = 0;
+    mWriteOffset                            = 0;
+    imageProcessor->mParams.downloadedBytes = 0;
+
+    imageProcessor->mHeaderParser.Init();
+
+    TEMPORARY_RETURN_IGNORED imageProcessor->mDownloader->OnPreparedForDownload(CHIP_NO_ERROR);
+}
+
+void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
+{
+    sl_status_t status    = SL_STATUS_OK;
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    if (imageProcessor == nullptr)
+    {
+        return;
+    }
+
+    if (writeBufOffset != 0)
+    {
+        imageProcessor->mParams.downloadedBytes += writeBufOffset;
+        status = sl_si91x_fwup_load(writeBuffer, writeBufOffset);
+        ChipLogProgress(SoftwareUpdate, "HandleFinalize fwup_load status: 0x%lX", static_cast<unsigned long>(status));
+
+        if (status != SL_STATUS_OK)
+        {
+            if (status == SL_STATUS_SI91X_FW_UPDATE_DONE)
+            {
+                mReset = true;
+            }
+            else
+            {
+                ChipLogError(SoftwareUpdate, "HandleFinalize sl_si91x_fwup_load() error 0x%lx",
+                             static_cast<unsigned long>(status));
+                imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
+                return;
+            }
+        }
+    }
+
+    TEMPORARY_RETURN_IGNORED imageProcessor->ReleaseBlock();
+    ChipLogProgress(SoftwareUpdate, "OTA image downloaded successfully");
+}
+
+void OTAImageProcessorImpl::HandleApply(intptr_t context)
+{
+    (void) context;
+    ChipLogProgress(SoftwareUpdate, "OTAImageProcessorImpl::HandleApply()");
+
+    if (!mReset)
+    {
+        ChipLogError(SoftwareUpdate, "Apply called but firmware update was not marked complete");
+        return;
+    }
+
+    ChipLogProgress(SoftwareUpdate, "M4 firmware update complete; rebooting for Security Bootloader install");
+
+    // Allow state-transition events to flush before reboot.
+    PlatformMgr().HandleServerShuttingDown();
+    k_msleep(CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS);
+    sys_reboot(SYS_REBOOT_COLD);
+}
+
+void OTAImageProcessorImpl::HandleAbort(intptr_t context)
+{
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    if (imageProcessor == nullptr)
+    {
+        return;
+    }
+
+    sl_status_t status = sl_si91x_fwup_abort();
+    if (status != SL_STATUS_OK)
+    {
+        ChipLogError(SoftwareUpdate, "sl_si91x_fwup_abort() error 0x%lx", static_cast<unsigned long>(status));
+    }
+
+    mFwChunkType   = kRpsHeader;
+    writeBufOffset = 0;
+    mReset         = false;
+
+    TEMPORARY_RETURN_IGNORED imageProcessor->ReleaseBlock();
+}
+
+void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
+{
+    sl_status_t status    = SL_STATUS_OK;
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    if (imageProcessor == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
+        return;
+    }
+    if (imageProcessor->mDownloader == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "mDownloader is null");
+        return;
+    }
+
+    ByteSpan block        = imageProcessor->mBlock;
+    CHIP_ERROR chip_error = imageProcessor->ProcessHeader(block);
+
+    if (chip_error != CHIP_NO_ERROR)
+    {
+        ChipLogError(SoftwareUpdate, "Matter image header parser error: %" CHIP_ERROR_FORMAT, chip_error.Format());
+        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
+        return;
+    }
+
+    // Fill word-aligned writeBuffer; flush when full. Remainder is written in HandleFinalize().
+    uint32_t blockReadOffset = 0;
+    while (blockReadOffset < block.size())
+    {
+        writeBuffer[writeBufOffset] = *(block.data() + blockReadOffset);
+        writeBufOffset++;
+        blockReadOffset++;
+        if (writeBufOffset == kAlignmentBytes)
+        {
+            writeBufOffset = 0;
+            if (mFwChunkType == kRpsHeader)
+            {
+                status = sl_si91x_fwup_start(writeBuffer);
+                if (status != SL_STATUS_OK)
+                {
+                    ChipLogError(SoftwareUpdate, "sl_si91x_fwup_start() error 0x%lx", static_cast<unsigned long>(status));
+                    imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
+                    return;
+                }
+                status       = sl_si91x_fwup_load(writeBuffer, kAlignmentBytes);
+                mFwChunkType = kRpsData;
+            }
+            else
+            {
+                status = sl_si91x_fwup_load(writeBuffer, kAlignmentBytes);
+            }
+
+            if (status != SL_STATUS_OK)
+            {
+                if (status == SL_STATUS_SI91X_FW_UPDATE_DONE)
+                {
+                    mReset = true;
+                }
+                else
+                {
+                    ChipLogError(SoftwareUpdate, "sl_si91x_fwup_load() error 0x%lx", static_cast<unsigned long>(status));
+                    imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
+                    return;
+                }
+            }
+
+            imageProcessor->mParams.downloadedBytes += kAlignmentBytes;
+        }
+    }
+
+    TEMPORARY_RETURN_IGNORED imageProcessor->mDownloader->FetchNextData();
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)
+{
+    if (mHeaderParser.IsInitialized())
+    {
+        OTAImageHeader header;
+        CHIP_ERROR error = mHeaderParser.AccumulateAndDecode(block, header);
+
+        VerifyOrReturnError(error != CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_NO_ERROR);
+        ReturnErrorOnFailure(error);
+
+        ChipLogProgress(SoftwareUpdate, "Image Header software version: %" PRIu32 " payload size: %" PRIu64, header.mSoftwareVersion,
+                        header.mPayloadSize);
+        mParams.totalFileBytes = header.mPayloadSize;
+        mHeaderParser.Clear();
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::SetBlock(ByteSpan & block)
+{
+    if ((block.data() == nullptr) || block.empty())
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    if (mBlock.size() < block.size())
+    {
+        TEMPORARY_RETURN_IGNORED ReleaseBlock();
+
+        mBlock = MutableByteSpan(static_cast<uint8_t *>(chip::Platform::MemoryAlloc(block.size())), block.size());
+        if (mBlock.data() == nullptr)
+        {
+            return CHIP_ERROR_NO_MEMORY;
+        }
+    }
+
+    CHIP_ERROR err = CopySpanToMutableSpan(block, mBlock);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(SoftwareUpdate, "Cannot copy block data: %" CHIP_ERROR_FORMAT, err.Format());
+        return err;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ReleaseBlock()
+{
+    if (mBlock.data() != nullptr)
+    {
+        chip::Platform::MemoryFree(mBlock.data());
+    }
+
+    mBlock = MutableByteSpan();
+    return CHIP_NO_ERROR;
+}
+
+OTAImageProcessorImpl & OTAImageProcessorImpl::GetDefaultInstance()
+{
+    return gImageProcessor;
+}
+
+} // namespace chip

--- a/src/platform/silabs/zephyr/OTAImageProcessorImpl.h
+++ b/src/platform/silabs/zephyr/OTAImageProcessorImpl.h
@@ -1,0 +1,76 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/ota-requestor/OTADownloader.h>
+#include <lib/core/OTAImageHeader.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/OTAImageProcessor.h>
+
+namespace chip {
+
+/**
+ * @brief Matter OTA image processor for SiWx917 on Zephyr.
+ *
+ * Strips the Matter OTA header and streams the RPS payload to the NWP via
+ * sl_si91x_fwup_start / sl_si91x_fwup_load. The Security Bootloader installs
+ * the image from ota_swap on reboot. This path does not use MCUboot.
+ */
+class OTAImageProcessorImpl : public OTAImageProcessorInterface
+{
+public:
+    CHIP_ERROR PrepareDownload() override;
+    CHIP_ERROR Finalize() override;
+    CHIP_ERROR Apply() override;
+    CHIP_ERROR Abort() override;
+    CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override;
+    CHIP_ERROR ConfirmCurrentImage() override;
+
+    void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
+    CHIP_ERROR Init(OTADownloader * downloader);
+    static OTAImageProcessorImpl & GetDefaultInstance();
+
+private:
+    static void HandlePrepareDownload(intptr_t context);
+    static void HandleFinalize(intptr_t context);
+    static void HandleApply(intptr_t context);
+    static void HandleAbort(intptr_t context);
+    static void HandleProcessBlock(intptr_t context);
+
+    CHIP_ERROR ProcessHeader(ByteSpan & block);
+    CHIP_ERROR SetBlock(ByteSpan & block);
+    CHIP_ERROR ReleaseBlock();
+
+    static constexpr size_t kAlignmentBytes = 64;
+    static constexpr uint8_t kRpsHeader     = 1;
+    static constexpr uint8_t kRpsData       = 2;
+
+    MutableByteSpan mBlock;
+    OTADownloader * mDownloader = nullptr;
+    OTAImageHeaderParser mHeaderParser;
+
+    static uint32_t mWriteOffset;
+    static uint16_t writeBufOffset;
+    static bool mReset;
+    static uint8_t mFwChunkType;
+    static uint8_t writeBuffer[kAlignmentBytes];
+};
+
+} // namespace chip


### PR DESCRIPTION
### Summary

This PR enables Matter OTA on SiWx917 Zephyr (siwx917_rb4338a) using the Silabs RPS + NWP/Security Bootloader path (sl_si91x_fwup_*), instead of the shared Zephyr MCUboot DFU flow.

The default Zephyr OTA path does not work on 917 because the common Zephyr OTAImageProcessorImpl assumes MCUboot (BOOTLOADER_MCUBOOT, IMG_MANAGER, slot0/slot1 partitions, signed .bin).
SiWx917 does not use that model. Flash layout has code_partition + ota_swap_partition, and updates are delivered as an RPS image applied by the NWP/Security Bootloader via WiseConnect firmware-upgrade APIs. Enabling MCUboot on 917 fails (missing slots) and would be the wrong install path even if partitions were faked.

**Changes**

- Kconfig: CHIP_OTA_REQUESTOR selects SIWX91X_FIRMWARE_UPGRADE (+ reboot) on SOC_SERIES_SIWG917. MCUBOOT path remains unchanged for other platforms.
- SiWx OTA processor (src/platform/silabs/zephyr/): Matter header -> sl_si91x_fwup_* -> reboot.
- Common Zephyr BUILD: vendor-neutral chip_zephyr_ota_image_processor GN arg (empty = MCUboot sources. Silabs CMake sets the SiWx source_set on 917).
- Post-build: wrap zephyr.rps (or signed RPS) as the matter.ota on 917. Keep existing signed-.bin wrap for EFR32.
- Overlays / initiator: keep NVM below ota_swap. SiWx-specific include and no-op self-test where MCUboot confirm does not apply.

### Related issues

N/A

### Testing

- Build lighting-app ota_a and ota_b (Software Version : 2) apps for siwx917_rb4338a with CONFIG_CHIP_OTA_REQUESTOR=y. confirm zephyr.rps and Matter .ota are produced
- Flash ota_a.rps, commission, run OTA with the generated .ota of ota_b application. Device reboots into the new image.
- Verify by reading Software Version String from chiptool (it should return "2")
