### PR TITLE
Guard the zero-length copy in the Span copy helpers

### DIFF
--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -402,8 +402,12 @@ inline CHIP_ERROR CopySpanToMutableSpan(ByteSpan span_to_copy, MutableByteSpan &
 {
     VerifyOrReturnError(out_buf.size() >= span_to_copy.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    // There is no guarantee that span_to_copy and out_buf don't overlap, so use memmove()
-    memmove(out_buf.data(), span_to_copy.data(), span_to_copy.size());
+    // No guarantee that span_to_copy and out_buf don't overlap, so memmove() not memcpy().
+    // An empty span may have a null data(), it is undefined behaviour to pass it to memmove() even at zero length.
+    if (!span_to_copy.empty())
+    {
+        memmove(out_buf.data(), span_to_copy.data(), span_to_copy.size());
+    }
     out_buf.reduce_size(span_to_copy.size());
 
     return CHIP_NO_ERROR;
@@ -413,8 +417,12 @@ inline CHIP_ERROR CopyCharSpanToMutableCharSpan(CharSpan cspan_to_copy, MutableC
 {
     VerifyOrReturnError(out_buf.size() >= cspan_to_copy.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    // There is no guarantee that cspan_to_copy and out_buf don't overlap, so use memmove()
-    memmove(out_buf.data(), cspan_to_copy.data(), cspan_to_copy.size());
+    // No guarantee that cspan_to_copy and out_buf don't overlap, so memmove() not memcpy().
+    // An empty span may have a null data(), it is undefined behaviour to pass it to memmove() even at zero length.
+    if (!cspan_to_copy.empty())
+    {
+        memmove(out_buf.data(), cspan_to_copy.data(), cspan_to_copy.size());
+    }
     out_buf.reduce_size(cspan_to_copy.size());
 
     return CHIP_NO_ERROR;
@@ -430,8 +438,13 @@ inline void CopyCharSpanToMutableCharSpanWithTruncation(CharSpan span_to_copy, M
 {
     size_t size_to_copy = std::min(span_to_copy.size(), out_span.size());
 
-    // There is no guarantee that span_to_copy and out_buf don't overlap, so use memmove()
-    memmove(out_span.data(), span_to_copy.data(), size_to_copy);
+    // No guarantee that span_to_copy and out_span don't overlap, so memmove() not memcpy().
+    // Either span may have a null data() when empty, which is undefined to pass to memmove() even at zero length.
+    // Check size_to_copy: it is zero when out_span is empty, even if span_to_copy is not.
+    if (size_to_copy != 0)
+    {
+        memmove(out_span.data(), span_to_copy.data(), size_to_copy);
+    }
     out_span.reduce_size(size_to_copy);
 }
 

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -94,6 +94,7 @@ chip_test_suite("tests") {
   ]
 
   public_deps = [
+    ":pw-test-macros",
     "${chip_root}/src/app/common:cluster-objects",
     "${chip_root}/src/credentials",
     "${chip_root}/src/lib/core",

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -29,6 +29,7 @@
 
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/Span.h>
+#include <lib/support/tests/ExtraPwTestMacros.h>
 
 using namespace chip;
 
@@ -472,4 +473,60 @@ TEST(TestSpan, TestFromCharSpan)
     // These should be compile errors -- fromCharSpan only takes ByteSpan.
     // ByteSpan disallowed1 = ByteSpan::fromCharSpan(bytes);
     // CharSpan disallowed2 = CharSpan::fromCharSpan<const uint8_t>(chars);
+}
+
+// A zero-length TLV string yields a { nullptr, 0 } span, so these cases drive that value through
+// each copy helper. The assertions pin the normal contract; the null memmove argument itself is
+// reported only by -fsanitize=undefined.
+TEST(TestSpan, TestCopySpanToMutableSpanFromNullSource)
+{
+    const ByteSpan nullSource;
+    ASSERT_EQ(nullSource.data(), nullptr);
+
+    uint8_t buf[4] = { 1, 2, 3, 4 };
+    MutableByteSpan out(buf);
+    EXPECT_SUCCESS(CopySpanToMutableSpan(nullSource, out));
+    EXPECT_TRUE(out.empty());
+    EXPECT_EQ(buf[0], static_cast<uint8_t>(1));
+
+    MutableByteSpan nullOut;
+    EXPECT_SUCCESS(CopySpanToMutableSpan(nullSource, nullOut));
+    EXPECT_TRUE(nullOut.empty());
+}
+
+TEST(TestSpan, TestCopyCharSpanToMutableCharSpanFromNullSource)
+{
+    const CharSpan nullSource;
+    ASSERT_EQ(nullSource.data(), nullptr);
+
+    char buf[4] = { 'a', 'b', 'c', 'd' };
+    MutableCharSpan out(buf);
+    EXPECT_SUCCESS(CopyCharSpanToMutableCharSpan(nullSource, out));
+    EXPECT_TRUE(out.empty());
+    EXPECT_EQ(buf[0], 'a');
+
+    MutableCharSpan nullOut;
+    EXPECT_SUCCESS(CopyCharSpanToMutableCharSpan(nullSource, nullOut));
+    EXPECT_TRUE(nullOut.empty());
+}
+
+TEST(TestSpan, TestCopyCharSpanToMutableCharSpanWithTruncationFromNullSource)
+{
+    const CharSpan nullSource;
+    ASSERT_EQ(nullSource.data(), nullptr);
+
+    char buf[4] = { 'a', 'b', 'c', 'd' };
+    MutableCharSpan out(buf);
+    CopyCharSpanToMutableCharSpanWithTruncation(nullSource, out);
+    EXPECT_TRUE(out.empty());
+    EXPECT_EQ(buf[0], 'a');
+
+    MutableCharSpan nullOut;
+    CopyCharSpanToMutableCharSpanWithTruncation(nullSource, nullOut);
+    EXPECT_TRUE(nullOut.empty());
+
+    // Truncation means a non-empty source can reach the copy with a zero-size destination.
+    MutableCharSpan nullOutFromNonEmpty;
+    CopyCharSpanToMutableCharSpanWithTruncation("abc"_span, nullOutFromNonEmpty);
+    EXPECT_TRUE(nullOutFromNonEmpty.empty());
 }


### PR DESCRIPTION
#### Summary

##### Problem

- The three `Span` copy helpers in `src/lib/support/Span.h` pass `data()` straight to `memmove()`.
- An empty `Span` may have a null `data()` — `TLVReader::GetDataPtr` returns one for every zero-length string — and passing a null pointer to `memmove()` is undefined even at zero length (C17 7.24.1p2), which `-fsanitize=undefined` reports as `null pointer passed as argument 2, which is declared to never be null`.

##### Solution

- Skip the copy when nothing is copied.
- `CopyCharSpanToMutableCharSpanWithTruncation` checks the clamped size rather than source emptiness: it truncates instead of failing, so `size_to_copy` is zero for an empty destination even when the source is not empty. Guarding on source emptiness there would leave the null destination case unguarded.

##### Caveats

- No behavioural change outside a sanitizer build.

#### Testing

- Added `TestCopySpanToMutableSpanFromNullSource`, `TestCopyCharSpanToMutableCharSpanFromNullSource` and `TestCopyCharSpanToMutableCharSpanWithTruncationFromNullSource` to `src/lib/support/tests/TestSpan.cpp`, covering a null source into both a sized and a default-constructed destination, plus a non-empty source into a zero-size destination for the truncation helper.
- Verified against `linux-x64-tests-clang-ubsan` with `UBSAN_OPTIONS=halt_on_error=1`: without the change the suite exits 1 reporting `Span.h:406`; with it, 14 tests pass and no reports are emitted.
- The truncation case was checked to discriminate the guard: replacing `size_to_copy != 0` with `!span_to_copy.empty()` reports `null pointer passed as argument 1` and exits 1, while the null-source tests alone stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
