### PR TITLE
Github action for enforcing Subject Matter Expert (SME) checks on labeled PRs

### DIFF
--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -54,6 +54,7 @@ The YAML file is strictly structured as a mapping of label names to lists of Git
 ### Rules & Behaviors
 - **Case-Insensitive**: Both label names and usernames are matched case-insensitively (`Security` matches `security`, `Cecille` matches `cecille`).
 - **No Leading `@`**: Usernames must not include leading `@` (use `username`, not `@username`).
+- **Quotes Optional**: Usernames can be unquoted or enclosed in quotes (`username`, `'username'`, or `"username"`). Quotes are not required for standard GitHub usernames.
 - **OR-Logic per Label**: At least **one** listed reviewer from the label's list must approve the PR.
 - **AND-Logic across Labels**: If a PR has multiple designated labels attached (e.g., both `security` and `certification`), **every** attached label requires at least one approval from its respective reviewer list (approval required for each domain).
 - **Author Self-Approval Exclusion**: A PR author **cannot approve their own PR**. Even if the author is listed as an SME for a label, another reviewer from that label's list must provide the approval.

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -1,12 +1,18 @@
 # SME Label Reviewers Automation
 
-This automation ensures that pull requests touching specialized domains or carrying designated GitHub labels receive formal approval from at least one designated Subject Matter Expert (SME) before merging.
+This automation ensures that pull requests touching specialized domains or
+carrying designated GitHub labels receive formal approval from at least one
+designated Subject Matter Expert (SME) before merging.
 
-Because GitHub's standard `CODEOWNERS` and branch protection review rules require dedicated GitHub Enterprise seats for every code owner, this automation runs as a **standard GitHub Actions status check** (`Check SME Approvals`). It enforces SME approvals on designated labels with **zero seat license overhead**.
+Because GitHub's standard `CODEOWNERS` and branch protection review rules
+require dedicated GitHub Enterprise seats for every code owner, this automation
+runs as a **standard GitHub Actions status check** (`Check SME Approvals`). It
+enforces SME approvals on designated labels with **zero seat license overhead**.
 
 ---
 
 ## Table of Contents
+
 1. [How to Add a New Label](#1-how-to-add-a-new-label)
 2. [How to Manage the YAML Reviewer List](#2-how-to-manage-the-yaml-reviewer-list)
 3. [How to Re-Run the Workflow Once Review is Complete](#3-how-to-re-run-the-workflow-once-review-is-complete)
@@ -17,107 +23,149 @@ Because GitHub's standard `CODEOWNERS` and branch protection review rules requir
 
 ## 1. How to Add a New Label
 
-You do **not** need to manually create labels on GitHub or have repository admin permissions.
+You do **not** need to manually create labels on GitHub or have repository admin
+permissions.
 
-**New labels are created automatically on GitHub whenever a pull request with changes to [`.github/label_reviewers.yaml`](./label_reviewers.yaml) is merged into `master`.**
+**New labels are created automatically on GitHub whenever a pull request with
+changes to [`.github/label_reviewers.yaml`](./label_reviewers.yaml) is merged
+into `master`.**
 
 ### Steps to Add a Label:
-1. Open a pull request that adds your new label and its designated SME usernames to [`.github/label_reviewers.yaml`](./label_reviewers.yaml).
-2. Once the PR is reviewed and merged into `master`, GitHub Actions automatically detects the new label and creates it in the repository.
 
-*(Optional)* To have GitHub automatically attach this label to future PRs based on touched file paths, add matching path rules to [`.github/labeler.yml`](./labeler.yml):
+1. Open a pull request that adds your new label and its designated SME usernames
+   to [`.github/label_reviewers.yaml`](./label_reviewers.yaml).
+2. Once the PR is reviewed and merged into `master`, GitHub Actions
+   automatically detects the new label and creates it in the repository.
+
+_(Optional)_ To have GitHub automatically attach this label to future PRs based
+on touched file paths, add matching path rules to
+[`.github/labeler.yml`](./labeler.yml):
 
 ```yaml
 # Example entry in .github/labeler.yml:
 security:
-  - changed-files:
-    - any-glob-to-any-file:
-      - 'src/crypto/*'
-      - 'src/crypto/**/*'
+    - changed-files:
+          - any-glob-to-any-file:
+                - "src/crypto/*"
+                - "src/crypto/**/*"
 ```
 
 ---
 
 ## 2. How to Manage the YAML Reviewer List
 
-The reviewer list is managed in [`.github/label_reviewers.yaml`](./label_reviewers.yaml).
+The reviewer list is managed in
+[`.github/label_reviewers.yaml`](./label_reviewers.yaml).
 
 ### File Format
-The YAML file is strictly structured as a mapping of label names to lists of GitHub usernames:
+
+The YAML file is strictly structured as a mapping of label names to lists of
+GitHub usernames:
 
 ```yaml
 <label_name>:
-  - <github_username_1>
-  - <github_username_2>
+    - <github_username_1>
+    - <github_username_2>
 ```
 
 ### Rules & Behaviors
-- **Case-Insensitive**: Both label names and usernames are matched case-insensitively (`Security` matches `security`, `Cecille` matches `cecille`).
-- **No Leading `@`**: Usernames must not include leading `@` (use `username`, not `@username`).
-- **Quotes Optional**: Usernames can be unquoted or enclosed in quotes (`username`, `'username'`, or `"username"`). Quotes are not required for standard GitHub usernames.
-- **OR-Logic per Label**: At least **one** listed reviewer from the label's list must approve the PR.
-- **AND-Logic across Labels**: If a PR has multiple designated labels attached (e.g., both `security` and `certification`), **every** attached label requires at least one approval from its respective reviewer list (approval required for each domain).
-- **Author Self-Approval Exclusion**: A PR author **cannot approve their own PR**. Even if the author is listed as an SME for a label, another reviewer from that label's list must provide the approval.
-- **State Transition Awareness**: The check accurately tracks current review states. If an SME approves, but later submits `CHANGES_REQUESTED` or the approval is `DISMISSED`, the approval is no longer valid until re-approved.
+
+-   **Case-Insensitive**: Both label names and usernames are matched
+    case-insensitively (`Security` matches `security`, `Cecille` matches
+    `cecille`).
+-   **No Leading `@`**: Usernames must not include leading `@` (use `username`,
+    not `@username`).
+-   **Quotes Optional**: Usernames can be unquoted or enclosed in quotes
+    (`username`, `'username'`, or `"username"`). Quotes are not required for
+    standard GitHub usernames.
+-   **OR-Logic per Label**: At least **one** listed reviewer from the label's
+    list must approve the PR.
+-   **AND-Logic across Labels**: If a PR has multiple designated labels attached
+    (e.g., both `security` and `certification`), **every** attached label
+    requires at least one approval from its respective reviewer list (approval
+    required for each domain).
+-   **Author Self-Approval Exclusion**: A PR author **cannot approve their own
+    PR**. Even if the author is listed as an SME for a label, another reviewer
+    from that label's list must provide the approval.
+-   **State Transition Awareness**: The check accurately tracks current review
+    states. If an SME approves, but later submits `CHANGES_REQUESTED` or the
+    approval is `DISMISSED`, the approval is no longer valid until re-approved.
 
 ### Example Configuration
+
 ```yaml
 # Core architecture & SDK infrastructure
 core:
-  - cecille
-  - andy31415
+    - cecille
+    - andy31415
 
 # Security & Cryptography reviews
 security:
-  - cecille
-  - bzbarsky-apple
+    - cecille
+    - bzbarsky-apple
 
 # Data Model & Cluster XML specifications
 data-model:
-  - bzbarsky-apple
-  - Boris-Virk
+    - bzbarsky-apple
+    - Boris-Virk
 ```
 
 ### Adding or Updating Reviewers
+
 1. Create a branch:
-   ```bash
-   git checkout -b update-sme-reviewers
-   ```
-2. Edit [`.github/label_reviewers.yaml`](./label_reviewers.yaml) to add the label and username(s).
+    ```bash
+    git checkout -b update-sme-reviewers
+    ```
+2. Edit [`.github/label_reviewers.yaml`](./label_reviewers.yaml) to add the
+   label and username(s).
 3. Commit and submit a PR:
-   ```bash
-   git add .github/label_reviewers.yaml
-   git commit -m "Update SME reviewers for <domain>"
-   git push origin update-sme-reviewers
-   ```
-4. Once merged into `master`, all future and open PRs will use the updated reviewer list.
+    ```bash
+    git add .github/label_reviewers.yaml
+    git commit -m "Update SME reviewers for <domain>"
+    git push origin update-sme-reviewers
+    ```
+4. Once merged into `master`, all future and open PRs will use the updated
+   reviewer list.
 
 ---
 
 ## 3. How to Re-Run the Workflow Once Review is Complete
 
-Once the designated SME has reviewed and submitted an **APPROVED** review, you have several quick ways to update the check:
+Once the designated SME has reviewed and submitted an **APPROVED** review, you
+have several quick ways to update the check:
 
 ### Method 1: Automatic Re-evaluation (Zero Action Required)
-The workflow actively listens to GitHub's `pull_request_review` events (`submitted`, `edited`, `dismissed`).  
-**As soon as the SME submits an "Approved" review, the workflow automatically re-runs and updates to green without any manual intervention.**
+
+The workflow actively listens to GitHub's `pull_request_review` events
+(`submitted`, `edited`, `dismissed`).  
+**As soon as the SME submits an "Approved" review, the workflow automatically
+re-runs and updates to green without any manual intervention.**
 
 ### Method 2: PR Comment Command (`/check-sme`)
-You can trigger an immediate re-evaluation directly from the PR conversation page:
+
+You can trigger an immediate re-evaluation directly from the PR conversation
+page:
+
 1. Open the PR.
 2. Type the following comment and submit:
-   ```text
-   /check-sme
-   ```
-3. GitHub Actions will detect the command and trigger the `Check SME Approvals` check immediately.
+    ```text
+    /check-sme
+    ```
+3. GitHub Actions will detect the command and trigger the `Check SME Approvals`
+   check immediately.
 
 ### Method 3: Re-Run from the PR "Checks" Tab
-1. On the pull request page, click on the **Checks** tab (or click **Details** next to `Check SME Approvals` in the status checks list at the bottom of the **Conversation** tab).
+
+1. On the pull request page, click on the **Checks** tab (or click **Details**
+   next to `Check SME Approvals` in the status checks list at the bottom of the
+   **Conversation** tab).
 2. Select **Check SME Approvals** from the left panel.
 3. In the top-right corner, click **Re-run jobs** (or **Re-run**).
 
 ### Method 4: Label Toggling
-Removing and re-adding the monitored label (or adding any other label) triggers the `labeled` / `unlabeled` PR event and immediately re-evaluates the check.
+
+Removing and re-adding the monitored label (or adding any other label) triggers
+the `labeled` / `unlabeled` PR event and immediately re-evaluates the check.
 
 ---
 
@@ -128,20 +176,23 @@ To prevent pull requests from merging until the SME review check passes:
 1. Open repository **Settings** -> **Branches**.
 2. Under **Branch protection rules**, edit your target branch (e.g. `master`).
 3. Check **Require status checks to pass before merging**.
-4. In the search box under "Status checks that are required", search for and select:
-   ```text
-   Check SME Approvals
-   ```
+4. In the search box under "Status checks that are required", search for and
+   select:
+    ```text
+    Check SME Approvals
+    ```
 5. Click **Save changes**.
 
-> [!NOTE]
-> Unlike standard GitHub "Require review from Code Owners", setting `Check SME Approvals` as a required status check does **not** consume any GitHub Enterprise seats or require external subscription services.
+> [!NOTE] Unlike standard GitHub "Require review from Code Owners", setting
+> `Check SME Approvals` as a required status check does **not** consume any
+> GitHub Enterprise seats or require external subscription services.
 
 ---
 
 ## 5. Local CLI Verification
 
-The underlying verification script uses the GitHub CLI (`gh`) and can also be run locally on a developer workstation or cloudtop:
+The underlying verification script uses the GitHub CLI (`gh`) and can also be
+run locally on a developer workstation or cloudtop:
 
 ```bash
 # Ensure GitHub CLI is authenticated (via gh auth login or GH_TOKEN)

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -146,9 +146,6 @@ The underlying verification script can also be run locally on a developer workst
 # Basic check on a specific PR
 python3 scripts/tools/check_label_reviewers.py --pr 30000
 
-# Dry-run check (inspect status without failing)
-python3 scripts/tools/check_label_reviewers.py --pr 30000 --dry-run
-
 # Test with a custom config file
 python3 scripts/tools/check_label_reviewers.py --pr 30000 --config /path/to/custom_reviewers.yaml
 ```

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -143,7 +143,10 @@ To prevent pull requests from merging until the SME review check passes:
 The underlying verification script can also be run locally on a developer workstation or cloudtop:
 
 ```bash
-# Basic check on a specific PR
+# Set your GitHub personal access token
+export GITHUB_TOKEN="ghp_xxx"
+
+# Run check on a specific PR
 python3 scripts/tools/check_label_reviewers.py --pr 30000
 
 # Test with a custom config file

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -55,7 +55,7 @@ The YAML file is strictly structured as a mapping of label names to lists of Git
 - **Case-Insensitive**: Both label names and usernames are matched case-insensitively (`Security` matches `security`, `Cecille` matches `cecille`).
 - **Optional `@`**: Leading `@` signs are automatically stripped (both `cecille` and `@cecille` work).
 - **OR-Logic per Label**: At least **one** listed reviewer from the label's list must approve the PR.
-- **AND-Logic across Labels**: If a PR has multiple designated labels attached (e.g., both `security` and `certification`), at least one SME from **each** label must approve.
+- **AND-Logic across Labels**: If a PR has multiple designated labels attached (e.g., both `security` and `certification`), **every** attached label requires at least one approval from its respective reviewer list (approval required for each domain).
 - **Author Self-Approval Exclusion**: A PR author **cannot approve their own PR**. Even if the author is listed as an SME for a label, another reviewer from that label's list must provide the approval.
 - **State Transition Awareness**: The check accurately tracks current review states. If an SME approves, but later submits `CHANGES_REQUESTED` or the approval is `DISMISSED`, the approval is no longer valid until re-approved.
 

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -69,6 +69,7 @@ GitHub usernames:
 ```
 
 ### Rules & Behaviors
+
 -   **Case-Insensitive**: Both label names and usernames are matched
     case-insensitively (`Security` matches `security`, `Cecille` matches
     `cecille`).

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -140,11 +140,11 @@ To prevent pull requests from merging until the SME review check passes:
 
 ## 5. Local CLI Verification
 
-The underlying verification script can also be run locally on a developer workstation or cloudtop:
+The underlying verification script uses the GitHub CLI (`gh`) and can also be run locally on a developer workstation or cloudtop:
 
 ```bash
-# Set your GitHub personal access token
-export GITHUB_TOKEN="ghp_xxx"
+# Ensure GitHub CLI is authenticated (via gh auth login or GH_TOKEN)
+gh auth status
 
 # Run check on a specific PR
 python3 scripts/tools/check_label_reviewers.py --pr 30000

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -81,6 +81,10 @@ GitHub usernames:
 -   **OR-Logic across Labels**: If a PR has multiple designated labels attached
     (e.g., both `security` and `certification`), approval from at least **one**
     reviewer from **any** of the attached labels' lists satisfies the check.
+-   **Override Label (`no-sme-check-required`)**: Attaching the
+    `no-sme-check-required` label to a PR bypasses the SME review requirement
+    completely, allowing emergency fixes or exempt PRs to pass the status check
+    without designated SME sign-off.
 -   **Author Self-Approval Exclusion**: A PR author **cannot approve their own
     PR**. Even if the author is listed as an SME for a label, another reviewer
     from that label's list must provide the approval.
@@ -163,6 +167,12 @@ page:
 
 Removing and re-adding the monitored label (or adding any other label) triggers
 the `labeled` / `unlabeled` PR event and immediately re-evaluates the check.
+
+### Method 5: Emergency Override (`no-sme-check-required`)
+
+If a PR needs to merge without designated SME review (e.g. an emergency hotfix
+or exempt change), attach the `no-sme-check-required` label to the pull request.
+The check will immediately pass and record that the SME review was bypassed.
 
 ---
 

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -1,0 +1,154 @@
+# SME Label Reviewers Automation
+
+This automation ensures that pull requests touching specialized domains or carrying designated GitHub labels receive formal approval from at least one designated Subject Matter Expert (SME) before merging.
+
+Because GitHub's standard `CODEOWNERS` and branch protection review rules require dedicated GitHub Enterprise seats for every code owner, this automation runs as a **standard GitHub Actions status check** (`Check SME Approvals`). It enforces SME approvals on designated labels with **zero seat license overhead**.
+
+---
+
+## Table of Contents
+1. [How to Add a New Label](#1-how-to-add-a-new-label)
+2. [How to Manage the YAML Reviewer List](#2-how-to-manage-the-yaml-reviewer-list)
+3. [How to Re-Run the Workflow Once Review is Complete](#3-how-to-re-run-the-workflow-once-review-is-complete)
+4. [Branch Protection Integration](#4-branch-protection-integration)
+5. [Local CLI Verification](#5-local-cli-verification)
+
+---
+
+## 1. How to Add a New Label
+
+You do **not** need to manually create labels on GitHub or have repository admin permissions.
+
+**New labels are created automatically on GitHub whenever a pull request with changes to [`.github/label_reviewers.yaml`](./label_reviewers.yaml) is merged into `master`.**
+
+### Steps to Add a Label:
+1. Open a pull request that adds your new label and its designated SME usernames to [`.github/label_reviewers.yaml`](./label_reviewers.yaml).
+2. Once the PR is reviewed and merged into `master`, GitHub Actions automatically detects the new label and creates it in the repository.
+
+*(Optional)* To have GitHub automatically attach this label to future PRs based on touched file paths, add matching path rules to [`.github/labeler.yml`](./labeler.yml):
+
+```yaml
+# Example entry in .github/labeler.yml:
+security:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/crypto/*'
+      - 'src/crypto/**/*'
+```
+
+---
+
+## 2. How to Manage the YAML Reviewer List
+
+The reviewer list is managed in [`.github/label_reviewers.yaml`](./label_reviewers.yaml).
+
+### File Format
+The YAML file is strictly structured as a mapping of label names to lists of GitHub usernames:
+
+```yaml
+<label_name>:
+  - <github_username_1>
+  - <github_username_2>
+```
+
+### Rules & Behaviors
+- **Case-Insensitive**: Both label names and usernames are matched case-insensitively (`Security` matches `security`, `Cecille` matches `cecille`).
+- **Optional `@`**: Leading `@` signs are automatically stripped (both `cecille` and `@cecille` work).
+- **OR-Logic per Label**: At least **one** listed reviewer from the label's list must approve the PR.
+- **AND-Logic across Labels**: If a PR has multiple designated labels attached (e.g., both `security` and `certification`), at least one SME from **each** label must approve.
+- **Author Self-Approval Exclusion**: A PR author **cannot approve their own PR**. Even if the author is listed as an SME for a label, another reviewer from that label's list must provide the approval.
+- **State Transition Awareness**: The check accurately tracks current review states. If an SME approves, but later submits `CHANGES_REQUESTED` or the approval is `DISMISSED`, the approval is no longer valid until re-approved.
+
+### Example Configuration
+```yaml
+# Core architecture & SDK infrastructure
+core:
+  - cecille
+  - andy31415
+
+# Security & Cryptography reviews
+security:
+  - cecille
+  - bzbarsky-apple
+
+# Data Model & Cluster XML specifications
+data-model:
+  - bzbarsky-apple
+  - Boris-Virk
+```
+
+### Adding or Updating Reviewers
+1. Create a branch:
+   ```bash
+   git checkout -b update-sme-reviewers
+   ```
+2. Edit [`.github/label_reviewers.yaml`](./label_reviewers.yaml) to add the label and username(s).
+3. Commit and submit a PR:
+   ```bash
+   git add .github/label_reviewers.yaml
+   git commit -m "Update SME reviewers for <domain>"
+   git push origin update-sme-reviewers
+   ```
+4. Once merged into `master`, all future and open PRs will use the updated reviewer list.
+
+---
+
+## 3. How to Re-Run the Workflow Once Review is Complete
+
+Once the designated SME has reviewed and submitted an **APPROVED** review, you have several quick ways to update the check:
+
+### Method 1: Automatic Re-evaluation (Zero Action Required)
+The workflow actively listens to GitHub's `pull_request_review` events (`submitted`, `edited`, `dismissed`).  
+**As soon as the SME submits an "Approved" review, the workflow automatically re-runs and updates to green without any manual intervention.**
+
+### Method 2: PR Comment Command (`/check-sme`)
+You can trigger an immediate re-evaluation directly from the PR conversation page:
+1. Open the PR.
+2. Type the following comment and submit:
+   ```text
+   /check-sme
+   ```
+3. GitHub Actions will detect the command and trigger the `Check SME Approvals` check immediately.
+
+### Method 3: Re-Run from the PR "Checks" Tab
+1. On the pull request page, click on the **Checks** tab (or click **Details** next to `Check SME Approvals` in the status checks list at the bottom of the **Conversation** tab).
+2. Select **Check SME Approvals** from the left panel.
+3. In the top-right corner, click **Re-run jobs** (or **Re-run**).
+
+### Method 4: Label Toggling
+Removing and re-adding the monitored label (or adding any other label) triggers the `labeled` / `unlabeled` PR event and immediately re-evaluates the check.
+
+---
+
+## 4. Branch Protection Integration
+
+To prevent pull requests from merging until the SME review check passes:
+
+1. Open repository **Settings** -> **Branches**.
+2. Under **Branch protection rules**, edit your target branch (e.g. `master`).
+3. Check **Require status checks to pass before merging**.
+4. In the search box under "Status checks that are required", search for and select:
+   ```text
+   Check SME Approvals
+   ```
+5. Click **Save changes**.
+
+> [!NOTE]
+> Unlike standard GitHub "Require review from Code Owners", setting `Check SME Approvals` as a required status check does **not** consume any GitHub Enterprise seats or require external subscription services.
+
+---
+
+## 5. Local CLI Verification
+
+The underlying verification script can also be run locally on a developer workstation or cloudtop:
+
+```bash
+# Basic check on a specific PR
+python3 scripts/tools/check_label_reviewers.py --pr 30000
+
+# Dry-run check (inspect status without failing)
+python3 scripts/tools/check_label_reviewers.py --pr 30000 --dry-run
+
+# Test with a custom config file
+python3 scripts/tools/check_label_reviewers.py --pr 30000 --config /path/to/custom_reviewers.yaml
+```

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -81,10 +81,11 @@ GitHub usernames:
 -   **OR-Logic across Labels**: If a PR has multiple designated labels attached
     (e.g., both `security` and `certification`), approval from at least **one**
     reviewer from **any** of the attached labels' lists satisfies the check.
--   **Override Label (`no-sme-check-required`)**: Attaching the
-    `no-sme-check-required` label to a PR bypasses the SME review requirement
-    completely, allowing emergency fixes or exempt PRs to pass the status check
-    without designated SME sign-off.
+-   **Override Labels (`no-sme-check-required`, `sdk-maintainer-approved`)**:
+    Attaching either the `no-sme-check-required` or `sdk-maintainer-approved`
+    label to a PR bypasses the SME review requirement completely, allowing
+    emergency fixes, exempt PRs, or maintainer-approved changes to pass the
+    status check without designated SME sign-off.
 -   **Author Self-Approval Exclusion**: A PR author **cannot approve their own
     PR**. Even if the author is listed as an SME for a label, another reviewer
     from that label's list must provide the approval.
@@ -168,10 +169,11 @@ page:
 Removing and re-adding the monitored label (or adding any other label) triggers
 the `labeled` / `unlabeled` PR event and immediately re-evaluates the check.
 
-### Method 5: Emergency Override (`no-sme-check-required`)
+### Method 5: Emergency or Maintainer Override (`no-sme-check-required`, `sdk-maintainer-approved`)
 
-If a PR needs to merge without designated SME review (e.g. an emergency hotfix
-or exempt change), attach the `no-sme-check-required` label to the pull request.
+If a PR needs to merge without designated SME review (e.g. an emergency hotfix,
+exempt change, or SDK maintainer sign-off), attach either the
+`no-sme-check-required` or `sdk-maintainer-approved` label to the pull request.
 The check will immediately pass and record that the SME review was bypassed.
 
 ---

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -146,6 +146,9 @@ The underlying verification script uses the GitHub CLI (`gh`) and can also be ru
 # Ensure GitHub CLI is authenticated (via gh auth login or GH_TOKEN)
 gh auth status
 
+# Validate YAML configuration syntax and format locally
+python3 scripts/tools/check_label_reviewers.py --validate-config
+
 # Run check on a specific PR
 python3 scripts/tools/check_label_reviewers.py --pr 30000
 

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -146,6 +146,9 @@ The underlying verification script uses the GitHub CLI (`gh`) and can also be ru
 # Ensure GitHub CLI is authenticated (via gh auth login or GH_TOKEN)
 gh auth status
 
+# Run unit tests
+python3 -m unittest scripts/tools/tests/test_check_label_reviewers.py
+
 # Validate YAML configuration syntax and format locally
 python3 scripts/tools/check_label_reviewers.py --validate-config
 

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -53,7 +53,7 @@ The YAML file is strictly structured as a mapping of label names to lists of Git
 
 ### Rules & Behaviors
 - **Case-Insensitive**: Both label names and usernames are matched case-insensitively (`Security` matches `security`, `Cecille` matches `cecille`).
-- **Optional `@`**: Leading `@` signs are automatically stripped (both `cecille` and `@cecille` work).
+- **No Leading `@`**: Usernames must not include leading `@` (use `username`, not `@username`).
 - **OR-Logic per Label**: At least **one** listed reviewer from the label's list must approve the PR.
 - **AND-Logic across Labels**: If a PR has multiple designated labels attached (e.g., both `security` and `certification`), **every** attached label requires at least one approval from its respective reviewer list (approval required for each domain).
 - **Author Self-Approval Exclusion**: A PR author **cannot approve their own PR**. Even if the author is listed as an SME for a label, another reviewer from that label's list must provide the approval.

--- a/.github/LABEL_REVIEWERS.md
+++ b/.github/LABEL_REVIEWERS.md
@@ -69,7 +69,6 @@ GitHub usernames:
 ```
 
 ### Rules & Behaviors
-
 -   **Case-Insensitive**: Both label names and usernames are matched
     case-insensitively (`Security` matches `security`, `Cecille` matches
     `cecille`).
@@ -78,12 +77,9 @@ GitHub usernames:
 -   **Quotes Optional**: Usernames can be unquoted or enclosed in quotes
     (`username`, `'username'`, or `"username"`). Quotes are not required for
     standard GitHub usernames.
--   **OR-Logic per Label**: At least **one** listed reviewer from the label's
-    list must approve the PR.
--   **AND-Logic across Labels**: If a PR has multiple designated labels attached
-    (e.g., both `security` and `certification`), **every** attached label
-    requires at least one approval from its respective reviewer list (approval
-    required for each domain).
+-   **OR-Logic across Labels**: If a PR has multiple designated labels attached
+    (e.g., both `security` and `certification`), approval from at least **one**
+    reviewer from **any** of the attached labels' lists satisfies the check.
 -   **Author Self-Approval Exclusion**: A PR author **cannot approve their own
     PR**. Even if the author is listed as an SME for a label, another reviewer
     from that label's list must provide the approval.

--- a/.github/label_reviewers.yaml
+++ b/.github/label_reviewers.yaml
@@ -34,8 +34,8 @@
 #   - Optional leading '@' on usernames is supported (e.g. '@username' or 'username').
 #   - PR authors cannot approve their own PRs (author approvals are ignored).
 #   - If a PR has no designated labels attached, the check passes automatically.
-#   - If multiple designated labels are attached, each label requires at least one
-#     approval from its respective list.
+#   - If multiple designated labels are attached, EVERY label requires at least one
+#     approval from its respective reviewer list.
 #
 # Format:
 #   <label_name>:

--- a/.github/label_reviewers.yaml
+++ b/.github/label_reviewers.yaml
@@ -31,7 +31,7 @@
 #
 # Key Features:
 #   - Usernames and labels are case-insensitive.
-#   - Optional leading '@' on usernames is supported (e.g. '@username' or 'username').
+#   - Usernames must NOT include leading '@' (e.g. 'username', not '@username').
 #   - PR authors cannot approve their own PRs (author approvals are ignored).
 #   - If a PR has no designated labels attached, the check passes automatically.
 #   - If multiple designated labels are attached, EVERY label requires at least one

--- a/.github/label_reviewers.yaml
+++ b/.github/label_reviewers.yaml
@@ -22,7 +22,7 @@
 #
 # When a pull request has one or more of these labels attached, the
 # "check-label-reviewers" GitHub Action verifies that at least one reviewer from
-# EACH matching label's list has submitted an APPROVED review.
+# ANY of the matching labels' lists has submitted an APPROVED review.
 #
 # Documentation: See .github/LABEL_REVIEWERS.md for complete instructions on:
 #   - Creating labels on GitHub
@@ -35,8 +35,8 @@
 #   - Quotes around usernames are optional (e.g. username, 'username', or "username").
 #   - PR authors cannot approve their own PRs (author approvals are ignored).
 #   - If a PR has no designated labels attached, the check passes automatically.
-#   - If multiple designated labels are attached, EVERY label requires at least one
-#     approval from its respective reviewer list.
+#   - If multiple designated labels are attached, approval from ANY one reviewer
+#     across any of the associated labels' lists satisfies the check.
 #
 # Format:
 #   <label_name>:

--- a/.github/label_reviewers.yaml
+++ b/.github/label_reviewers.yaml
@@ -32,6 +32,7 @@
 # Key Features:
 #   - Usernames and labels are case-insensitive.
 #   - Usernames must NOT include leading '@' (e.g. 'username', not '@username').
+#   - Quotes around usernames are optional (e.g. username, 'username', or "username").
 #   - PR authors cannot approve their own PRs (author approvals are ignored).
 #   - If a PR has no designated labels attached, the check passes automatically.
 #   - If multiple designated labels are attached, EVERY label requires at least one

--- a/.github/label_reviewers.yaml
+++ b/.github/label_reviewers.yaml
@@ -41,55 +41,10 @@
 #   <label_name>:
 #     - <github_username_1>
 #     - <github_username_2>
+#
+# Example (uncomment and customize to add new SME review labels):
+#   # my-label:
+#   #   - github-username1
+#   #   - github-username2
 # ==============================================================================
 
-# Core architecture & SDK infrastructure
-core:
-  - cecille
-  - andy31415
-
-# Security & Cryptography reviews
-security:
-  - cecille
-  - bzbarsky-apple
-
-crypto:
-  - cecille
-  - woane
-
-# Data Model & Cluster XML specifications
-data-model:
-  - bzbarsky-apple
-  - Boris-Virk
-
-# Certification testing & test harness
-certification:
-  - robfusco
-  - dhrishi
-
-# Device Attestation Credentials (DACs) & PAI/CD verification
-attestation:
-  - cecille
-  - woane
-
-# Build tools & CI scripts
-scripts:
-  - andy31415
-  - cecille
-
-# Platform-specific SME reviews (when tagged by label)
-darwin:
-  - bzbarsky-apple
-  - jwhiting-apple
-
-esp32:
-  - shubhamdp
-  - wqx6
-
-nxp:
-  - doru91
-  - dinabenamar
-
-silabs:
-  - jmartinez-silabs
-  - lpbeliveau-silabs

--- a/.github/label_reviewers.yaml
+++ b/.github/label_reviewers.yaml
@@ -37,6 +37,8 @@
 #   - If a PR has no designated labels attached, the check passes automatically.
 #   - If multiple designated labels are attached, approval from ANY one reviewer
 #     across any of the associated labels' lists satisfies the check.
+#   - Override Label: Attaching "no-sme-check-required" to a PR completely
+#     bypasses the SME approval check.
 #
 # Format:
 #   <label_name>:

--- a/.github/label_reviewers.yaml
+++ b/.github/label_reviewers.yaml
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ==============================================================================
+# Subject Matter Expert (SME) Reviewers by Pull Request Label
+# ==============================================================================
+# This configuration maps GitHub PR labels to lists of designated Subject Matter
+# Expert (SME) reviewers.
+#
+# When a pull request has one or more of these labels attached, the
+# "check-label-reviewers" GitHub Action verifies that at least one reviewer from
+# EACH matching label's list has submitted an APPROVED review.
+#
+# Documentation: See .github/LABEL_REVIEWERS.md for complete instructions on:
+#   - Creating labels on GitHub
+#   - Managing reviewer lists
+#   - Re-running the check from within PRs (via comment, UI, or events)
+#
+# Key Features:
+#   - Usernames and labels are case-insensitive.
+#   - Optional leading '@' on usernames is supported (e.g. '@username' or 'username').
+#   - PR authors cannot approve their own PRs (author approvals are ignored).
+#   - If a PR has no designated labels attached, the check passes automatically.
+#   - If multiple designated labels are attached, each label requires at least one
+#     approval from its respective list.
+#
+# Format:
+#   <label_name>:
+#     - <github_username_1>
+#     - <github_username_2>
+# ==============================================================================
+
+# Core architecture & SDK infrastructure
+core:
+  - cecille
+  - andy31415
+
+# Security & Cryptography reviews
+security:
+  - cecille
+  - bzbarsky-apple
+
+crypto:
+  - cecille
+  - woane
+
+# Data Model & Cluster XML specifications
+data-model:
+  - bzbarsky-apple
+  - Boris-Virk
+
+# Certification testing & test harness
+certification:
+  - robfusco
+  - dhrishi
+
+# Device Attestation Credentials (DACs) & PAI/CD verification
+attestation:
+  - cecille
+  - woane
+
+# Build tools & CI scripts
+scripts:
+  - andy31415
+  - cecille
+
+# Platform-specific SME reviews (when tagged by label)
+darwin:
+  - bzbarsky-apple
+  - jwhiting-apple
+
+esp32:
+  - shubhamdp
+  - wqx6
+
+nxp:
+  - doru91
+  - dinabenamar
+
+silabs:
+  - jmartinez-silabs
+  - lpbeliveau-silabs

--- a/.github/label_reviewers.yaml
+++ b/.github/label_reviewers.yaml
@@ -37,8 +37,8 @@
 #   - If a PR has no designated labels attached, the check passes automatically.
 #   - If multiple designated labels are attached, approval from ANY one reviewer
 #     across any of the associated labels' lists satisfies the check.
-#   - Override Label: Attaching "no-sme-check-required" to a PR completely
-#     bypasses the SME approval check.
+#   - Override Labels: Attaching "no-sme-check-required" or
+#     "sdk-maintainer-approved" to a PR completely bypasses the SME approval check.
 #
 # Format:
 #   <label_name>:

--- a/.github/workflows/check_label_reviewers.yaml
+++ b/.github/workflows/check_label_reviewers.yaml
@@ -78,6 +78,10 @@ jobs:
           git fetch origin "refs/pull/${{ steps.params.outputs.pr_number }}/head" --depth=1
           git checkout FETCH_HEAD -- .github/label_reviewers.yaml || true
 
+      - name: Run Unit Tests
+        run: |
+          python3 -m unittest scripts/tools/tests/test_check_label_reviewers.py
+
       - name: Validate Configuration File
         run: |
           python3 scripts/tools/check_label_reviewers.py \

--- a/.github/workflows/check_label_reviewers.yaml
+++ b/.github/workflows/check_label_reviewers.yaml
@@ -75,6 +75,7 @@ jobs:
       - name: Execute SME Reviewer Check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ steps.params.outputs.sync_labels }}" = "true" ]; then
             python3 scripts/tools/check_label_reviewers.py \

--- a/.github/workflows/check_label_reviewers.yaml
+++ b/.github/workflows/check_label_reviewers.yaml
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Check SME Label Reviewers
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  issue_comment:
+    types: [created]
+  push:
+    branches: [master]
+    paths:
+      - ".github/label_reviewers.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  check-sme-review:
+    name: Check SME Approvals
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request != null && contains(github.event.comment.body, '/check-sme'))
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Dependencies
+        run: |
+          pip install --no-cache-dir pyyaml
+
+      - name: Determine PR Number and Options
+        id: params
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "push" ]; then
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "sync_labels=true" >> "$GITHUB_OUTPUT"
+            echo "dry_run_flag=" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+            echo "sync_labels=false" >> "$GITHUB_OUTPUT"
+            echo "dry_run_flag=" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "sync_labels=false" >> "$GITHUB_OUTPUT"
+            echo "dry_run_flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Execute SME Reviewer Check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.params.outputs.sync_labels }}" = "true" ]; then
+            python3 scripts/tools/check_label_reviewers.py \
+              --repo "${{ github.repository }}" \
+              --config .github/label_reviewers.yaml \
+              --sync-labels
+          fi
+
+          if [ -n "${{ steps.params.outputs.pr_number }}" ]; then
+            python3 scripts/tools/check_label_reviewers.py \
+              --pr "${{ steps.params.outputs.pr_number }}" \
+              --repo "${{ github.repository }}" \
+              --config .github/label_reviewers.yaml \
+              ${{ steps.params.outputs.dry_run_flag }}
+          fi

--- a/.github/workflows/check_label_reviewers.yaml
+++ b/.github/workflows/check_label_reviewers.yaml
@@ -64,15 +64,12 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "push" ]; then
             echo "pr_number=" >> "$GITHUB_OUTPUT"
             echo "sync_labels=true" >> "$GITHUB_OUTPUT"
-            echo "dry_run_flag=" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "issue_comment" ]; then
             echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
             echo "sync_labels=false" >> "$GITHUB_OUTPUT"
-            echo "dry_run_flag=" >> "$GITHUB_OUTPUT"
           else
             echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "sync_labels=false" >> "$GITHUB_OUTPUT"
-            echo "dry_run_flag=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Execute SME Reviewer Check
@@ -90,6 +87,5 @@ jobs:
             python3 scripts/tools/check_label_reviewers.py \
               --pr "${{ steps.params.outputs.pr_number }}" \
               --repo "${{ github.repository }}" \
-              --config .github/label_reviewers.yaml \
-              ${{ steps.params.outputs.dry_run_flag }}
+              --config .github/label_reviewers.yaml
           fi

--- a/.github/workflows/check_label_reviewers.yaml
+++ b/.github/workflows/check_label_reviewers.yaml
@@ -72,6 +72,18 @@ jobs:
             echo "sync_labels=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Fetch PR Configuration
+        if: steps.params.outputs.pr_number != ''
+        run: |
+          git fetch origin "refs/pull/${{ steps.params.outputs.pr_number }}/head" --depth=1
+          git checkout FETCH_HEAD -- .github/label_reviewers.yaml || true
+
+      - name: Validate Configuration File
+        run: |
+          python3 scripts/tools/check_label_reviewers.py \
+            --config .github/label_reviewers.yaml \
+            --validate-config
+
       - name: Execute SME Reviewer Check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -79,7 +79,6 @@ def fetch_pull_request_data(repo: str, pr_number: int) -> dict[str, Any]:
         raise RuntimeError(f"Failed to parse gh output as JSON: {e}") from e
 
 
-
 def parse_label_config(config_path: str) -> dict[str, LabelRule]:
     """Parses the YAML configuration file mapping labels to SME reviewers.
 

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -302,6 +302,11 @@ def main() -> int:
         help="Ensure all configured labels exist on GitHub, creating any that are missing.",
     )
     parser.add_argument(
+        "--validate-config",
+        action="store_true",
+        help="Validate the syntax and format of the configuration file and exit.",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -325,6 +330,12 @@ def main() -> int:
     logging.info(f"Configured labels with SME reviewers ({len(config_mapping)}):")
     for key, rule in config_mapping.items():
         logging.debug(f"  - '{rule.display_name}': {sorted(rule.smes)}")
+
+    if args.validate_config:
+        print(
+            f"✅ Configuration in {args.config} is valid ({len(config_mapping)} label(s) configured)."
+        )
+        return 0
 
     if args.sync_labels:
         logging.info(f"Syncing labels from {args.config} to repository {args.repo}...")

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -17,8 +17,8 @@
 
 """SME (Subject Matter Expert) Label Reviewer Checker for Pull Requests.
 
-Verifies that for each designated label attached to a pull request, at least one
-designated SME username from the corresponding configuration has approved the PR.
+Verifies that for PRs with designated labels attached, at least one designated
+SME username from any of the matching labels' lists has approved the PR.
 Uses the GitHub CLI (`gh`) to fetch PR reviews and labels.
 """
 
@@ -177,12 +177,19 @@ def evaluate_pr_labels(
     return evaluations
 
 
+def is_sme_review_satisfied(evaluations: list[LabelEvaluation]) -> bool:
+    """Returns True if no monitored labels are present, or if ANY label has at least one SME approval."""
+    if not evaluations:
+        return True
+    return any(ev.satisfied for ev in evaluations)
+
+
 def generate_step_summary(
     evaluations: list[LabelEvaluation],
     pr_number: int,
     pr_title: str,
     pr_author: str,
-    all_passed: bool,
+    passed: bool,
 ) -> str:
     """Builds a GitHub Actions Markdown Step Summary."""
     md = []
@@ -207,21 +214,28 @@ def generate_step_summary(
             status_icon = "✅ Approved"
             approvers_str = ", ".join([f"@{u}" for u in ev.approvers])
         else:
-            status_icon = "❌ Missing"
+            status_icon = "⚪ Satisfied (by other label)" if passed else "❌ Missing"
             approvers_str = "*None*"
         md.append(f"| {label_code} | {status_icon} | {req_smes} | {approvers_str} |")
 
     md.append("")
-    if all_passed:
-        md.append(
-            "> ✅ **All SME Review Requirements Met!**  \n"
-            "> At least one designated reviewer from each required label has approved this PR."
-        )
+    if passed:
+        all_matching_approvers = sorted({f"@{u}" for ev in evaluations for u in ev.approvers})
+        if all_matching_approvers:
+            md.append(
+                "> ✅ **SME Review Requirement Met!**  \n"
+                f"> At least one designated reviewer ({', '.join(all_matching_approvers)}) has approved this PR."
+            )
+        else:
+            md.append(
+                "> ✅ **SME Review Requirement Met!**  \n"
+                "> This PR does not require SME approval."
+            )
     else:
-        missing_count = sum(1 for ev in evaluations if not ev.satisfied)
+        all_req_smes = sorted({f"@{u}" for ev in evaluations for u in ev.rule.smes})
         md.append(
-            f"> ❌ **Review Required**: {missing_count} label(s) are missing required SME approval.  \n"
-            "> Please request review from at least one of the listed subject matter experts."
+            "> ❌ **Review Required**: Missing SME approval.  \n"
+            f"> Please request review from at least one SME from any of the required label lists: {', '.join(all_req_smes)}."
         )
 
     return "\n".join(md)
@@ -392,10 +406,12 @@ def main() -> int:
     if not evaluations:
         print("ℹ️  No designated SME review labels attached to this PR.")
         print("   Check passed automatically.\n" + "=" * 72)
-        all_passed = True
+        passed = True
     else:
         print(f"Found {len(evaluations)} monitored SME label(s) on this PR:\n")
-        all_passed = True
+        passed = is_sme_review_satisfied(evaluations)
+        all_matching_approvers = sorted({u for ev in evaluations for u in ev.approvers})
+
         for idx, ev in enumerate(evaluations, 1):
             req_smes = ", ".join([f"@{u}" for u in ev.rule.smes])
             if ev.satisfied:
@@ -404,13 +420,20 @@ def main() -> int:
                 print(f"      Required SMEs: {req_smes}")
                 print(f"      Status:        ✅ APPROVED by {approver_mentions}\n")
             else:
-                all_passed = False
                 print(f"  [{idx}] Label: '{ev.rule.name}'")
                 print(f"      Required SMEs: {req_smes}")
-                print("      Status:        ❌ MISSING APPROVAL")
-                print(
-                    f"      Action:        Requires at least one approval from: {req_smes}\n"
-                )
+                if passed:
+                    print(
+                        f"      Status:        ⚪ Not directly reviewed (requirement satisfied by {', '.join([f'@{u}' for u in all_matching_approvers])})\n"
+                    )
+                else:
+                    print("      Status:        ❌ MISSING APPROVAL\n")
+
+        if not passed:
+            all_smes = sorted({f"@{u}" for ev in evaluations for u in ev.rule.smes})
+            print(
+                f"  Action: Requires at least one approval from any of: {', '.join(all_smes)}\n"
+            )
         print("=" * 72)
 
     # Output parameters for GitHub Actions
@@ -423,11 +446,11 @@ def main() -> int:
         write_github_outputs(
             gh_output,
             {
-                "passed": "true" if all_passed else "false",
+                "passed": "true" if passed else "false",
                 "total_monitored_labels": str(len(evaluations)),
-                "missing_count": str(len(missing_labels)),
+                "missing_count": "0" if passed else str(len(missing_labels)),
                 "approved_labels": ",".join(approved_labels),
-                "missing_labels": ",".join(missing_labels),
+                "missing_labels": "" if passed else ",".join(missing_labels),
             },
         )
 
@@ -435,12 +458,12 @@ def main() -> int:
     gh_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if gh_summary:
         summary_md = generate_step_summary(
-            evaluations, pr_number, pr_title, pr_author, all_passed
+            evaluations, pr_number, pr_title, pr_author, passed
         )
         write_step_summary(gh_summary, summary_md)
 
-    if all_passed:
-        print("✅ SUCCESS: All required SME reviews have been satisfied.\n")
+    if passed:
+        print("✅ SUCCESS: SME review requirement has been satisfied.\n")
         return 0
 
     print("❌ FAILURE: Missing required SME review approval(s).\n")

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -19,7 +19,7 @@
 
 Verifies that for each designated label attached to a pull request, at least one
 designated SME username from the corresponding configuration has approved the PR.
-Can be executed manually or as part of a GitHub Actions workflow.
+Uses the GitHub CLI (`gh`) to fetch PR reviews and labels.
 """
 
 from __future__ import annotations
@@ -28,9 +28,8 @@ import argparse
 import json
 import logging
 import os
+import subprocess
 import sys
-import urllib.error
-import urllib.request
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -58,77 +57,28 @@ class LabelEvaluation:
         return not self.present_on_pr or len(self.approvers) > 0
 
 
-class GitHubApiClient:
-    """Lightweight GitHub REST API client using standard library urllib."""
+def fetch_pull_request_data(repo: str, pr_number: int) -> dict[str, Any]:
+    """Fetches pull request details and latest reviews using the gh CLI."""
+    cmd = [
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--json",
+        "author,title,state,labels,latestReviews",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return json.loads(proc.stdout)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"gh pr view failed (exit code {e.returncode}): {e.stderr.strip()}"
+        ) from e
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Failed to parse gh output as JSON: {e}") from e
 
-    def __init__(self, token: str) -> None:
-        self.token = token
-
-    def request(self, url: str) -> Any:
-        headers = {
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "chip-label-reviewer-action",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "Authorization": f"Bearer {self.token}",
-        }
-
-        req = urllib.request.Request(url, headers=headers)
-        try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                content = resp.read().decode("utf-8")
-                return json.loads(content)
-        except urllib.error.HTTPError as e:
-            err_msg = e.read().decode("utf-8", errors="replace")
-            if e.code == 404:
-                raise RuntimeError(f"Resource not found at {url}") from e
-            if e.code in (401, 403):
-                raise RuntimeError(
-                    f"GitHub API authorization/rate limit error (HTTP {e.code}): {err_msg}"
-                ) from e
-            raise RuntimeError(
-                f"GitHub API request failed (HTTP {e.code}) for {url}: {err_msg}"
-            ) from e
-        except urllib.error.URLError as e:
-            raise RuntimeError(f"Failed to reach GitHub API: {e.reason}") from e
-
-    def get_pull_request(self, repo: str, pr_number: int) -> dict[str, Any]:
-        url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
-        return self.request(url)
-
-    def get_pull_request_reviews(
-        self, repo: str, pr_number: int
-    ) -> list[dict[str, Any]]:
-        reviews = []
-        page = 1
-        while True:
-            url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews?per_page=100&page={page}"
-            data = self.request(url)
-            if not isinstance(data, list) or not data:
-                break
-            reviews.extend(data)
-            if len(data) < 100:
-                break
-            page += 1
-        return reviews
-
-    def post(self, url: str, data: dict[str, Any]) -> Any:
-        headers = {
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "chip-label-reviewer-action",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.token}",
-        }
-
-        body = json.dumps(data).encode("utf-8")
-        req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-        try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                content = resp.read().decode("utf-8")
-                return json.loads(content)
-        except urllib.error.HTTPError as e:
-            err_msg = e.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"GitHub API POST failed (HTTP {e.code}): {err_msg}") from e
 
 
 def parse_label_config(config_path: str) -> dict[str, LabelRule]:
@@ -190,40 +140,6 @@ def parse_label_config(config_path: str) -> dict[str, LabelRule]:
     return mapping
 
 
-def compute_effective_approvers(
-    reviews: list[dict[str, Any]], author: str
-) -> set[str]:
-    """Computes currently approving users from chronological PR reviews.
-
-    Respects state transitions: APPROVED -> CHANGES_REQUESTED -> APPROVED.
-    PR author cannot approve their own pull request.
-    """
-    approvers: set[str] = set()
-    change_requesters: set[str] = set()
-    author_lower = author.lower() if author else ""
-
-    for review in reviews:
-        user_info = review.get("user")
-        if not user_info or not user_info.get("login"):
-            continue
-        user = user_info["login"].lower()
-        state = review.get("state")
-
-        if state == "APPROVED":
-            approvers.add(user)
-            change_requesters.discard(user)
-        elif state == "CHANGES_REQUESTED":
-            change_requesters.add(user)
-            approvers.discard(user)
-        elif state == "DISMISSED":
-            approvers.discard(user)
-            change_requesters.discard(user)
-
-    # Discard author from approvers
-    approvers.discard(author_lower)
-    return approvers
-
-
 def evaluate_pr_labels(
     pr_labels: list[str],
     config_mapping: dict[str, LabelRule],
@@ -245,40 +161,6 @@ def evaluate_pr_labels(
             )
 
     return evaluations
-
-
-def extract_pr_number_from_environment() -> int | None:
-    """Tries to extract PR number from environment or GitHub event payload."""
-    env_pr = os.environ.get("PR_NUMBER")
-    if env_pr and env_pr.isdigit():
-        return int(env_pr)
-
-    event_path = os.environ.get("GITHUB_EVENT_PATH")
-    if event_path and os.path.exists(event_path):
-        try:
-            with open(event_path, encoding="utf-8") as f:
-                event_data = json.load(f)
-            # From pull_request or pull_request_target event
-            if "pull_request" in event_data and "number" in event_data["pull_request"]:
-                return int(event_data["pull_request"]["number"])
-            # From issue_comment event on a pull request
-            if (
-                "issue" in event_data
-                and "pull_request" in event_data["issue"]
-                and "number" in event_data["issue"]
-            ):
-                return int(event_data["issue"]["number"])
-            # From workflow_dispatch inputs
-            if (
-                "inputs" in event_data
-                and "pr_number" in event_data["inputs"]
-                and str(event_data["inputs"]["pr_number"]).isdigit()
-            ):
-                return int(event_data["inputs"]["pr_number"])
-        except Exception as e:
-            logging.debug(f"Could not parse GITHUB_EVENT_PATH: {e}")
-
-    return None
 
 
 def generate_step_summary(
@@ -350,26 +232,18 @@ def write_step_summary(summary_path: str, summary_markdown: str) -> None:
         logging.warning(f"Failed writing to GITHUB_STEP_SUMMARY: {e}")
 
 
-def sync_labels_to_github(
-    repo: str, config_mapping: dict[str, LabelRule], client: GitHubApiClient
-) -> list[str]:
-    """Ensures all configured labels exist in the GitHub repository.
-
-    Fetches existing labels and creates any missing ones via POST /repos/:owner/:repo/labels.
-    """
-    existing_labels = set()
-    page = 1
-    while True:
-        url = f"https://api.github.com/repos/{repo}/labels?per_page=100&page={page}"
-        data = client.request(url)
-        if not isinstance(data, list) or not data:
-            break
-        for item in data:
-            if isinstance(item, dict) and "name" in item:
-                existing_labels.add(item["name"].strip().lower())
-        if len(data) < 100:
-            break
-        page += 1
+def sync_labels_to_github(repo: str, config_mapping: dict[str, LabelRule]) -> list[str]:
+    """Ensures all configured labels exist in the GitHub repository using gh CLI."""
+    cmd = ["gh", "label", "list", "--repo", repo, "--limit", "1000", "--json", "name"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        data = json.loads(proc.stdout)
+        existing_labels = {
+            item["name"].strip().lower() for item in data if "name" in item
+        }
+    except Exception as e:
+        logging.warning(f"Could not list existing labels on {repo}: {e}")
+        existing_labels = set()
 
     created: list[str] = []
     for key, rule in config_mapping.items():
@@ -377,20 +251,28 @@ def sync_labels_to_github(
             logging.info(
                 f"Label '{rule.display_name}' does not exist on {repo}. Creating..."
             )
-            url = f"https://api.github.com/repos/{repo}/labels"
-            payload = {
-                "name": rule.display_name,
-                "description": f"Requires SME review: {rule.display_name}",
-                "color": "ededed",
-            }
+            create_cmd = [
+                "gh",
+                "label",
+                "create",
+                rule.display_name,
+                "--repo",
+                repo,
+                "--description",
+                f"Requires SME review: {rule.display_name}",
+                "--color",
+                "ededed",
+            ]
             try:
-                client.post(url, payload)
+                subprocess.run(create_cmd, capture_output=True, text=True, check=True)
                 created.append(rule.display_name)
                 logging.info(
                     f"✅ Successfully created label '{rule.display_name}' on GitHub."
                 )
-            except Exception as e:
-                logging.warning(f"Could not create label '{rule.display_name}': {e}")
+            except subprocess.CalledProcessError as e:
+                logging.warning(
+                    f"Could not create label '{rule.display_name}': {e.stderr.strip()}"
+                )
 
     return created
 
@@ -402,7 +284,7 @@ def main() -> int:
     parser.add_argument(
         "--pr",
         type=int,
-        help="Pull request number (auto-detected if omitted in GitHub Actions)",
+        help="Pull request number",
     )
     parser.add_argument(
         "--repo",
@@ -413,11 +295,6 @@ def main() -> int:
         "--config",
         default=DEFAULT_CONFIG_PATH,
         help=f"Path to the YAML label reviewers file (default: {DEFAULT_CONFIG_PATH})",
-    )
-    parser.add_argument(
-        "--token",
-        default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"),
-        help="GitHub API token (reads GITHUB_TOKEN or GH_TOKEN env if not specified)",
     )
     parser.add_argument(
         "--sync-labels",
@@ -449,39 +326,30 @@ def main() -> int:
     for key, rule in config_mapping.items():
         logging.debug(f"  - '{rule.display_name}': {sorted(rule.smes)}")
 
-    if not args.token:
-        logging.error(
-            "GitHub API token is required. Set GITHUB_TOKEN environment variable or pass --token."
-        )
-        return 2
-
-    client = GitHubApiClient(token=args.token)
-
     if args.sync_labels:
         logging.info(f"Syncing labels from {args.config} to repository {args.repo}...")
-        created = sync_labels_to_github(args.repo, config_mapping, client)
+        created = sync_labels_to_github(args.repo, config_mapping)
         if created:
             print(f"Created {len(created)} new label(s) on GitHub: {', '.join(created)}")
         else:
             print("All configured labels already exist on GitHub.")
-        if not args.pr and not extract_pr_number_from_environment():
+        if not args.pr:
             return 0
 
-    pr_number = args.pr or extract_pr_number_from_environment()
-    if not pr_number:
-        logging.error(
-            "PR number not provided. Pass --pr <number> or run within a GitHub Action PR context."
-        )
+    if not args.pr:
+        logging.error("PR number not provided. Pass --pr <number>.")
         return 2
+
+    pr_number = args.pr
     logging.info(f"Fetching PR #{pr_number} from {args.repo}...")
     try:
-        pr_data = client.get_pull_request(args.repo, pr_number)
+        pr_data = fetch_pull_request_data(args.repo, pr_number)
     except Exception as e:
         logging.error(f"Failed to fetch PR #{pr_number}: {e}")
         return 2
 
     pr_title = pr_data.get("title", "")
-    pr_author = pr_data.get("user", {}).get("login", "")
+    pr_author = pr_data.get("author", {}).get("login", "")
     pr_state = pr_data.get("state", "")
     pr_labels = [l.get("name", "") for l in pr_data.get("labels", [])]
 
@@ -491,14 +359,14 @@ def main() -> int:
     print("=" * 72)
     print(f"Active PR labels: {pr_labels}\n")
 
-    logging.info(f"Fetching reviews for PR #{pr_number}...")
-    try:
-        raw_reviews = client.get_pull_request_reviews(args.repo, pr_number)
-    except Exception as e:
-        logging.error(f"Failed to fetch reviews for PR #{pr_number}: {e}")
-        return 2
-
-    approvers = compute_effective_approvers(raw_reviews, author=pr_author)
+    # Author cannot approve their own PR
+    author_lower = pr_author.lower()
+    approvers = {
+        r.get("author", {}).get("login", "").lower()
+        for r in pr_data.get("latestReviews", [])
+        if r.get("state") == "APPROVED"
+        and r.get("author", {}).get("login", "").lower() != author_lower
+    }
     logging.info(f"Active approved reviews from: {sorted(approvers) or 'None'}")
 
     evaluations = evaluate_pr_labels(pr_labels, config_mapping, approvers)

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -37,7 +37,8 @@ import yaml
 
 DEFAULT_REPO = "project-chip/connectedhomeip"
 DEFAULT_CONFIG_PATH = ".github/label_reviewers.yaml"
-DEFAULT_OVERRIDE_LABEL = "no-sme-check-required"
+DEFAULT_OVERRIDE_LABELS = ("no-sme-check-required", "sdk-maintainer-approved")
+DEFAULT_OVERRIDE_LABEL = DEFAULT_OVERRIDE_LABELS[0]
 
 
 @dataclass
@@ -178,13 +179,30 @@ def evaluate_pr_labels(
     return evaluations
 
 
+def find_active_override(
+    pr_labels: list[str],
+    override_labels: str | list[str] | tuple[str, ...] = DEFAULT_OVERRIDE_LABELS,
+) -> str | None:
+    """Returns the matching override label name if present on the PR, or None."""
+    if isinstance(override_labels, str):
+        target_list = [override_labels]
+    else:
+        target_list = list(override_labels)
+
+    clean_pr_labels = {l.strip().lower(): l.strip() for l in pr_labels if l and l.strip()}
+    for target in target_list:
+        key = target.strip().lower()
+        if key in clean_pr_labels:
+            return clean_pr_labels[key]
+    return None
+
+
 def check_override_present(
     pr_labels: list[str],
-    override_label: str = DEFAULT_OVERRIDE_LABEL,
+    override_labels: str | list[str] | tuple[str, ...] = DEFAULT_OVERRIDE_LABELS,
 ) -> bool:
-    """Checks if the override label is attached to the PR (case-insensitive)."""
-    target = override_label.strip().lower()
-    return any(l.strip().lower() == target for l in pr_labels if l and l.strip())
+    """Checks if any override label is attached to the PR (case-insensitive)."""
+    return find_active_override(pr_labels, override_labels) is not None
 
 
 def is_sme_review_satisfied(
@@ -292,9 +310,9 @@ def write_step_summary(summary_path: str, summary_markdown: str) -> None:
 def sync_labels_to_github(
     repo: str,
     config_mapping: dict[str, LabelRule],
-    override_label: str = DEFAULT_OVERRIDE_LABEL,
+    override_labels: str | list[str] | tuple[str, ...] = DEFAULT_OVERRIDE_LABELS,
 ) -> list[str]:
-    """Ensures all configured labels and the override label exist in the GitHub repository using gh CLI."""
+    """Ensures all configured labels and override labels exist in the GitHub repository using gh CLI."""
     cmd = ["gh", "label", "list", "--repo", repo, "--limit", "1000", "--json", "name"]
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
@@ -308,32 +326,35 @@ def sync_labels_to_github(
 
     created: list[str] = []
 
-    if override_label and override_label.strip().lower() not in existing_labels:
-        logging.info(
-            f"Override label '{override_label}' does not exist on {repo}. Creating..."
-        )
-        create_cmd = [
-            "gh",
-            "label",
-            "create",
-            override_label,
-            "--repo",
-            repo,
-            "--description",
-            "Override to bypass required SME reviews",
-            "--color",
-            "fbca04",
-        ]
-        try:
-            subprocess.run(create_cmd, capture_output=True, text=True, check=True)
-            created.append(override_label)
+    target_override_labels = [override_labels] if isinstance(override_labels, str) else list(override_labels)
+
+    for o_label in target_override_labels:
+        if o_label and o_label.strip().lower() not in existing_labels:
             logging.info(
-                f"✅ Successfully created override label '{override_label}' on GitHub."
+                f"Override label '{o_label}' does not exist on {repo}. Creating..."
             )
-        except subprocess.CalledProcessError as e:
-            logging.warning(
-                f"Could not create override label '{override_label}': {e.stderr.strip()}"
-            )
+            create_cmd = [
+                "gh",
+                "label",
+                "create",
+                o_label,
+                "--repo",
+                repo,
+                "--description",
+                "Override to bypass required SME reviews",
+                "--color",
+                "fbca04",
+            ]
+            try:
+                subprocess.run(create_cmd, capture_output=True, text=True, check=True)
+                created.append(o_label)
+                logging.info(
+                    f"✅ Successfully created override label '{o_label}' on GitHub."
+                )
+            except subprocess.CalledProcessError as e:
+                logging.warning(
+                    f"Could not create override label '{o_label}': {e.stderr.strip()}"
+                )
 
     for key, rule in config_mapping.items():
         if key not in existing_labels:
@@ -397,8 +418,9 @@ def main() -> int:
     )
     parser.add_argument(
         "--override-label",
-        default=DEFAULT_OVERRIDE_LABEL,
-        help=f"Label name that bypasses SME review checks (default: {DEFAULT_OVERRIDE_LABEL})",
+        action="append",
+        dest="override_labels",
+        help=f"Label name that bypasses SME review checks (can be specified multiple times; default: {', '.join(DEFAULT_OVERRIDE_LABELS)})",
     )
     parser.add_argument(
         "--log-level",
@@ -408,6 +430,13 @@ def main() -> int:
     )
 
     args = parser.parse_args()
+
+    override_labels: list[str] = []
+    if args.override_labels:
+        for item in args.override_labels:
+            override_labels.extend([s.strip() for s in item.split(",") if s.strip()])
+    else:
+        override_labels = list(DEFAULT_OVERRIDE_LABELS)
 
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper()),
@@ -433,7 +462,7 @@ def main() -> int:
 
     if args.sync_labels:
         logging.info(f"Syncing labels from {args.config} to repository {args.repo}...")
-        created = sync_labels_to_github(args.repo, config_mapping, args.override_label)
+        created = sync_labels_to_github(args.repo, config_mapping, override_labels)
         if created:
             print(f"Created {len(created)} new label(s) on GitHub: {', '.join(created)}")
         else:
@@ -467,9 +496,10 @@ def main() -> int:
     approvers = extract_approvers(pr_data)
     logging.info(f"Active approved reviews from: {sorted(approvers) or 'None'}")
 
-    overridden = check_override_present(pr_labels, args.override_label)
+    active_override = find_active_override(pr_labels, override_labels)
+    overridden = active_override is not None
     if overridden:
-        print(f"⚠️  Override label '{args.override_label}' is present on this PR.")
+        print(f"⚠️  Override label '{active_override}' is present on this PR.")
         print("   SME review check is bypassed.\n" + "=" * 72)
 
     evaluations = evaluate_pr_labels(pr_labels, config_mapping, approvers)
@@ -493,7 +523,7 @@ def main() -> int:
             elif overridden:
                 print(f"  [{idx}] Label: '{ev.rule.name}'")
                 print(f"      Required SMEs: {req_smes}")
-                print(f"      Status:        ⚪ OVERRIDDEN by '{args.override_label}'\n")
+                print(f"      Status:        ⚪ OVERRIDDEN by '{active_override}'\n")
             else:
                 print(f"  [{idx}] Label: '{ev.rule.name}'")
                 print(f"      Required SMEs: {req_smes}")
@@ -540,12 +570,12 @@ def main() -> int:
             pr_author,
             passed,
             overridden=overridden,
-            override_label=args.override_label,
+            override_label=active_override or (override_labels[0] if override_labels else DEFAULT_OVERRIDE_LABEL),
         )
         write_step_summary(gh_summary, summary_md)
 
     if overridden:
-        print(f"⚠️ BYPASSED: SME review check overridden by '{args.override_label}'.\n")
+        print(f"⚠️ BYPASSED: SME review check overridden by '{active_override}'.\n")
         return 0
 
     if passed:

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -41,9 +41,8 @@ DEFAULT_CONFIG_PATH = ".github/label_reviewers.yaml"
 
 @dataclass
 class LabelRule:
-    display_name: str
-    smes: set[str]
-    display_smes: list[str]
+    name: str
+    smes: list[str]
 
 
 @dataclass
@@ -104,37 +103,38 @@ def parse_label_config(config_path: str) -> dict[str, LabelRule]:
     for label_raw, val in content.items():
         if not isinstance(label_raw, str):
             continue
-        label_display = label_raw.strip()
-        label_key = label_display.lower()
+        label_name = label_raw.strip()
+        label_key = label_name.lower()
 
         if not isinstance(val, list):
             raise ValueError(
-                f"Invalid format for label '{label_display}' in {config_path}: "
+                f"Invalid format for label '{label_name}' in {config_path}: "
                 f"expected a list of usernames, got {type(val).__name__}."
             )
 
-        sme_normalized: set[str] = set()
-        sme_display: list[str] = []
+        smes: list[str] = []
         for u in val:
-            if isinstance(u, str) and u.strip():
-                clean_name = u.strip().lstrip("@")
-                sme_normalized.add(clean_name.lower())
-                sme_display.append(clean_name)
-            else:
+            if not isinstance(u, str) or not u.strip():
                 raise ValueError(
-                    f"Invalid reviewer entry under label '{label_display}' in {config_path}: "
+                    f"Invalid reviewer entry under label '{label_name}' in {config_path}: "
                     f"expected a username string, got {u!r}."
                 )
+            clean_name = u.strip()
+            if clean_name.startswith("@"):
+                raise ValueError(
+                    f"Invalid reviewer '{clean_name}' under label '{label_name}' in {config_path}: "
+                    f"do not include '@' in usernames."
+                )
+            smes.append(clean_name)
 
-        if not sme_normalized:
+        if not smes:
             raise ValueError(
-                f"Label '{label_display}' in {config_path} must have at least one reviewer listed."
+                f"Label '{label_name}' in {config_path} must have at least one reviewer listed."
             )
 
         mapping[label_key] = LabelRule(
-            display_name=label_display,
-            smes=sme_normalized,
-            display_smes=sme_display,
+            name=label_name,
+            smes=smes,
         )
 
     return mapping
@@ -151,7 +151,7 @@ def evaluate_pr_labels(
 
     for key, rule in config_mapping.items():
         if key in pr_label_keys:
-            matching_approvers = sorted(rule.smes.intersection(approvers))
+            matching_approvers = [u for u in rule.smes if u.lower() in approvers]
             evaluations.append(
                 LabelEvaluation(
                     rule=rule,
@@ -187,8 +187,8 @@ def generate_step_summary(
     md.append("| :--- | :---: | :--- | :--- |")
 
     for ev in evaluations:
-        label_code = f"`{ev.rule.display_name}`"
-        req_smes = ", ".join([f"@{u}" for u in ev.rule.display_smes])
+        label_code = f"`{ev.rule.name}`"
+        req_smes = ", ".join([f"@{u}" for u in ev.rule.smes])
         if ev.satisfied:
             status_icon = "✅ Approved"
             approvers_str = ", ".join([f"@{u}" for u in ev.approvers])
@@ -249,29 +249,29 @@ def sync_labels_to_github(repo: str, config_mapping: dict[str, LabelRule]) -> li
     for key, rule in config_mapping.items():
         if key not in existing_labels:
             logging.info(
-                f"Label '{rule.display_name}' does not exist on {repo}. Creating..."
+                f"Label '{rule.name}' does not exist on {repo}. Creating..."
             )
             create_cmd = [
                 "gh",
                 "label",
                 "create",
-                rule.display_name,
+                rule.name,
                 "--repo",
                 repo,
                 "--description",
-                f"Requires SME review: {rule.display_name}",
+                f"Requires SME review: {rule.name}",
                 "--color",
                 "ededed",
             ]
             try:
                 subprocess.run(create_cmd, capture_output=True, text=True, check=True)
-                created.append(rule.display_name)
+                created.append(rule.name)
                 logging.info(
-                    f"✅ Successfully created label '{rule.display_name}' on GitHub."
+                    f"✅ Successfully created label '{rule.name}' on GitHub."
                 )
             except subprocess.CalledProcessError as e:
                 logging.warning(
-                    f"Could not create label '{rule.display_name}': {e.stderr.strip()}"
+                    f"Could not create label '{rule.name}': {e.stderr.strip()}"
                 )
 
     return created
@@ -329,7 +329,7 @@ def main() -> int:
 
     logging.info(f"Configured labels with SME reviewers ({len(config_mapping)}):")
     for key, rule in config_mapping.items():
-        logging.debug(f"  - '{rule.display_name}': {sorted(rule.smes)}")
+        logging.debug(f"  - '{rule.name}': {rule.smes}")
 
     if args.validate_config:
         print(
@@ -390,15 +390,15 @@ def main() -> int:
         print(f"Found {len(evaluations)} monitored SME label(s) on this PR:\n")
         all_passed = True
         for idx, ev in enumerate(evaluations, 1):
-            req_smes = ", ".join([f"@{u}" for u in ev.rule.display_smes])
+            req_smes = ", ".join([f"@{u}" for u in ev.rule.smes])
             if ev.satisfied:
                 approver_mentions = ", ".join([f"@{u}" for u in ev.approvers])
-                print(f"  [{idx}] Label: '{ev.rule.display_name}'")
+                print(f"  [{idx}] Label: '{ev.rule.name}'")
                 print(f"      Required SMEs: {req_smes}")
                 print(f"      Status:        ✅ APPROVED by {approver_mentions}\n")
             else:
                 all_passed = False
-                print(f"  [{idx}] Label: '{ev.rule.display_name}'")
+                print(f"  [{idx}] Label: '{ev.rule.name}'")
                 print(f"      Required SMEs: {req_smes}")
                 print("      Status:        ❌ MISSING APPROVAL")
                 print(
@@ -410,9 +410,9 @@ def main() -> int:
     gh_output = os.environ.get("GITHUB_OUTPUT")
     if gh_output:
         missing_labels = [
-            ev.rule.display_name for ev in evaluations if not ev.satisfied
+            ev.rule.name for ev in evaluations if not ev.satisfied
         ]
-        approved_labels = [ev.rule.display_name for ev in evaluations if ev.satisfied]
+        approved_labels = [ev.rule.name for ev in evaluations if ev.satisfied]
         write_github_outputs(
             gh_output,
             {

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -17,7 +17,7 @@
 
 """SME (Subject Matter Expert) Label Reviewer Checker for Pull Requests.
 
-Verifies that if a designated label is attached to a pull request, at least one
+Verifies that for each designated label attached to a pull request, at least one
 designated SME username from the corresponding configuration has approved the PR.
 Can be executed manually or as part of a GitHub Actions workflow.
 """

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -91,8 +91,11 @@ def parse_label_config(config_path: str) -> dict[str, LabelRule]:
     if not os.path.exists(config_path):
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
-    with open(config_path, encoding="utf-8") as f:
-        content = yaml.safe_load(f) or {}
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            content = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        raise ValueError(f"YAML syntax error in {config_path}: {e}") from e
 
     if not isinstance(content, dict):
         raise ValueError(
@@ -138,6 +141,18 @@ def parse_label_config(config_path: str) -> dict[str, LabelRule]:
         )
 
     return mapping
+
+
+def extract_approvers(pr_data: dict[str, Any]) -> set[str]:
+    """Extracts lowercase usernames of approved reviewers from PR JSON data, excluding the author."""
+    pr_author = pr_data.get("author", {}).get("login", "")
+    author_lower = pr_author.lower() if pr_author else ""
+    return {
+        r.get("author", {}).get("login", "").lower()
+        for r in pr_data.get("latestReviews", [])
+        if r.get("state") == "APPROVED"
+        and r.get("author", {}).get("login", "").lower() != author_lower
+    }
 
 
 def evaluate_pr_labels(
@@ -370,14 +385,7 @@ def main() -> int:
     print("=" * 72)
     print(f"Active PR labels: {pr_labels}\n")
 
-    # Author cannot approve their own PR
-    author_lower = pr_author.lower()
-    approvers = {
-        r.get("author", {}).get("login", "").lower()
-        for r in pr_data.get("latestReviews", [])
-        if r.get("state") == "APPROVED"
-        and r.get("author", {}).get("login", "").lower() != author_lower
-    }
+    approvers = extract_approvers(pr_data)
     logging.info(f"Active approved reviews from: {sorted(approvers) or 'None'}")
 
     evaluations = evaluate_pr_labels(pr_labels, config_mapping, approvers)

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -37,6 +37,7 @@ import yaml
 
 DEFAULT_REPO = "project-chip/connectedhomeip"
 DEFAULT_CONFIG_PATH = ".github/label_reviewers.yaml"
+DEFAULT_OVERRIDE_LABEL = "no-sme-check-required"
 
 
 @dataclass
@@ -177,9 +178,21 @@ def evaluate_pr_labels(
     return evaluations
 
 
-def is_sme_review_satisfied(evaluations: list[LabelEvaluation]) -> bool:
-    """Returns True if no monitored labels are present, or if ANY label has at least one SME approval."""
-    if not evaluations:
+def check_override_present(
+    pr_labels: list[str],
+    override_label: str = DEFAULT_OVERRIDE_LABEL,
+) -> bool:
+    """Checks if the override label is attached to the PR (case-insensitive)."""
+    target = override_label.strip().lower()
+    return any(l.strip().lower() == target for l in pr_labels if l and l.strip())
+
+
+def is_sme_review_satisfied(
+    evaluations: list[LabelEvaluation],
+    overridden: bool = False,
+) -> bool:
+    """Returns True if overridden, no monitored labels are present, or ANY label has at least one SME approval."""
+    if overridden or not evaluations:
         return True
     return any(ev.satisfied for ev in evaluations)
 
@@ -190,6 +203,8 @@ def generate_step_summary(
     pr_title: str,
     pr_author: str,
     passed: bool,
+    overridden: bool = False,
+    override_label: str = DEFAULT_OVERRIDE_LABEL,
 ) -> str:
     """Builds a GitHub Actions Markdown Step Summary."""
     md = []
@@ -197,11 +212,17 @@ def generate_step_summary(
     md.append(f"**Title**: {pr_title}  ")
     md.append(f"**Author**: @{pr_author}  \n")
 
-    if not evaluations:
+    if overridden:
         md.append(
-            "> ℹ️ **No monitored SME review labels attached.**  \n"
-            "> This PR does not currently require specialized subject matter expert sign-off."
+            f"> ⚠️ **SME Review Requirement Bypassed**: Override label `{override_label}` is attached to this PR.\n"
         )
+
+    if not evaluations:
+        if not overridden:
+            md.append(
+                "> ℹ️ **No monitored SME review labels attached.**  \n"
+                "> This PR does not currently require specialized subject matter expert sign-off."
+            )
         return "\n".join(md)
 
     md.append("| Label | Status | Required SMEs | Approved By |")
@@ -213,13 +234,21 @@ def generate_step_summary(
         if ev.satisfied:
             status_icon = "✅ Approved"
             approvers_str = ", ".join([f"@{u}" for u in ev.approvers])
+        elif overridden:
+            status_icon = f"⚪ Overridden (`{override_label}`)"
+            approvers_str = "*None*"
         else:
             status_icon = "⚪ Satisfied (by other label)" if passed else "❌ Missing"
             approvers_str = "*None*"
         md.append(f"| {label_code} | {status_icon} | {req_smes} | {approvers_str} |")
 
     md.append("")
-    if passed:
+    if overridden:
+        md.append(
+            "> ⚠️ **SME Review Requirement Bypassed via Override Label.**  \n"
+            f"> The `{override_label}` label was applied to skip SME sign-off."
+        )
+    elif passed:
         all_matching_approvers = sorted({f"@{u}" for ev in evaluations for u in ev.approvers})
         if all_matching_approvers:
             md.append(
@@ -260,8 +289,12 @@ def write_step_summary(summary_path: str, summary_markdown: str) -> None:
         logging.warning(f"Failed writing to GITHUB_STEP_SUMMARY: {e}")
 
 
-def sync_labels_to_github(repo: str, config_mapping: dict[str, LabelRule]) -> list[str]:
-    """Ensures all configured labels exist in the GitHub repository using gh CLI."""
+def sync_labels_to_github(
+    repo: str,
+    config_mapping: dict[str, LabelRule],
+    override_label: str = DEFAULT_OVERRIDE_LABEL,
+) -> list[str]:
+    """Ensures all configured labels and the override label exist in the GitHub repository using gh CLI."""
     cmd = ["gh", "label", "list", "--repo", repo, "--limit", "1000", "--json", "name"]
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
@@ -274,6 +307,34 @@ def sync_labels_to_github(repo: str, config_mapping: dict[str, LabelRule]) -> li
         existing_labels = set()
 
     created: list[str] = []
+
+    if override_label and override_label.strip().lower() not in existing_labels:
+        logging.info(
+            f"Override label '{override_label}' does not exist on {repo}. Creating..."
+        )
+        create_cmd = [
+            "gh",
+            "label",
+            "create",
+            override_label,
+            "--repo",
+            repo,
+            "--description",
+            "Override to bypass required SME reviews",
+            "--color",
+            "fbca04",
+        ]
+        try:
+            subprocess.run(create_cmd, capture_output=True, text=True, check=True)
+            created.append(override_label)
+            logging.info(
+                f"✅ Successfully created override label '{override_label}' on GitHub."
+            )
+        except subprocess.CalledProcessError as e:
+            logging.warning(
+                f"Could not create override label '{override_label}': {e.stderr.strip()}"
+            )
+
     for key, rule in config_mapping.items():
         if key not in existing_labels:
             logging.info(
@@ -335,6 +396,11 @@ def main() -> int:
         help="Validate the syntax and format of the configuration file and exit.",
     )
     parser.add_argument(
+        "--override-label",
+        default=DEFAULT_OVERRIDE_LABEL,
+        help=f"Label name that bypasses SME review checks (default: {DEFAULT_OVERRIDE_LABEL})",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -367,7 +433,7 @@ def main() -> int:
 
     if args.sync_labels:
         logging.info(f"Syncing labels from {args.config} to repository {args.repo}...")
-        created = sync_labels_to_github(args.repo, config_mapping)
+        created = sync_labels_to_github(args.repo, config_mapping, args.override_label)
         if created:
             print(f"Created {len(created)} new label(s) on GitHub: {', '.join(created)}")
         else:
@@ -401,6 +467,11 @@ def main() -> int:
     approvers = extract_approvers(pr_data)
     logging.info(f"Active approved reviews from: {sorted(approvers) or 'None'}")
 
+    overridden = check_override_present(pr_labels, args.override_label)
+    if overridden:
+        print(f"⚠️  Override label '{args.override_label}' is present on this PR.")
+        print("   SME review check is bypassed.\n" + "=" * 72)
+
     evaluations = evaluate_pr_labels(pr_labels, config_mapping, approvers)
 
     if not evaluations:
@@ -409,7 +480,7 @@ def main() -> int:
         passed = True
     else:
         print(f"Found {len(evaluations)} monitored SME label(s) on this PR:\n")
-        passed = is_sme_review_satisfied(evaluations)
+        passed = is_sme_review_satisfied(evaluations, overridden=overridden)
         all_matching_approvers = sorted({u for ev in evaluations for u in ev.approvers})
 
         for idx, ev in enumerate(evaluations, 1):
@@ -419,6 +490,10 @@ def main() -> int:
                 print(f"  [{idx}] Label: '{ev.rule.name}'")
                 print(f"      Required SMEs: {req_smes}")
                 print(f"      Status:        ✅ APPROVED by {approver_mentions}\n")
+            elif overridden:
+                print(f"  [{idx}] Label: '{ev.rule.name}'")
+                print(f"      Required SMEs: {req_smes}")
+                print(f"      Status:        ⚪ OVERRIDDEN by '{args.override_label}'\n")
             else:
                 print(f"  [{idx}] Label: '{ev.rule.name}'")
                 print(f"      Required SMEs: {req_smes}")
@@ -447,6 +522,7 @@ def main() -> int:
             gh_output,
             {
                 "passed": "true" if passed else "false",
+                "overridden": "true" if overridden else "false",
                 "total_monitored_labels": str(len(evaluations)),
                 "missing_count": "0" if passed else str(len(missing_labels)),
                 "approved_labels": ",".join(approved_labels),
@@ -458,9 +534,19 @@ def main() -> int:
     gh_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if gh_summary:
         summary_md = generate_step_summary(
-            evaluations, pr_number, pr_title, pr_author, passed
+            evaluations,
+            pr_number,
+            pr_title,
+            pr_author,
+            passed,
+            overridden=overridden,
+            override_label=args.override_label,
         )
         write_step_summary(gh_summary, summary_md)
+
+    if overridden:
+        print(f"⚠️ BYPASSED: SME review check overridden by '{args.override_label}'.\n")
+        return 0
 
     if passed:
         print("✅ SUCCESS: SME review requirement has been satisfied.\n")

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""SME (Subject Matter Expert) Label Reviewer Checker for Pull Requests.
+
+Verifies that if a designated label is attached to a pull request, at least one
+designated SME username from the corresponding configuration has approved the PR.
+Can be executed manually or as part of a GitHub Actions workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+DEFAULT_REPO = "project-chip/connectedhomeip"
+DEFAULT_CONFIG_PATH = ".github/label_reviewers.yaml"
+
+
+@dataclass
+class LabelRule:
+    display_name: str
+    smes: set[str]
+    display_smes: list[str]
+
+
+@dataclass
+class LabelEvaluation:
+    rule: LabelRule
+    present_on_pr: bool
+    approvers: list[str] = field(default_factory=list)
+
+    @property
+    def satisfied(self) -> bool:
+        return not self.present_on_pr or len(self.approvers) > 0
+
+
+class GitHubApiClient:
+    """Lightweight GitHub REST API client using standard library urllib."""
+
+    def __init__(self, token: str | None = None) -> None:
+        self.token = token
+
+    def request(self, url: str) -> Any:
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "chip-label-reviewer-action",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                content = resp.read().decode("utf-8")
+                return json.loads(content)
+        except urllib.error.HTTPError as e:
+            err_msg = e.read().decode("utf-8", errors="replace")
+            if e.code == 404:
+                raise RuntimeError(f"Resource not found at {url}") from e
+            if e.code in (401, 403):
+                raise RuntimeError(
+                    f"GitHub API authorization/rate limit error (HTTP {e.code}): {err_msg}"
+                ) from e
+            raise RuntimeError(
+                f"GitHub API request failed (HTTP {e.code}) for {url}: {err_msg}"
+            ) from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"Failed to reach GitHub API: {e.reason}") from e
+
+    def get_pull_request(self, repo: str, pr_number: int) -> dict[str, Any]:
+        url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
+        return self.request(url)
+
+    def get_pull_request_reviews(
+        self, repo: str, pr_number: int
+    ) -> list[dict[str, Any]]:
+        reviews = []
+        page = 1
+        while True:
+            url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews?per_page=100&page={page}"
+            data = self.request(url)
+            if not isinstance(data, list) or not data:
+                break
+            reviews.extend(data)
+            if len(data) < 100:
+                break
+            page += 1
+        return reviews
+
+    def post(self, url: str, data: dict[str, Any]) -> Any:
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "chip-label-reviewer-action",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        body = json.dumps(data).encode("utf-8")
+        req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                content = resp.read().decode("utf-8")
+                return json.loads(content)
+        except urllib.error.HTTPError as e:
+            err_msg = e.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"GitHub API POST failed (HTTP {e.code}): {err_msg}") from e
+
+
+def parse_label_config(config_path: str) -> dict[str, LabelRule]:
+    """Parses the YAML configuration file mapping labels to SME reviewers.
+
+    Expected format is strictly a mapping of label names to lists of usernames:
+      label_name:
+        - username1
+        - username2
+    """
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    with open(config_path, encoding="utf-8") as f:
+        content = yaml.safe_load(f) or {}
+
+    if not isinstance(content, dict):
+        raise ValueError(
+            f"Invalid format in {config_path}: expected a YAML mapping of label names to reviewer lists."
+        )
+
+    mapping: dict[str, LabelRule] = {}
+    for label_raw, val in content.items():
+        if not isinstance(label_raw, str):
+            continue
+        label_display = label_raw.strip()
+        label_key = label_display.lower()
+
+        if not isinstance(val, list):
+            raise ValueError(
+                f"Invalid format for label '{label_display}' in {config_path}: "
+                f"expected a list of usernames, got {type(val).__name__}."
+            )
+
+        sme_normalized: set[str] = set()
+        sme_display: list[str] = []
+        for u in val:
+            if isinstance(u, str) and u.strip():
+                clean_name = u.strip().lstrip("@")
+                sme_normalized.add(clean_name.lower())
+                sme_display.append(clean_name)
+            else:
+                raise ValueError(
+                    f"Invalid reviewer entry under label '{label_display}' in {config_path}: "
+                    f"expected a username string, got {u!r}."
+                )
+
+        if not sme_normalized:
+            raise ValueError(
+                f"Label '{label_display}' in {config_path} must have at least one reviewer listed."
+            )
+
+        mapping[label_key] = LabelRule(
+            display_name=label_display,
+            smes=sme_normalized,
+            display_smes=sme_display,
+        )
+
+    return mapping
+
+
+def compute_effective_approvers(
+    reviews: list[dict[str, Any]], author: str
+) -> set[str]:
+    """Computes currently approving users from chronological PR reviews.
+
+    Respects state transitions: APPROVED -> CHANGES_REQUESTED -> APPROVED.
+    PR author cannot approve their own pull request.
+    """
+    approvers: set[str] = set()
+    change_requesters: set[str] = set()
+    author_lower = author.lower() if author else ""
+
+    for review in reviews:
+        user_info = review.get("user")
+        if not user_info or not user_info.get("login"):
+            continue
+        user = user_info["login"].lower()
+        state = review.get("state")
+
+        if state == "APPROVED":
+            approvers.add(user)
+            change_requesters.discard(user)
+        elif state == "CHANGES_REQUESTED":
+            change_requesters.add(user)
+            approvers.discard(user)
+        elif state == "DISMISSED":
+            approvers.discard(user)
+            change_requesters.discard(user)
+
+    # Discard author from approvers
+    approvers.discard(author_lower)
+    return approvers
+
+
+def evaluate_pr_labels(
+    pr_labels: list[str],
+    config_mapping: dict[str, LabelRule],
+    approvers: set[str],
+) -> list[LabelEvaluation]:
+    """Evaluates each matching label attached to the PR against active approvers."""
+    pr_label_keys = {l.strip().lower() for l in pr_labels if l and l.strip()}
+    evaluations: list[LabelEvaluation] = []
+
+    for key, rule in config_mapping.items():
+        if key in pr_label_keys:
+            matching_approvers = sorted(rule.smes.intersection(approvers))
+            evaluations.append(
+                LabelEvaluation(
+                    rule=rule,
+                    present_on_pr=True,
+                    approvers=matching_approvers,
+                )
+            )
+
+    return evaluations
+
+
+def extract_pr_number_from_environment() -> int | None:
+    """Tries to extract PR number from environment or GitHub event payload."""
+    env_pr = os.environ.get("PR_NUMBER")
+    if env_pr and env_pr.isdigit():
+        return int(env_pr)
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path and os.path.exists(event_path):
+        try:
+            with open(event_path, encoding="utf-8") as f:
+                event_data = json.load(f)
+            # From pull_request or pull_request_target event
+            if "pull_request" in event_data and "number" in event_data["pull_request"]:
+                return int(event_data["pull_request"]["number"])
+            # From issue_comment event on a pull request
+            if (
+                "issue" in event_data
+                and "pull_request" in event_data["issue"]
+                and "number" in event_data["issue"]
+            ):
+                return int(event_data["issue"]["number"])
+            # From workflow_dispatch inputs
+            if (
+                "inputs" in event_data
+                and "pr_number" in event_data["inputs"]
+                and str(event_data["inputs"]["pr_number"]).isdigit()
+            ):
+                return int(event_data["inputs"]["pr_number"])
+        except Exception as e:
+            logging.debug(f"Could not parse GITHUB_EVENT_PATH: {e}")
+
+    return None
+
+
+def generate_step_summary(
+    evaluations: list[LabelEvaluation],
+    pr_number: int,
+    pr_title: str,
+    pr_author: str,
+    all_passed: bool,
+) -> str:
+    """Builds a GitHub Actions Markdown Step Summary."""
+    md = []
+    md.append(f"## 🏷️ SME Label Review Check for PR #{pr_number}\n")
+    md.append(f"**Title**: {pr_title}  ")
+    md.append(f"**Author**: @{pr_author}  \n")
+
+    if not evaluations:
+        md.append(
+            "> ℹ️ **No monitored SME review labels attached.**  \n"
+            "> This PR does not currently require specialized subject matter expert sign-off."
+        )
+        return "\n".join(md)
+
+    md.append("| Label | Status | Required SMEs | Approved By |")
+    md.append("| :--- | :---: | :--- | :--- |")
+
+    for ev in evaluations:
+        label_code = f"`{ev.rule.display_name}`"
+        req_smes = ", ".join([f"@{u}" for u in ev.rule.display_smes])
+        if ev.satisfied:
+            status_icon = "✅ Approved"
+            approvers_str = ", ".join([f"@{u}" for u in ev.approvers])
+        else:
+            status_icon = "❌ Missing"
+            approvers_str = "*None*"
+        md.append(f"| {label_code} | {status_icon} | {req_smes} | {approvers_str} |")
+
+    md.append("")
+    if all_passed:
+        md.append(
+            "> ✅ **All SME Review Requirements Met!**  \n"
+            "> At least one designated reviewer from each required label has approved this PR."
+        )
+    else:
+        missing_count = sum(1 for ev in evaluations if not ev.satisfied)
+        md.append(
+            f"> ❌ **Review Required**: {missing_count} label(s) are missing required SME approval.  \n"
+            "> Please request review from at least one of the listed subject matter experts."
+        )
+
+    return "\n".join(md)
+
+
+def write_github_outputs(output_path: str, outputs: dict[str, str]) -> None:
+    """Writes key-value outputs to $GITHUB_OUTPUT file."""
+    try:
+        with open(output_path, "a", encoding="utf-8") as f:
+            for k, v in outputs.items():
+                f.write(f"{k}={v}\n")
+    except OSError as e:
+        logging.warning(f"Failed writing to GITHUB_OUTPUT: {e}")
+
+
+def write_step_summary(summary_path: str, summary_markdown: str) -> None:
+    """Appends markdown content to $GITHUB_STEP_SUMMARY file."""
+    try:
+        with open(summary_path, "a", encoding="utf-8") as f:
+            f.write(summary_markdown + "\n")
+    except OSError as e:
+        logging.warning(f"Failed writing to GITHUB_STEP_SUMMARY: {e}")
+
+
+def sync_labels_to_github(
+    repo: str, config_mapping: dict[str, LabelRule], client: GitHubApiClient
+) -> list[str]:
+    """Ensures all configured labels exist in the GitHub repository.
+
+    Fetches existing labels and creates any missing ones via POST /repos/:owner/:repo/labels.
+    """
+    existing_labels = set()
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{repo}/labels?per_page=100&page={page}"
+        data = client.request(url)
+        if not isinstance(data, list) or not data:
+            break
+        for item in data:
+            if isinstance(item, dict) and "name" in item:
+                existing_labels.add(item["name"].strip().lower())
+        if len(data) < 100:
+            break
+        page += 1
+
+    created: list[str] = []
+    for key, rule in config_mapping.items():
+        if key not in existing_labels:
+            logging.info(
+                f"Label '{rule.display_name}' does not exist on {repo}. Creating..."
+            )
+            url = f"https://api.github.com/repos/{repo}/labels"
+            payload = {
+                "name": rule.display_name,
+                "description": f"Requires SME review: {rule.display_name}",
+                "color": "ededed",
+            }
+            try:
+                client.post(url, payload)
+                created.append(rule.display_name)
+                logging.info(
+                    f"✅ Successfully created label '{rule.display_name}' on GitHub."
+                )
+            except Exception as e:
+                logging.warning(f"Could not create label '{rule.display_name}': {e}")
+
+    return created
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify that PRs with designated labels are approved by designated SME reviewers."
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        help="Pull request number (auto-detected if omitted in GitHub Actions)",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"GitHub repository in owner/repo format (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Path to the YAML label reviewers file (default: {DEFAULT_CONFIG_PATH})",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"),
+        help="GitHub API token (reads GITHUB_TOKEN or GH_TOKEN env if not specified)",
+    )
+    parser.add_argument(
+        "--sync-labels",
+        action="store_true",
+        help="Ensure all configured labels exist on GitHub, creating any that are missing.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Evaluate and report status, but always exit with code 0",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper()),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    logging.info(f"Loading configuration from {args.config}...")
+    try:
+        config_mapping = parse_label_config(args.config)
+    except Exception as e:
+        logging.error(f"Failed to load config: {e}")
+        return 2
+
+    logging.info(f"Configured labels with SME reviewers ({len(config_mapping)}):")
+    for key, rule in config_mapping.items():
+        logging.debug(f"  - '{rule.display_name}': {sorted(rule.smes)}")
+
+    client = GitHubApiClient(token=args.token)
+
+    if args.sync_labels:
+        logging.info(f"Syncing labels from {args.config} to repository {args.repo}...")
+        created = sync_labels_to_github(args.repo, config_mapping, client)
+        if created:
+            print(f"Created {len(created)} new label(s) on GitHub: {', '.join(created)}")
+        else:
+            print("All configured labels already exist on GitHub.")
+        if not args.pr and not extract_pr_number_from_environment():
+            return 0
+
+    pr_number = args.pr or extract_pr_number_from_environment()
+    if not pr_number:
+        logging.error(
+            "PR number not provided. Pass --pr <number> or run within a GitHub Action PR context."
+        )
+        return 2
+    logging.info(f"Fetching PR #{pr_number} from {args.repo}...")
+    try:
+        pr_data = client.get_pull_request(args.repo, pr_number)
+    except Exception as e:
+        logging.error(f"Failed to fetch PR #{pr_number}: {e}")
+        return 2
+
+    pr_title = pr_data.get("title", "")
+    pr_author = pr_data.get("user", {}).get("login", "")
+    pr_state = pr_data.get("state", "")
+    pr_labels = [l.get("name", "") for l in pr_data.get("labels", [])]
+
+    print("\n" + "=" * 72)
+    print(f"SME Label Review Check for PR #{pr_number}: '{pr_title}'")
+    print(f"Repository: {args.repo} | Author: @{pr_author} | State: {pr_state}")
+    print("=" * 72)
+    print(f"Active PR labels: {pr_labels}\n")
+
+    logging.info(f"Fetching reviews for PR #{pr_number}...")
+    try:
+        raw_reviews = client.get_pull_request_reviews(args.repo, pr_number)
+    except Exception as e:
+        logging.error(f"Failed to fetch reviews for PR #{pr_number}: {e}")
+        return 2
+
+    approvers = compute_effective_approvers(raw_reviews, author=pr_author)
+    logging.info(f"Active approved reviews from: {sorted(approvers) or 'None'}")
+
+    evaluations = evaluate_pr_labels(pr_labels, config_mapping, approvers)
+
+    if not evaluations:
+        print("ℹ️  No designated SME review labels attached to this PR.")
+        print("   Check passed automatically.\n" + "=" * 72)
+        all_passed = True
+    else:
+        print(f"Found {len(evaluations)} monitored SME label(s) on this PR:\n")
+        all_passed = True
+        for idx, ev in enumerate(evaluations, 1):
+            req_smes = ", ".join([f"@{u}" for u in ev.rule.display_smes])
+            if ev.satisfied:
+                approver_mentions = ", ".join([f"@{u}" for u in ev.approvers])
+                print(f"  [{idx}] Label: '{ev.rule.display_name}'")
+                print(f"      Required SMEs: {req_smes}")
+                print(f"      Status:        ✅ APPROVED by {approver_mentions}\n")
+            else:
+                all_passed = False
+                print(f"  [{idx}] Label: '{ev.rule.display_name}'")
+                print(f"      Required SMEs: {req_smes}")
+                print("      Status:        ❌ MISSING APPROVAL")
+                print(
+                    f"      Action:        Requires at least one approval from: {req_smes}\n"
+                )
+        print("=" * 72)
+
+    # Output parameters for GitHub Actions
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        missing_labels = [
+            ev.rule.display_name for ev in evaluations if not ev.satisfied
+        ]
+        approved_labels = [ev.rule.display_name for ev in evaluations if ev.satisfied]
+        write_github_outputs(
+            gh_output,
+            {
+                "passed": "true" if all_passed else "false",
+                "total_monitored_labels": str(len(evaluations)),
+                "missing_count": str(len(missing_labels)),
+                "approved_labels": ",".join(approved_labels),
+                "missing_labels": ",".join(missing_labels),
+            },
+        )
+
+    # Step summary for GitHub Actions
+    gh_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if gh_summary:
+        summary_md = generate_step_summary(
+            evaluations, pr_number, pr_title, pr_author, all_passed
+        )
+        write_step_summary(gh_summary, summary_md)
+
+    if all_passed:
+        print("✅ SUCCESS: All required SME reviews have been satisfied.\n")
+        return 0
+
+    if args.dry_run:
+        print("⚠️  DRY RUN: Missing SME approvals, but exiting 0 due to --dry-run.\n")
+        return 0
+
+    print("❌ FAILURE: Missing required SME review approval(s).\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -427,11 +427,6 @@ def main() -> int:
         help="Ensure all configured labels exist on GitHub, creating any that are missing.",
     )
     parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Evaluate and report status, but always exit with code 0",
-    )
-    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -556,10 +551,6 @@ def main() -> int:
 
     if all_passed:
         print("✅ SUCCESS: All required SME reviews have been satisfied.\n")
-        return 0
-
-    if args.dry_run:
-        print("⚠️  DRY RUN: Missing SME approvals, but exiting 0 due to --dry-run.\n")
         return 0
 
     print("❌ FAILURE: Missing required SME review approval(s).\n")

--- a/scripts/tools/check_label_reviewers.py
+++ b/scripts/tools/check_label_reviewers.py
@@ -61,7 +61,7 @@ class LabelEvaluation:
 class GitHubApiClient:
     """Lightweight GitHub REST API client using standard library urllib."""
 
-    def __init__(self, token: str | None = None) -> None:
+    def __init__(self, token: str) -> None:
         self.token = token
 
     def request(self, url: str) -> Any:
@@ -69,9 +69,8 @@ class GitHubApiClient:
             "Accept": "application/vnd.github+json",
             "User-Agent": "chip-label-reviewer-action",
             "X-GitHub-Api-Version": "2022-11-28",
+            "Authorization": f"Bearer {self.token}",
         }
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
 
         req = urllib.request.Request(url, headers=headers)
         try:
@@ -118,9 +117,8 @@ class GitHubApiClient:
             "User-Agent": "chip-label-reviewer-action",
             "X-GitHub-Api-Version": "2022-11-28",
             "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.token}",
         }
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
 
         body = json.dumps(data).encode("utf-8")
         req = urllib.request.Request(url, data=body, headers=headers, method="POST")
@@ -450,6 +448,12 @@ def main() -> int:
     logging.info(f"Configured labels with SME reviewers ({len(config_mapping)}):")
     for key, rule in config_mapping.items():
         logging.debug(f"  - '{rule.display_name}': {sorted(rule.smes)}")
+
+    if not args.token:
+        logging.error(
+            "GitHub API token is required. Set GITHUB_TOKEN environment variable or pass --token."
+        )
+        return 2
 
     client = GitHubApiClient(token=args.token)
 

--- a/scripts/tools/tests/test_check_label_reviewers.py
+++ b/scripts/tools/tests/test_check_label_reviewers.py
@@ -26,10 +26,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # isort: split
 
 # pylint: disable=wrong-import-position
-from check_label_reviewers import (DEFAULT_OVERRIDE_LABEL, DEFAULT_OVERRIDE_LABELS, LabelEvaluation,  # noqa: E402
-                                   LabelRule, check_override_present, evaluate_pr_labels, extract_approvers,
-                                   find_active_override, generate_step_summary, is_sme_review_satisfied,
-                                   parse_label_config)
+from check_label_reviewers import LabelEvaluation  # noqa: E402
+from check_label_reviewers import (LabelRule, check_override_present, evaluate_pr_labels, extract_approvers, find_active_override,
+                                   generate_step_summary, is_sme_review_satisfied, parse_label_config)
 
 
 class TestParseLabelConfig(unittest.TestCase):

--- a/scripts/tools/tests/test_check_label_reviewers.py
+++ b/scripts/tools/tests/test_check_label_reviewers.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 # pylint: disable=wrong-import-position
 from check_label_reviewers import (LabelEvaluation, LabelRule, evaluate_pr_labels, extract_approvers,  # noqa: E402
-                                   generate_step_summary, parse_label_config)
+                                   generate_step_summary, is_sme_review_satisfied, parse_label_config)
 
 
 class TestParseLabelConfig(unittest.TestCase):
@@ -256,16 +256,27 @@ class TestEvaluatePrLabels(unittest.TestCase):
 
         self.assertEqual(len(evaluations), 2)
         self.assertTrue(all(ev.satisfied for ev in evaluations))
+        self.assertTrue(is_sme_review_satisfied(evaluations))
 
-    def test_multi_label_partial_approval_fails(self) -> None:
+    def test_multi_label_one_approval_satisfies_overall_check(self) -> None:
         pr_labels = ["Security", "data-model"]
-        approvers = {"alice"}  # Security approved, data-model missing
+        approvers = {"alice"}  # Security approved, data-model unreviewed
         evaluations = evaluate_pr_labels(pr_labels, self.config, approvers)
 
         self.assertEqual(len(evaluations), 2)
         eval_dict = {ev.rule.name: ev.satisfied for ev in evaluations}
         self.assertTrue(eval_dict["Security"])
         self.assertFalse(eval_dict["Data-Model"])
+        # Overall check passes because at least one SME from ANY label approved
+        self.assertTrue(is_sme_review_satisfied(evaluations))
+
+    def test_multi_label_no_sme_approvals_fails_overall_check(self) -> None:
+        pr_labels = ["Security", "data-model"]
+        approvers = {"external_reviewer"}
+        evaluations = evaluate_pr_labels(pr_labels, self.config, approvers)
+
+        self.assertEqual(len(evaluations), 2)
+        self.assertFalse(is_sme_review_satisfied(evaluations))
 
     def test_case_insensitive_label_and_username_matching(self) -> None:
         pr_labels = ["sEcUrItY"]
@@ -291,7 +302,20 @@ class TestGenerateStepSummary(unittest.TestCase):
         summary = generate_step_summary(evals, 100, "Security patch", "author1", True)
 
         self.assertIn("| `Security` | ✅ Approved | @alice, @bob | @alice |", summary)
-        self.assertIn("All SME Review Requirements Met!", summary)
+        self.assertIn("SME Review Requirement Met!", summary)
+
+    def test_summary_multi_label_partially_approved(self) -> None:
+        rule1 = LabelRule(name="Security", smes=["alice"])
+        rule2 = LabelRule(name="Data-Model", smes=["bob"])
+        evals = [
+            LabelEvaluation(rule=rule1, present_on_pr=True, approvers=["alice"]),
+            LabelEvaluation(rule=rule2, present_on_pr=True, approvers=[]),
+        ]
+        summary = generate_step_summary(evals, 100, "Security patch", "author1", True)
+
+        self.assertIn("| `Security` | ✅ Approved | @alice | @alice |", summary)
+        self.assertIn("| `Data-Model` | ⚪ Satisfied (by other label) | @bob | *None* |", summary)
+        self.assertIn("SME Review Requirement Met!", summary)
 
     def test_summary_missing_approval_label(self) -> None:
         rule = LabelRule(name="Security", smes=["alice", "bob"])
@@ -305,7 +329,7 @@ class TestGenerateStepSummary(unittest.TestCase):
 class TestEndToEndJsonEvaluation(unittest.TestCase):
     """Tests end-to-end evaluation using simulated GitHub CLI JSON output."""
 
-    def test_full_evaluation_flow(self) -> None:
+    def test_full_evaluation_flow_with_one_matching_sme(self) -> None:
         # 1. Mock JSON output matching `gh pr view --json author,title,state,labels,latestReviews`
         mock_gh_json = {
             "title": "Add secure channel encryption",
@@ -340,13 +364,32 @@ class TestEndToEndJsonEvaluation(unittest.TestCase):
 
         # 5. Evaluate
         evaluations = evaluate_pr_labels(pr_labels, config, approvers)
-        all_passed = all(ev.satisfied for ev in evaluations)
+        # "security" is approved by sme_alice; under ANY-reviewer logic, check passes!
+        self.assertTrue(is_sme_review_satisfied(evaluations))
 
-        # "security" is approved by sme_alice; "core" is missing approval from lead_dev
-        self.assertFalse(all_passed)
-        eval_status = {ev.rule.name: ev.satisfied for ev in evaluations}
-        self.assertTrue(eval_status["security"])
-        self.assertFalse(eval_status["core"])
+    def test_full_evaluation_flow_missing_all_smes(self) -> None:
+        mock_gh_json = {
+            "title": "Add secure channel encryption",
+            "author": {"login": "contributor"},
+            "state": "OPEN",
+            "labels": [
+                {"name": "security"},
+                {"name": "core"},
+            ],
+            "latestReviews": [
+                {"author": {"login": "contributor"}, "state": "APPROVED"},  # self-approval
+                {"author": {"login": "peer_reviewer"}, "state": "APPROVED"},  # not an SME
+            ],
+        }
+        config = {
+            "security": LabelRule(name="security", smes=["sme_alice", "sme_bob"]),
+            "core": LabelRule(name="core", smes=["lead_dev"]),
+        }
+        approvers = extract_approvers(mock_gh_json)
+        pr_labels = [l["name"] for l in mock_gh_json.get("labels", [])]
+        evaluations = evaluate_pr_labels(pr_labels, config, approvers)
+
+        self.assertFalse(is_sme_review_satisfied(evaluations))
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_check_label_reviewers.py
+++ b/scripts/tools/tests/test_check_label_reviewers.py
@@ -26,7 +26,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # isort: split
 
 # pylint: disable=wrong-import-position
-from check_label_reviewers import (LabelEvaluation, LabelRule, evaluate_pr_labels, extract_approvers,  # noqa: E402
+from check_label_reviewers import (DEFAULT_OVERRIDE_LABEL, LabelEvaluation, LabelRule,  # noqa: E402
+                                   check_override_present, evaluate_pr_labels, extract_approvers,
                                    generate_step_summary, is_sme_review_satisfied, parse_label_config)
 
 
@@ -212,6 +213,34 @@ class TestExtractApprovers(unittest.TestCase):
         self.assertEqual(extract_approvers(empty_data), set())
 
 
+class TestCheckOverridePresent(unittest.TestCase):
+    """Tests checking for the presence of override labels."""
+
+    def test_default_override_label_exact_match(self) -> None:
+        pr_labels = ["bug", "no-sme-check-required", "security"]
+        self.assertTrue(check_override_present(pr_labels))
+
+    def test_override_label_case_insensitive(self) -> None:
+        pr_labels = ["No-SME-Check-Required"]
+        self.assertTrue(check_override_present(pr_labels))
+
+    def test_override_label_with_surrounding_whitespace(self) -> None:
+        pr_labels = ["  no-sme-check-required  "]
+        self.assertTrue(check_override_present(pr_labels))
+
+    def test_override_label_not_present(self) -> None:
+        pr_labels = ["bug", "security", "enhancement"]
+        self.assertFalse(check_override_present(pr_labels))
+
+    def test_override_label_empty_labels(self) -> None:
+        self.assertFalse(check_override_present([]))
+
+    def test_custom_override_label(self) -> None:
+        pr_labels = ["exempt-from-sme"]
+        self.assertTrue(check_override_present(pr_labels, override_label="exempt-from-sme"))
+        self.assertFalse(check_override_present(pr_labels, override_label="other-label"))
+
+
 class TestEvaluatePrLabels(unittest.TestCase):
     """Tests evaluating PR labels against configured rules and approvers."""
 
@@ -287,6 +316,15 @@ class TestEvaluatePrLabels(unittest.TestCase):
         self.assertTrue(evaluations[0].satisfied)
         self.assertEqual(evaluations[0].approvers, ["alice"])
 
+    def test_overridden_satisfies_check_even_without_approvals(self) -> None:
+        rule = LabelRule(name="Security", smes=["alice"])
+        ev = LabelEvaluation(rule=rule, present_on_pr=True, approvers=[])
+        self.assertFalse(is_sme_review_satisfied([ev]))
+        self.assertTrue(is_sme_review_satisfied([ev], overridden=True))
+
+    def test_overridden_satisfies_check_with_no_evaluations(self) -> None:
+        self.assertTrue(is_sme_review_satisfied([], overridden=True))
+
 
 class TestGenerateStepSummary(unittest.TestCase):
     """Tests generating GitHub Actions Markdown step summaries."""
@@ -324,6 +362,23 @@ class TestGenerateStepSummary(unittest.TestCase):
 
         self.assertIn("| `Security` | ❌ Missing | @alice, @bob | *None* |", summary)
         self.assertIn("Review Required", summary)
+
+    def test_summary_overridden_with_monitored_labels(self) -> None:
+        rule = LabelRule(name="Security", smes=["alice"])
+        evals = [LabelEvaluation(rule=rule, present_on_pr=True, approvers=[])]
+        summary = generate_step_summary(
+            evals, 100, "Security patch", "author1", True, overridden=True, override_label="no-sme-check-required"
+        )
+        self.assertIn("SME Review Requirement Bypassed", summary)
+        self.assertIn("no-sme-check-required", summary)
+        self.assertIn("| `Security` | ⚪ Overridden (`no-sme-check-required`) | @alice | *None* |", summary)
+
+    def test_summary_overridden_no_monitored_labels(self) -> None:
+        summary = generate_step_summary(
+            [], 100, "No labels PR", "author1", True, overridden=True, override_label="no-sme-check-required"
+        )
+        self.assertIn("SME Review Requirement Bypassed", summary)
+        self.assertIn("no-sme-check-required", summary)
 
 
 class TestEndToEndJsonEvaluation(unittest.TestCase):
@@ -390,6 +445,28 @@ class TestEndToEndJsonEvaluation(unittest.TestCase):
         evaluations = evaluate_pr_labels(pr_labels, config, approvers)
 
         self.assertFalse(is_sme_review_satisfied(evaluations))
+
+    def test_full_evaluation_flow_with_override_label(self) -> None:
+        mock_gh_json = {
+            "title": "Emergency hotfix for crypto issue",
+            "author": {"login": "contributor"},
+            "state": "OPEN",
+            "labels": [
+                {"name": "security"},
+                {"name": "no-sme-check-required"},
+            ],
+            "latestReviews": [],
+        }
+        config = {
+            "security": LabelRule(name="security", smes=["sme_alice", "sme_bob"]),
+        }
+        approvers = extract_approvers(mock_gh_json)
+        pr_labels = [l["name"] for l in mock_gh_json.get("labels", [])]
+        overridden = check_override_present(pr_labels)
+        self.assertTrue(overridden)
+
+        evaluations = evaluate_pr_labels(pr_labels, config, approvers)
+        self.assertTrue(is_sme_review_satisfied(evaluations, overridden=overridden))
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_check_label_reviewers.py
+++ b/scripts/tools/tests/test_check_label_reviewers.py
@@ -26,14 +26,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # isort: split
 
 # pylint: disable=wrong-import-position
-from check_label_reviewers import (  # noqa: E402
-    LabelEvaluation,
-    LabelRule,
-    evaluate_pr_labels,
-    extract_approvers,
-    generate_step_summary,
-    parse_label_config,
-)
+from check_label_reviewers import (LabelEvaluation, LabelRule, evaluate_pr_labels, extract_approvers,  # noqa: E402
+                                   generate_step_summary, parse_label_config)
 
 
 class TestParseLabelConfig(unittest.TestCase):

--- a/scripts/tools/tests/test_check_label_reviewers.py
+++ b/scripts/tools/tests/test_check_label_reviewers.py
@@ -78,6 +78,18 @@ Data-Model:
         self.assertEqual(mapping["data-model"].name, "Data-Model")
         self.assertEqual(mapping["data-model"].smes, ["bzbarsky-apple", "Boris-Virk"])
 
+    def test_valid_config_quoted_and_unquoted_usernames(self) -> None:
+        yaml_content = """
+security:
+  - alice
+  - 'bob'
+  - "charlie"
+"""
+        config_path = self._write_temp_config(yaml_content)
+        mapping = parse_label_config(config_path)
+
+        self.assertEqual(mapping["security"].smes, ["alice", "bob", "charlie"])
+
     def test_empty_config(self) -> None:
         yaml_content = "# Only comments in this file\n"
         config_path = self._write_temp_config(yaml_content)

--- a/scripts/tools/tests/test_check_label_reviewers.py
+++ b/scripts/tools/tests/test_check_label_reviewers.py
@@ -26,9 +26,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # isort: split
 
 # pylint: disable=wrong-import-position
-from check_label_reviewers import (DEFAULT_OVERRIDE_LABEL, LabelEvaluation, LabelRule,  # noqa: E402
-                                   check_override_present, evaluate_pr_labels, extract_approvers,
-                                   generate_step_summary, is_sme_review_satisfied, parse_label_config)
+from check_label_reviewers import (DEFAULT_OVERRIDE_LABEL, DEFAULT_OVERRIDE_LABELS, LabelEvaluation,  # noqa: E402
+                                   LabelRule, check_override_present, evaluate_pr_labels, extract_approvers,
+                                   find_active_override, generate_step_summary, is_sme_review_satisfied,
+                                   parse_label_config)
 
 
 class TestParseLabelConfig(unittest.TestCase):
@@ -220,13 +221,21 @@ class TestCheckOverridePresent(unittest.TestCase):
         pr_labels = ["bug", "no-sme-check-required", "security"]
         self.assertTrue(check_override_present(pr_labels))
 
+    def test_sdk_maintainer_approved_exact_match(self) -> None:
+        pr_labels = ["bug", "sdk-maintainer-approved", "security"]
+        self.assertTrue(check_override_present(pr_labels))
+
     def test_override_label_case_insensitive(self) -> None:
         pr_labels = ["No-SME-Check-Required"]
         self.assertTrue(check_override_present(pr_labels))
+        pr_labels_maintainer = ["SDK-Maintainer-Approved"]
+        self.assertTrue(check_override_present(pr_labels_maintainer))
 
     def test_override_label_with_surrounding_whitespace(self) -> None:
         pr_labels = ["  no-sme-check-required  "]
         self.assertTrue(check_override_present(pr_labels))
+        pr_labels_maintainer = ["  sdk-maintainer-approved  "]
+        self.assertTrue(check_override_present(pr_labels_maintainer))
 
     def test_override_label_not_present(self) -> None:
         pr_labels = ["bug", "security", "enhancement"]
@@ -237,8 +246,24 @@ class TestCheckOverridePresent(unittest.TestCase):
 
     def test_custom_override_label(self) -> None:
         pr_labels = ["exempt-from-sme"]
-        self.assertTrue(check_override_present(pr_labels, override_label="exempt-from-sme"))
-        self.assertFalse(check_override_present(pr_labels, override_label="other-label"))
+        self.assertTrue(check_override_present(pr_labels, override_labels="exempt-from-sme"))
+        self.assertTrue(check_override_present(pr_labels, override_labels=["exempt-from-sme", "other"]))
+        self.assertFalse(check_override_present(pr_labels, override_labels="other-label"))
+
+    def test_find_active_override(self) -> None:
+        self.assertIsNone(find_active_override(["bug", "feature"]))
+        self.assertEqual(
+            find_active_override(["bug", "sdk-maintainer-approved"]),
+            "sdk-maintainer-approved",
+        )
+        self.assertEqual(
+            find_active_override(["SDK-Maintainer-Approved"]),
+            "SDK-Maintainer-Approved",
+        )
+        self.assertEqual(
+            find_active_override(["no-sme-check-required", "sdk-maintainer-approved"]),
+            "no-sme-check-required",
+        )
 
 
 class TestEvaluatePrLabels(unittest.TestCase):
@@ -467,6 +492,28 @@ class TestEndToEndJsonEvaluation(unittest.TestCase):
 
         evaluations = evaluate_pr_labels(pr_labels, config, approvers)
         self.assertTrue(is_sme_review_satisfied(evaluations, overridden=overridden))
+
+    def test_full_evaluation_flow_with_sdk_maintainer_approved(self) -> None:
+        mock_gh_json = {
+            "title": "Core maintenance refactor approved by SDK maintainer",
+            "author": {"login": "contributor"},
+            "state": "OPEN",
+            "labels": [
+                {"name": "core"},
+                {"name": "sdk-maintainer-approved"},
+            ],
+            "latestReviews": [],
+        }
+        config = {
+            "core": LabelRule(name="core", smes=["lead_dev"]),
+        }
+        approvers = extract_approvers(mock_gh_json)
+        pr_labels = [l["name"] for l in mock_gh_json.get("labels", [])]
+        active_override = find_active_override(pr_labels)
+        self.assertEqual(active_override, "sdk-maintainer-approved")
+
+        evaluations = evaluate_pr_labels(pr_labels, config, approvers)
+        self.assertTrue(is_sme_review_satisfied(evaluations, overridden=bool(active_override)))
 
 
 if __name__ == "__main__":

--- a/scripts/tools/tests/test_check_label_reviewers.py
+++ b/scripts/tools/tests/test_check_label_reviewers.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+import tempfile
+import unittest
+
+# Ensure the parent directory is in the path so we can import check_label_reviewers
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# isort: split
+
+# pylint: disable=wrong-import-position
+from check_label_reviewers import (  # noqa: E402
+    LabelEvaluation,
+    LabelRule,
+    evaluate_pr_labels,
+    extract_approvers,
+    generate_step_summary,
+    parse_label_config,
+)
+
+
+class TestParseLabelConfig(unittest.TestCase):
+    """Tests parsing and validation of .github/label_reviewers.yaml."""
+
+    def _write_temp_config(self, content: str) -> str:
+        temp = tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".yaml", encoding="utf-8")
+        temp.write(content)
+        temp.close()
+        self.addCleanup(os.unlink, temp.name)
+        return temp.name
+
+    def test_valid_config_single_label(self) -> None:
+        yaml_content = """
+security:
+  - alice
+  - bob
+"""
+        config_path = self._write_temp_config(yaml_content)
+        mapping = parse_label_config(config_path)
+
+        self.assertIn("security", mapping)
+        self.assertEqual(mapping["security"].name, "security")
+        self.assertEqual(mapping["security"].smes, ["alice", "bob"])
+
+    def test_valid_config_multiple_labels(self) -> None:
+        yaml_content = """
+Security:
+  - alice
+Data-Model:
+  - bzbarsky-apple
+  - Boris-Virk
+"""
+        config_path = self._write_temp_config(yaml_content)
+        mapping = parse_label_config(config_path)
+
+        self.assertIn("security", mapping)
+        self.assertEqual(mapping["security"].name, "Security")
+        self.assertEqual(mapping["security"].smes, ["alice"])
+
+        self.assertIn("data-model", mapping)
+        self.assertEqual(mapping["data-model"].name, "Data-Model")
+        self.assertEqual(mapping["data-model"].smes, ["bzbarsky-apple", "Boris-Virk"])
+
+    def test_empty_config(self) -> None:
+        yaml_content = "# Only comments in this file\n"
+        config_path = self._write_temp_config(yaml_content)
+        mapping = parse_label_config(config_path)
+        self.assertEqual(mapping, {})
+
+    def test_missing_config_file(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            parse_label_config("/path/does/not/exist.yaml")
+
+    def test_invalid_yaml_structure_not_dict(self) -> None:
+        yaml_content = """
+- item1
+- item2
+"""
+        config_path = self._write_temp_config(yaml_content)
+        with self.assertRaises(ValueError) as ctx:
+            parse_label_config(config_path)
+        self.assertIn("expected a YAML mapping", str(ctx.exception))
+
+    def test_invalid_label_value_not_list(self) -> None:
+        yaml_content = """
+security: "alice"
+"""
+        config_path = self._write_temp_config(yaml_content)
+        with self.assertRaises(ValueError) as ctx:
+            parse_label_config(config_path)
+        self.assertIn("expected a list of usernames", str(ctx.exception))
+
+    def test_empty_reviewer_list(self) -> None:
+        yaml_content = """
+security: []
+"""
+        config_path = self._write_temp_config(yaml_content)
+        with self.assertRaises(ValueError) as ctx:
+            parse_label_config(config_path)
+        self.assertIn("must have at least one reviewer listed", str(ctx.exception))
+
+    def test_invalid_reviewer_entry_not_string(self) -> None:
+        yaml_content = """
+security:
+  - 12345
+"""
+        config_path = self._write_temp_config(yaml_content)
+        with self.assertRaises(ValueError) as ctx:
+            parse_label_config(config_path)
+        self.assertIn("expected a username string", str(ctx.exception))
+
+    def test_reviewer_with_leading_at_symbol_rejected(self) -> None:
+        yaml_content = """
+security:
+  - "@cecille"
+"""
+        config_path = self._write_temp_config(yaml_content)
+        with self.assertRaises(ValueError) as ctx:
+            parse_label_config(config_path)
+        self.assertIn("do not include '@' in usernames", str(ctx.exception))
+
+    def test_unquoted_at_symbol_raises_yaml_syntax_error(self) -> None:
+        yaml_content = """
+security:
+  - @cecille
+"""
+        config_path = self._write_temp_config(yaml_content)
+        with self.assertRaises(ValueError) as ctx:
+            parse_label_config(config_path)
+        self.assertIn("YAML syntax error", str(ctx.exception))
+
+
+class TestExtractApprovers(unittest.TestCase):
+    """Tests extracting valid approvers from GitHub PR JSON payloads."""
+
+    def test_extract_approved_reviews(self) -> None:
+        pr_data = {
+            "author": {"login": "author_user"},
+            "latestReviews": [
+                {"author": {"login": "alice"}, "state": "APPROVED"},
+                {"author": {"login": "bob"}, "state": "APPROVED"},
+            ],
+        }
+        approvers = extract_approvers(pr_data)
+        self.assertEqual(approvers, {"alice", "bob"})
+
+    def test_ignores_non_approved_review_states(self) -> None:
+        pr_data = {
+            "author": {"login": "author_user"},
+            "latestReviews": [
+                {"author": {"login": "alice"}, "state": "APPROVED"},
+                {"author": {"login": "charlie"}, "state": "CHANGES_REQUESTED"},
+                {"author": {"login": "david"}, "state": "COMMENTED"},
+                {"author": {"login": "eve"}, "state": "DISMISSED"},
+            ],
+        }
+        approvers = extract_approvers(pr_data)
+        self.assertEqual(approvers, {"alice"})
+
+    def test_excludes_author_self_approval(self) -> None:
+        pr_data = {
+            "author": {"login": "author_user"},
+            "latestReviews": [
+                {"author": {"login": "author_user"}, "state": "APPROVED"},
+                {"author": {"login": "reviewer1"}, "state": "APPROVED"},
+            ],
+        }
+        approvers = extract_approvers(pr_data)
+        self.assertNotIn("author_user", approvers)
+        self.assertEqual(approvers, {"reviewer1"})
+
+    def test_case_insensitive_logins(self) -> None:
+        pr_data = {
+            "author": {"login": "Author_User"},
+            "latestReviews": [
+                {"author": {"login": "AUTHOR_USER"}, "state": "APPROVED"},
+                {"author": {"login": "Alice-Expert"}, "state": "APPROVED"},
+            ],
+        }
+        approvers = extract_approvers(pr_data)
+        self.assertNotIn("author_user", approvers)
+        self.assertEqual(approvers, {"alice-expert"})
+
+    def test_empty_reviews_and_missing_author(self) -> None:
+        pr_data = {"latestReviews": []}
+        self.assertEqual(extract_approvers(pr_data), set())
+
+        empty_data: dict[str, object] = {}
+        self.assertEqual(extract_approvers(empty_data), set())
+
+
+class TestEvaluatePrLabels(unittest.TestCase):
+    """Tests evaluating PR labels against configured rules and approvers."""
+
+    def setUp(self) -> None:
+        self.config = {
+            "security": LabelRule(name="Security", smes=["alice", "bob"]),
+            "data-model": LabelRule(name="Data-Model", smes=["charlie", "david"]),
+        }
+
+    def test_no_monitored_labels_on_pr(self) -> None:
+        pr_labels = ["bug", "documentation", "enhancement"]
+        approvers = {"anyone"}
+        evaluations = evaluate_pr_labels(pr_labels, self.config, approvers)
+        self.assertEqual(evaluations, [])
+
+    def test_single_monitored_label_approved(self) -> None:
+        pr_labels = ["Security", "bug"]
+        approvers = {"alice"}
+        evaluations = evaluate_pr_labels(pr_labels, self.config, approvers)
+
+        self.assertEqual(len(evaluations), 1)
+        ev = evaluations[0]
+        self.assertEqual(ev.rule.name, "Security")
+        self.assertTrue(ev.satisfied)
+        self.assertEqual(ev.approvers, ["alice"])
+
+    def test_single_monitored_label_not_approved(self) -> None:
+        pr_labels = ["security"]
+        approvers = {"someone_else"}
+        evaluations = evaluate_pr_labels(pr_labels, self.config, approvers)
+
+        self.assertEqual(len(evaluations), 1)
+        ev = evaluations[0]
+        self.assertEqual(ev.rule.name, "Security")
+        self.assertFalse(ev.satisfied)
+        self.assertEqual(ev.approvers, [])
+
+    def test_multi_label_all_approved(self) -> None:
+        pr_labels = ["Security", "data-model"]
+        approvers = {"alice", "david"}
+        evaluations = evaluate_pr_labels(pr_labels, self.config, approvers)
+
+        self.assertEqual(len(evaluations), 2)
+        self.assertTrue(all(ev.satisfied for ev in evaluations))
+
+    def test_multi_label_partial_approval_fails(self) -> None:
+        pr_labels = ["Security", "data-model"]
+        approvers = {"alice"}  # Security approved, data-model missing
+        evaluations = evaluate_pr_labels(pr_labels, self.config, approvers)
+
+        self.assertEqual(len(evaluations), 2)
+        eval_dict = {ev.rule.name: ev.satisfied for ev in evaluations}
+        self.assertTrue(eval_dict["Security"])
+        self.assertFalse(eval_dict["Data-Model"])
+
+    def test_case_insensitive_label_and_username_matching(self) -> None:
+        pr_labels = ["sEcUrItY"]
+        approvers = {"ALICE".lower()}
+        evaluations = evaluate_pr_labels(pr_labels, self.config, approvers)
+
+        self.assertEqual(len(evaluations), 1)
+        self.assertTrue(evaluations[0].satisfied)
+        self.assertEqual(evaluations[0].approvers, ["alice"])
+
+
+class TestGenerateStepSummary(unittest.TestCase):
+    """Tests generating GitHub Actions Markdown step summaries."""
+
+    def test_summary_no_monitored_labels(self) -> None:
+        summary = generate_step_summary([], 100, "Fix typo", "author1", True)
+        self.assertIn("No monitored SME review labels attached", summary)
+        self.assertIn("Fix typo", summary)
+
+    def test_summary_approved_label(self) -> None:
+        rule = LabelRule(name="Security", smes=["alice", "bob"])
+        evals = [LabelEvaluation(rule=rule, present_on_pr=True, approvers=["alice"])]
+        summary = generate_step_summary(evals, 100, "Security patch", "author1", True)
+
+        self.assertIn("| `Security` | ✅ Approved | @alice, @bob | @alice |", summary)
+        self.assertIn("All SME Review Requirements Met!", summary)
+
+    def test_summary_missing_approval_label(self) -> None:
+        rule = LabelRule(name="Security", smes=["alice", "bob"])
+        evals = [LabelEvaluation(rule=rule, present_on_pr=True, approvers=[])]
+        summary = generate_step_summary(evals, 100, "Security patch", "author1", False)
+
+        self.assertIn("| `Security` | ❌ Missing | @alice, @bob | *None* |", summary)
+        self.assertIn("Review Required", summary)
+
+
+class TestEndToEndJsonEvaluation(unittest.TestCase):
+    """Tests end-to-end evaluation using simulated GitHub CLI JSON output."""
+
+    def test_full_evaluation_flow(self) -> None:
+        # 1. Mock JSON output matching `gh pr view --json author,title,state,labels,latestReviews`
+        mock_gh_json = {
+            "title": "Add secure channel encryption",
+            "author": {"login": "contributor"},
+            "state": "OPEN",
+            "labels": [
+                {"name": "security"},
+                {"name": "core"},
+                {"name": "enhancement"},
+            ],
+            "latestReviews": [
+                {"author": {"login": "sme_alice"}, "state": "APPROVED"},
+                {"author": {"login": "contributor"}, "state": "APPROVED"},  # self-approval
+                {"author": {"login": "peer_reviewer"}, "state": "APPROVED"},  # not an SME
+            ],
+        }
+
+        # 2. Config mapping
+        config = {
+            "security": LabelRule(name="security", smes=["sme_alice", "sme_bob"]),
+            "core": LabelRule(name="core", smes=["lead_dev"]),
+        }
+
+        # 3. Extract approvers from JSON
+        approvers = extract_approvers(mock_gh_json)
+        self.assertIn("sme_alice", approvers)
+        self.assertIn("peer_reviewer", approvers)
+        self.assertNotIn("contributor", approvers)  # author excluded
+
+        # 4. Extract labels from JSON
+        pr_labels = [l["name"] for l in mock_gh_json.get("labels", [])]
+
+        # 5. Evaluate
+        evaluations = evaluate_pr_labels(pr_labels, config, approvers)
+        all_passed = all(ev.satisfied for ev in evaluations)
+
+        # "security" is approved by sme_alice; "core" is missing approval from lead_dev
+        self.assertFalse(all_passed)
+        eval_status = {ev.rule.name: ev.satisfied for ev in evaluations}
+        self.assertTrue(eval_status["security"])
+        self.assertFalse(eval_status["core"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
During the 1.8 feature lock discussion in TSG 207 (https://github.com/CHIP-Specifications/minute-matter/blob/main/tsg/2026-08-11.adoc), we discussed asking teams to confirm they have sufficient resources for at least a first pass review on all spec, test plans and SDK code. In the meeting we also discussed the technical means to do so and proposed allowing each team to maintain a list of subject matter experts (SMEs) who would be responsible for reviewing.

This PR introduces a CI check that PRs that are labeled for a particular feature include a review from one of the listed github users (the SME).

The readme file details how users can add new labels and users to the checking process. A brief summary:
- new labels are created when users add new top-level yaml tags to the config file
- PRs require reviews from at least one SME in the list
- PRs with multiple labels require a review from at least one SME from each group

There is also a new CI job that checks the formatting of the YAML file and also a CI job that runs the unit tests for the check functions.

NOTE - I did generate this PR with a bot, though I have been through several rounds of review with the bot and am now satisfied with the output. 

### Related issues

### Testing
Unit tests for the check script are added, though I have not tested this action directly in github because it needs to land first. Note that because there are no labels currently defined, this action is basically a no-op at this point.