### PR TITLE
[setup_payload] Use vector size instead of capacity in QRCodeSetupPayloadGenerator

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -277,9 +277,9 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase38Representation(std::string 
     ReturnErrorOnFailure(generateTLVFromOptionalData(mPayload, tlvDataStart, tlvDataStartSize, tlvDataLengthInBytes));
 
     std::vector<uint8_t> bits(kTotalPayloadDataSizeInBytes + tlvDataLengthInBytes);
-    MutableByteSpan bitsSpan(bits.data(), bits.capacity());
-    std::vector<char> buffer(base38EncodedLength(bits.capacity()) + strlen(kQRCodePrefix));
-    MutableCharSpan bufferSpan(buffer.data(), buffer.capacity());
+    MutableByteSpan bitsSpan(bits.data(), bits.size());
+    std::vector<char> buffer(base38EncodedLength(bits.size()) + strlen(kQRCodePrefix));
+    MutableCharSpan bufferSpan(buffer.data(), buffer.size());
 
     static constexpr char kDelimiterString[]{ kPayloadDelimiter, 0 };
     ReturnErrorOnFailure(payloadBase38RepresentationWithTLV(mPayload, bufferSpan, bitsSpan, tlvDataStart, tlvDataLengthInBytes,


### PR DESCRIPTION
### Summary

Use `size()` instead of `capacity()` when initializing `MutableByteSpan` and `MutableCharSpan` in `QRCodeSetupPayloadGenerator::payloadBase38Representation`.

#### Problem
`bits` is sized with `std::vector<uint8_t>(kTotalPayloadDataSizeInBytes + tlvDataLengthInBytes)` and `buffer` with `std::vector<char>(base38EncodedLength(...) + strlen(kQRCodePrefix))`. Both are sized to the exact required lengths, but their `capacity()` was passed to `MutableByteSpan` and `MutableCharSpan`. When `capacity() > size()` (for example, due to allocator size class rounding, custom allocators, or size-returning new), `payloadBase38RepresentationWithTLV` and `base38Encode` operate on the span length (capacity), causing trailing uninitialized/zero elements to be encoded into the QR code payload.

#### Solution
Pass `bits.size()` and `buffer.size()` instead of `.capacity()` to the respective `Span` constructors and length computations.

### Related issues
None

### Testing
- Ran all setup_payload unit tests:
  - `TestQRCode` (passed 21/21)
  - `TestQRCodeTLV` (passed 13/13)
  - `TestSetupPayload` (passed 4/4)
  - `TestManualCode` (passed 20/20)
  - `TestAdditionalDataPayload` (passed 6/6)