### PR TITLE
Add Proximity Ranging cluster test scripts

### DIFF
--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/impl/LoggingRangingAdapter.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/impl/LoggingRangingAdapter.cpp
@@ -45,6 +45,26 @@ constexpr uint16_t kDefaultErrorMarginCm = 10;
 constexpr int8_t kDefaultRssiDbm         = -50;
 constexpr int8_t kDefaultTxPowerDbm      = 0;
 
+/// Deterministic elapsed-seconds measurement offset. The spec requires every
+/// RangingResult to carry either TimeOfMeasurement (absolute epoch seconds) or
+/// TimeOfMeasurementOffset (seconds elapsed since the measurement was taken).
+/// A stub has no trusted wall clock, so it reports the offset form; a fixed
+/// value keeps cert tests able to assert an exact result.
+///
+/// REAL ADAPTER: this constant does not exist in production. Report the radio's
+/// real measurement time — an absolute TimeOfMeasurement when the device has a
+/// trusted clock, otherwise the true elapsed time since the measurement taken
+/// from the radio's timestamp. At least one of the two MUST always be present.
+constexpr uint32_t kDefaultTimeOfMeasurementOffsetS = 1;
+
+/// Number of simultaneous ranging sessions this (stub) adapter reports it can
+/// hold. Deterministic and non-zero so cert tests can assert an exact value.
+///
+/// REAL ADAPTER: derive this from the radio's real session capacity (how many
+/// concurrent ranging sessions the ranging engine can track at once); do not
+/// hard-code it.
+constexpr uint8_t kDefaultMaxConcurrentSessions = 4;
+
 /// Simulated radio measurement latency. Each StartSession call schedules a
 /// timer of this duration; when the timer fires the adapter emits exactly
 /// one OnMeasurementData. Three seconds approximates a realistic ranging
@@ -192,6 +212,19 @@ Structs::RangingCapabilitiesStruct::Type LoggingRangingAdapter::GetCapabilities(
     Structs::RangingCapabilitiesStruct::Type capabilities = {};
     capabilities.technology                               = mTechnology;
     capabilities.periodicRangingSupport                   = mPeriodicRangingSupport;
+    // The LoggingRangingAdapter can act as both the active initiator and the
+    // passive responder for its technology, so it advertises both role-support
+    // bits. Cert tests (TC-PROXR-2.3/2.4) check these before asking DUT_I to
+    // initiate and DUT_R to respond.
+    //
+    // REAL ADAPTER: report exactly the roles the radio can perform for this
+    // technology (query the radio driver); do not hard-code both.
+    capabilities.supportedRangingRoles = BitMask<RangingRoleSupportBitmap>(RangingRoleSupportBitmap::kInitiatorSupport,
+                                                                           RangingRoleSupportBitmap::kResponderSupport);
+    // MaxConcurrentSessions is Optional<> in the current data model but is treated
+    // as mandatory by the cert tests (it is planned to become mandatory in the
+    // spec), so the stub always reports it.
+    capabilities.maxConcurrentSessions.SetValue(kDefaultMaxConcurrentSessions);
     switch (mTechnology)
     {
     case RangingTechEnum::kWiFiNextGenerationRanging:
@@ -603,6 +636,10 @@ Structs::RangingMeasurementDataStruct::Type LoggingRangingAdapter::BuildMeasurem
     Structs::RangingMeasurementDataStruct::Type measurement{};
     measurement.distance.SetNonNull(kDefaultDistanceCm);
     measurement.errorMargin.SetValue(kDefaultErrorMarginCm);
+    // Spec: every RangingResult SHALL carry TimeOfMeasurement or
+    // TimeOfMeasurementOffset. The stub reports a deterministic elapsed-seconds
+    // offset (see kDefaultTimeOfMeasurementOffsetS).
+    measurement.timeOfMeasurementOffset.SetValue(kDefaultTimeOfMeasurementOffsetS);
     switch (mTechnology)
     {
     case RangingTechEnum::kBLEBeaconRSSIRanging:

--- a/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/impl/LoggingRangingAdapter.cpp
+++ b/examples/all-devices-app/all-devices-common/device/types/proximity-ranger/impl/LoggingRangingAdapter.cpp
@@ -219,8 +219,8 @@ Structs::RangingCapabilitiesStruct::Type LoggingRangingAdapter::GetCapabilities(
     //
     // REAL ADAPTER: report exactly the roles the radio can perform for this
     // technology (query the radio driver); do not hard-code both.
-    capabilities.supportedRangingRoles = BitMask<RangingRoleSupportBitmap>(RangingRoleSupportBitmap::kInitiatorSupport,
-                                                                           RangingRoleSupportBitmap::kResponderSupport);
+    capabilities.supportedRangingRoles =
+        BitMask<RangingRoleSupportBitmap>(RangingRoleSupportBitmap::kInitiatorSupport, RangingRoleSupportBitmap::kResponderSupport);
     // MaxConcurrentSessions is Optional<> in the current data model but is treated
     // as mandatory by the cert tests (it is planned to become mandatory in the
     // spec), so the stub always reports it.

--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -10729,3 +10729,66 @@ PICS:
 
     - label: "Does the device implement the End command?"
       id: WEBRTCR.S.C03.Rsp
+
+    #
+    # Proximity Ranging Cluster
+    #
+    - label:
+          "Does the device implement the Proximity Ranging cluster as a server?"
+      id: PROXR.S
+
+    # Features
+    - label: "Does the device support the Wi-Fi USD Proximity Ranging feature?"
+      id: PROXR.S.F00
+
+    - label: "Does the device support the Bluetooth Channel Sounding feature?"
+      id: PROXR.S.F01
+
+    - label: "Does the device support the BLE Beacon RSSI feature?"
+      id: PROXR.S.F02
+
+    - label: "Does the device support the UWB Ranging feature?"
+      id: PROXR.S.F03
+
+    # Server attributes
+    - label: "Does the device implement the RangingCapabilities attribute?"
+      id: PROXR.S.A0000
+
+    - label: "Does the device implement the WiFiDevIK attribute?"
+      id: PROXR.S.A0001
+
+    - label: "Does the device implement the BLEDeviceID attribute?"
+      id: PROXR.S.A0002
+
+    - label: "Does the device implement the BLTDevIK attribute?"
+      id: PROXR.S.A0003
+
+    - label: "Does the device implement the BLTCSSecurityLevel attribute?"
+      id: PROXR.S.A0004
+
+    - label: "Does the device implement the BLTCSModeCapability attribute?"
+      id: PROXR.S.A0005
+
+    - label: "Does the device implement the SessionIDList attribute?"
+      id: PROXR.S.A0006
+
+    - label: "Does the device implement the RangingConstraints attribute?"
+      id: PROXR.S.A0007
+
+    # Commands received
+    - label: "Does the device implement the StartRangingRequest command?"
+      id: PROXR.S.C00.Rsp
+
+    - label: "Does the device implement the StopRangingRequest command?"
+      id: PROXR.S.C02.Rsp
+
+    # Commands generated
+    - label: "Does the device implement the StartRangingResponse command?"
+      id: PROXR.S.C01.Tx
+
+    # Events
+    - label: "Does the device implement the RangingResult event?"
+      id: PROXR.S.E00
+
+    - label: "Does the device implement the RangingSessionStatus event?"
+      id: PROXR.S.E01

--- a/src/app/tests/suites/certification/ci-pics-values
+++ b/src/app/tests/suites/certification/ci-pics-values
@@ -3202,3 +3202,34 @@ JFADMIN.C=1
 
 # Attributes
 JFADMIN.S.A0000=1 #AdministratorFabricIndex
+
+# Proximity Ranging Cluster
+# Server
+PROXR.S=1
+
+# Features
+PROXR.S.F00=1  # WFUSDPD - Wi-Fi USD Proximity Ranging
+PROXR.S.F01=1  # BLTCS - Bluetooth Channel Sounding
+PROXR.S.F02=1  # BLERBC - BLE Beacon RSSI
+PROXR.S.F03=0  # UWBR - UWB Ranging
+
+# Attributes
+PROXR.S.A0000=1  # RangingCapabilities
+PROXR.S.A0001=1  # WiFiDevIK
+PROXR.S.A0002=1  # BLEDeviceID
+PROXR.S.A0003=1  # BLTDevIK
+PROXR.S.A0004=1  # BLTCSSecurityLevel
+PROXR.S.A0005=1  # BLTCSModeCapability
+PROXR.S.A0006=1  # SessionIDList
+PROXR.S.A0007=0  # RangingConstraints (not implemented by all-devices-app)
+
+# Commands Received
+PROXR.S.C00.Rsp=1  # StartRangingRequest
+PROXR.S.C02.Rsp=1  # StopRangingRequest
+
+# Commands Generated
+PROXR.S.C01.Tx=1   # StartRangingResponse
+
+# Events
+PROXR.S.E00=1      # RangingResult
+PROXR.S.E01=1      # RangingSessionStatus

--- a/src/python_testing/TC_PROXRTestBase.py
+++ b/src/python_testing/TC_PROXRTestBase.py
@@ -28,6 +28,7 @@ reflector/responder (DUT_R) and commission it onto the DUT's fabric; the helpers
 here own that lifecycle so 2.3 and 2.4 share exactly one implementation.
 """
 
+import contextlib
 import logging
 import os
 import queue
@@ -240,6 +241,7 @@ class ProximityRangingTestBase:
     def build_wifi_request(self, *, role, peer_wifi_ik, pmk, start_time=0, end_time=6,
                            interval=None, min_distance=None, max_distance=None,
                            technology=RangingTechEnum.kWiFiRoundTripTimeRanging):
+        self._assert_key_len(peer_wifi_ik, DEVICE_IDENTITY_KEY_LEN, "peerWiFiDevIK")
         self._assert_key_len(pmk, PMK_LEN, "PMK")
         return _PROXR.Commands.StartRangingRequest(
             technology=technology,
@@ -251,6 +253,7 @@ class ProximityRangingTestBase:
     def build_blt_request(self, *, role, peer_blt_ik, ltk, security_level, mode,
                           start_time=0, end_time=6, interval=None,
                           min_distance=None, max_distance=None):
+        self._assert_key_len(peer_blt_ik, DEVICE_IDENTITY_KEY_LEN, "peerBLTDevIK")
         self._assert_key_len(ltk, LTK_LEN, "LTK")
         return _PROXR.Commands.StartRangingRequest(
             technology=RangingTechEnum.kBluetoothChannelSounding,
@@ -283,6 +286,16 @@ class ProximityRangingTestBase:
             endpoint = self.get_endpoint()
         return await self.send_single_cmd(
             cmd=_PROXR.Commands.StopRangingRequest(sessionID=session_id), node_id=node_id, endpoint=endpoint)
+
+    async def stop_ranging_best_effort(self, session_id, node_id=None, endpoint=None):
+        """Hermetic cleanup for a responder session that is still running: send
+        StopRanging but tolerate the session having already self-terminated at its
+        EndTime (NOT_FOUND / INVALID_IN_STATE). Bounding the session here keeps a
+        finite-MaxConcurrentSessions DUT from accumulating leftover sessions across
+        sequential steps, without reintroducing a hard StopRanging that would race
+        the session's own EndTime expiry."""
+        with contextlib.suppress(InteractionModelError):
+            await self.send_stop_ranging(session_id, node_id=node_id, endpoint=endpoint)
 
     async def expect_start_ranging_status(self, cmd, expected_cluster_status: int, node_id=None, endpoint=None):
         """Send StartRangingRequest and assert it is rejected with a specific
@@ -361,7 +374,10 @@ class ProximityRangingTestBase:
         self._reflector_discriminator = random.randint(2048, 4095)
         # all-devices-app has no --passcode flag; it uses the SDK default passcode.
         self._reflector_passcode = 20202021
-        self._reflector_port = 5546
+        # Reflector secure port defaults to 5546 but is overridable so two runs on
+        # one host (e.g. concurrent 2.3 and 2.4) can pick distinct ports and not
+        # collide. Provide via --int-arg th_reflector_port:<port>.
+        self._reflector_port = int(self.user_params.get("th_reflector_port", 5546))
         self.reflector = Subprocess(
             app, "--device", "proximity-ranger:1",
             "--KVS", self._reflector_kvs,

--- a/src/python_testing/TC_PROXRTestBase.py
+++ b/src/python_testing/TC_PROXRTestBase.py
@@ -1,0 +1,393 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+"""Shared helpers for the Proximity Ranging (PROXR) cluster certification tests.
+
+This is a mixin meant to be combined with a ``MatterBaseTest`` subclass (in
+practice ``MatterTestCommissionedDevice``); it relies on the base class for
+``read_single_attribute_check_success``, ``send_single_cmd``, ``get_endpoint``,
+``default_controller`` and ``dut_node_id``.  It carries no ``MatterBaseTest``
+inheritance itself so the runner's "one leaf test class per file" rule holds.
+
+The two-device tests (2.3 / 2.4) launch a second all-devices-app instance as the
+reflector/responder (DUT_R) and commission it onto the DUT's fabric; the helpers
+here own that lifecycle so 2.3 and 2.4 share exactly one implementation.
+"""
+
+import logging
+import os
+import queue
+import random
+import tempfile
+import time
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+import matter.testing.matter_asserts as matter_asserts
+from matter import ChipDeviceCtrl
+from matter.interaction_model import InteractionModelError
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.tasks import Subprocess
+
+logger = logging.getLogger(__name__)
+
+_PROXR = Clusters.ProximityRanging
+
+RangingTechEnum = _PROXR.Enums.RangingTechEnum
+RangingRoleEnum = _PROXR.Enums.RangingRoleEnum
+RangingSessionStatusEnum = _PROXR.Enums.RangingSessionStatusEnum
+BLERBCSecurityModeEnum = _PROXR.Enums.BLERBCSecurityModeEnum
+BLTCSSecurityLevelEnum = _PROXR.Enums.BLTCSSecurityLevelEnum
+BLTCSModeEnum = _PROXR.Enums.BLTCSModeEnum
+StatusCodeEnum = _PROXR.Enums.StatusCodeEnum
+Feature = _PROXR.Bitmaps.Feature
+RangingRoleSupportBitmap = _PROXR.Bitmaps.RangingRoleSupportBitmap
+
+# Device identity keys (WiFiDevIK / BLTDevIK) are 16-byte octet strings.
+DEVICE_IDENTITY_KEY_LEN = 16
+
+# Key-material lengths are fixed by the data model, and they are NOT all the same:
+# WiFiRangingDeviceRoleConfigStruct.PMK is length="32" minLength="32", while
+# BLTChannelSoundingDeviceRoleConfigStruct.LTK and
+# BLERangingDeviceRoleConfigStruct.SessionKey are length="16" minLength="16"
+# (proximity-ranging-cluster.xml). A DUT that enforces the octstr constraint
+# rejects a wrong-length value with CONSTRAINT_ERROR, so the TH must generate each
+# at its own mandated length rather than sharing one default.
+PMK_LEN = 32
+LTK_LEN = 16
+SESSION_KEY_LEN = 16
+
+# "Unknown peer" sentinels recognised by the all-devices-app LoggingRangingAdapter
+# (impl/LoggingRangingAdapter.cpp).  A StartRangingRequest whose peer identity for
+# the matching technology equals one of these makes the stub accept the session
+# but emit no measurement, so the active-initiator session terminates with
+# kPeerNotFound instead of kSessionEndTimeReached.  These satisfy the plan's "a
+# value different from the peer's identity" requirement while deterministically
+# driving the peer-not-found path on the reference app.
+UNKNOWN_PEER_BLE_DEVICE_ID = 0xDEADBEEFCAFEBABE
+UNKNOWN_PEER_DEV_IK = bytes([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]) * 2
+
+# The LoggingRangingAdapter schedules a single measurement this many seconds after
+# each ranging instance starts (kSimulatedRangingDuration = 3000 ms).  Event waits
+# are sized off this latency plus the request EndTime rather than fixed sleeps.
+SIMULATED_RANGING_LATENCY_S = 3
+
+# All-devices-app enables all three server features (WFUSDPD | BLTCS | BLERBC).
+WIFI_TECHNOLOGIES = (RangingTechEnum.kWiFiRoundTripTimeRanging, RangingTechEnum.kWiFiNextGenerationRanging)
+
+
+class ProximityRangingTestBase:
+    """Mixin with PROXR attribute reads, StartRangingRequest builders and the
+    two-device (initiator/reflector) subprocess lifecycle."""
+
+    # ----- attribute reads -----------------------------------------------------
+
+    async def read_proxr_attribute(self, attribute, node_id=None, endpoint=None):
+        """Read a single PROXR attribute, defaulting to the matched endpoint and
+        the primary DUT.  Wildcard-subscription verification is disabled: session
+        state (SessionIDList) mutates faster than the background subscription can
+        track, and reflector reads target a node the subscription controller does
+        not cover."""
+        if endpoint is None:
+            endpoint = self.get_endpoint()
+        return await self.read_single_attribute_check_success(
+            cluster=_PROXR, attribute=attribute, node_id=node_id, endpoint=endpoint,
+            verify_wildcard_subscription=False)
+
+    async def read_feature_map(self, node_id=None, endpoint=None) -> int:
+        return await self.read_proxr_attribute(_PROXR.Attributes.FeatureMap, node_id=node_id, endpoint=endpoint)
+
+    async def has_feature(self, feature: Feature, node_id=None, endpoint=None) -> bool:
+        return bool((await self.read_feature_map(node_id=node_id, endpoint=endpoint)) & feature)
+
+    async def read_session_id_list(self, node_id=None, endpoint=None):
+        return await self.read_proxr_attribute(_PROXR.Attributes.SessionIDList, node_id=node_id, endpoint=endpoint)
+
+    # ----- capability helpers --------------------------------------------------
+
+    @staticmethod
+    def capability_for_technology(capabilities, technology):
+        """Return the RangingCapabilitiesStruct element for a technology, or None."""
+        for cap in capabilities:
+            if cap.technology == technology:
+                return cap
+        return None
+
+    @staticmethod
+    def negotiate_technology(caps_i, caps_r, candidate_technologies):
+        """Return the technology the DUT_I/DUT_R pair has in common for a feature
+        family, or None. Implements the plan's "common value of the Technology
+        field of the saved RangingCapabilitiesStruct attributes of DUT_I and
+        DUT_R": the first candidate both DUTs advertise a capability element for.
+        For Wi-Fi this chooses between kWiFiRoundTripTimeRanging and
+        kWiFiNextGenerationRanging, so a NextGen-only device pair still works."""
+        for tech in candidate_technologies:
+            if (ProximityRangingTestBase.capability_for_technology(caps_i, tech) is not None
+                    and ProximityRangingTestBase.capability_for_technology(caps_r, tech) is not None):
+                return tech
+        return None
+
+    def negotiate_block(self, *, caps_i, caps_r, fmap_i, fmap_r, feature_bit, candidate_technologies, require_periodic=False):
+        """Decide whether a per-technology ranging block can run against BOTH
+        DUTs, and if so which technology to use. Returns ``(technology, reason)``:
+        ``technology`` is the negotiated RangingTechEnum when the block should run
+        (``reason == "ok"``); otherwise ``None`` with a human-readable reason to
+        log and skip.
+
+        A block runs only when BOTH DUTs advertise a capability element for the
+        chosen technology AND both have the feature bit set AND DUT_I advertises
+        initiator-role support while DUT_R advertises responder-role support
+        (RangingRoleSupportBitmap). FeatureMaps are read per DUT (passed in as
+        ``fmap_i``/``fmap_r``) rather than via ``feature_guard``, which only
+        evaluates the primary DUT. When ``require_periodic`` is set the block also
+        requires at least one of the two DUTs to advertise periodic support for
+        the technology (the "claims periodic" trigger); the caller then asserts
+        the plan's step-2 requirement that periodic support is true on BOTH."""
+        tech = self.negotiate_technology(caps_i, caps_r, candidate_technologies)
+        if tech is None:
+            names = "/".join(t.name for t in candidate_technologies)
+            return None, f"no technology in [{names}] is common to DUT_I and DUT_R RangingCapabilities"
+        if not (fmap_i & feature_bit):
+            return None, f"DUT_I FeatureMap does not set {feature_bit.name}"
+        if not (fmap_r & feature_bit):
+            return None, f"DUT_R FeatureMap does not set {feature_bit.name}"
+        cap_i = self.capability_for_technology(caps_i, tech)
+        cap_r = self.capability_for_technology(caps_r, tech)
+        if not (cap_i.supportedRangingRoles & RangingRoleSupportBitmap.kInitiatorSupport):
+            return None, f"DUT_I does not advertise InitiatorSupport for {tech.name}"
+        if not (cap_r.supportedRangingRoles & RangingRoleSupportBitmap.kResponderSupport):
+            return None, f"DUT_R does not advertise ResponderSupport for {tech.name}"
+        if require_periodic and not (cap_i.periodicRangingSupport or cap_r.periodicRangingSupport):
+            return None, f"neither DUT advertises PeriodicRangingSupport for {tech.name}"
+        return tech, "ok"
+
+    @staticmethod
+    def negotiate_bltcs_mode(mode_i, mode_r):
+        """Return a BLTCSMode supported by both DUTs, or None if their
+        BLTCSModeCapability values do not intersect. Compatibility rule: a device
+        reporting kBoth can range in either PBR or RTT; a device reporting
+        kPBROnly or kRTTOnly can only do that single mode. The negotiated mode is
+        the intersection of what both devices can do; kBoth is returned only when
+        both devices can do both."""
+        supported = {
+            BLTCSModeEnum.kPBROnly: {BLTCSModeEnum.kPBROnly},
+            BLTCSModeEnum.kRTTOnly: {BLTCSModeEnum.kRTTOnly},
+            BLTCSModeEnum.kBoth: {BLTCSModeEnum.kPBROnly, BLTCSModeEnum.kRTTOnly},
+        }
+        common = supported.get(mode_i, set()) & supported.get(mode_r, set())
+        if not common:
+            return None
+        if common == {BLTCSModeEnum.kPBROnly, BLTCSModeEnum.kRTTOnly}:
+            return BLTCSModeEnum.kBoth
+        return BLTCSModeEnum.kPBROnly if BLTCSModeEnum.kPBROnly in common else BLTCSModeEnum.kRTTOnly
+
+    # ----- RangingResult validation -------------------------------------------
+
+    @staticmethod
+    def assert_time_of_measurement_present(data):
+        """The plan requires every checked RangingResult to carry TimeOfMeasurement
+        OR TimeOfMeasurementOffset. Hard-require at least one is present, and
+        type-check whichever are present. Both fields are elapsed_s / epoch-second
+        uint32 values in the data model, so uint32 validation applies."""
+        has_absolute = data.timeOfMeasurement is not None
+        has_offset = data.timeOfMeasurementOffset is not None
+        asserts.assert_true(
+            has_absolute or has_offset,
+            "RangingResult must carry TimeOfMeasurement or TimeOfMeasurementOffset (at least one is required)")
+        if has_absolute:
+            matter_asserts.assert_valid_uint32(data.timeOfMeasurement, "TimeOfMeasurement")
+        if has_offset:
+            matter_asserts.assert_valid_uint32(data.timeOfMeasurementOffset, "TimeOfMeasurementOffset")
+
+    # ----- StartRangingRequest builders ---------------------------------------
+
+    @staticmethod
+    def _trigger(start_time, end_time, interval=None):
+        return _PROXR.Structs.RangingTriggerConditionStruct(
+            startTime=start_time, endTime=end_time, rangingInstanceInterval=interval)
+
+    @staticmethod
+    def _reporting(min_distance=None, max_distance=None):
+        if min_distance is None and max_distance is None:
+            return None
+        return _PROXR.Structs.ReportingConditionStruct(
+            minDistanceCondition=min_distance, maxDistanceCondition=max_distance)
+
+    @staticmethod
+    def _assert_key_len(material, expected_len, name):
+        """Guard the TH's own request construction: the data model fixes each key's
+        length, and a DUT that enforces the constraint would answer
+        CONSTRAINT_ERROR. Failing here names the mistake instead of surfacing it as
+        an unexplained rejection from the DUT."""
+        asserts.assert_equal(len(material), expected_len,
+                             f"{name} must be exactly {expected_len} bytes per the data model")
+
+    def build_wifi_request(self, *, role, peer_wifi_ik, pmk, start_time=0, end_time=6,
+                           interval=None, min_distance=None, max_distance=None,
+                           technology=RangingTechEnum.kWiFiRoundTripTimeRanging):
+        self._assert_key_len(pmk, PMK_LEN, "PMK")
+        return _PROXR.Commands.StartRangingRequest(
+            technology=technology,
+            wiFiRangingDeviceRoleConfig=_PROXR.Structs.WiFiRangingDeviceRoleConfigStruct(
+                role=role, peerWiFiDevIK=peer_wifi_ik, pmk=pmk),
+            trigger=self._trigger(start_time, end_time, interval),
+            reportingCondition=self._reporting(min_distance, max_distance))
+
+    def build_blt_request(self, *, role, peer_blt_ik, ltk, security_level, mode,
+                          start_time=0, end_time=6, interval=None,
+                          min_distance=None, max_distance=None):
+        self._assert_key_len(ltk, LTK_LEN, "LTK")
+        return _PROXR.Commands.StartRangingRequest(
+            technology=RangingTechEnum.kBluetoothChannelSounding,
+            BLTChannelSoundingDeviceRoleConfig=_PROXR.Structs.BLTChannelSoundingDeviceRoleConfigStruct(
+                role=role, peerBLTDevIK=peer_blt_ik, BLTCSMode=mode, BLTCSSecurityLevel=security_level, ltk=ltk),
+            trigger=self._trigger(start_time, end_time, interval),
+            reportingCondition=self._reporting(min_distance, max_distance))
+
+    def build_ble_request(self, *, role, peer_ble_device_id, session_key, start_time=0, end_time=6,
+                          interval=None, min_distance=None, max_distance=None):
+        self._assert_key_len(session_key, SESSION_KEY_LEN, "SessionKey")
+        return _PROXR.Commands.StartRangingRequest(
+            technology=RangingTechEnum.kBLEBeaconRSSIRanging,
+            BLERangingDeviceRoleConfig=_PROXR.Structs.BLERangingDeviceRoleConfigStruct(
+                role=role, peerBLEDeviceID=peer_ble_device_id,
+                BLERBCSecurityMode=BLERBCSecurityModeEnum.kBLEDeviceIDObfuscation, sessionKey=session_key),
+            trigger=self._trigger(start_time, end_time, interval),
+            reportingCondition=self._reporting(min_distance, max_distance))
+
+    # ----- command send helpers -----------------------------------------------
+
+    async def send_start_ranging(self, cmd, node_id=None, endpoint=None):
+        """Send StartRangingRequest and return the StartRangingResponse."""
+        if endpoint is None:
+            endpoint = self.get_endpoint()
+        return await self.send_single_cmd(cmd=cmd, node_id=node_id, endpoint=endpoint)
+
+    async def send_stop_ranging(self, session_id, node_id=None, endpoint=None):
+        if endpoint is None:
+            endpoint = self.get_endpoint()
+        return await self.send_single_cmd(
+            cmd=_PROXR.Commands.StopRangingRequest(sessionID=session_id), node_id=node_id, endpoint=endpoint)
+
+    async def expect_start_ranging_status(self, cmd, expected_cluster_status: int, node_id=None, endpoint=None):
+        """Send StartRangingRequest and assert it is rejected with a specific
+        cluster-specific StatusCodeEnum value."""
+        try:
+            await self.send_start_ranging(cmd, node_id=node_id, endpoint=endpoint)
+            asserts.fail(f"Expected StartRangingRequest to be rejected with clusterStatus {expected_cluster_status}, "
+                         "but it succeeded")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.clusterStatus, expected_cluster_status,
+                                 f"Unexpected cluster status; expected {expected_cluster_status}")
+
+    @staticmethod
+    def random_secret(length: int = 16) -> bytes:
+        return os.urandom(length)
+
+    # ----- event subscription helpers -----------------------------------------
+
+    async def subscribe_proxr_events(self, node_id, endpoint=None):
+        """Subscribe to all PROXR events on a node and drop the priming
+        re-delivery of historical events. Fresh subscriptions re-read the DUT's
+        event log, so without this drop a later exchange would consume an earlier
+        exchange's RangingResult. Callers still match on SessionID (see
+        wait_ranging_result / wait_session_status) as a second line of defence."""
+        if endpoint is None:
+            endpoint = self.get_endpoint()
+        cb = EventSubscriptionHandler(expected_cluster=_PROXR)
+        await cb.start(self.default_controller, node_id, endpoint)
+        cb.flush_events()
+        return cb
+
+    def _wait_for_event(self, cb, event_id, session_id, timeout_sec):
+        """Return the next PROXR event of a given id whose SessionID matches,
+        discarding events of other types or other sessions; fail on timeout."""
+        deadline = time.time() + timeout_sec
+        while True:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                asserts.fail(f"Timeout waiting for PROXR event id {event_id} (session {session_id})")
+            try:
+                ev = cb.get_event_from_queue(block=True, timeout=max(0.1, remaining))
+            except queue.Empty:
+                asserts.fail(f"Timeout waiting for PROXR event id {event_id} (session {session_id})")
+            if ev is None:
+                continue
+            if (ev.Header.ClusterId == _PROXR.id and ev.Header.EventId == event_id
+                    and getattr(ev.Data, "sessionID", None) == session_id):
+                return ev.Data
+
+    def wait_ranging_result(self, cb, session_id, timeout_sec):
+        return self._wait_for_event(cb, _PROXR.Events.RangingResult.event_id, session_id, timeout_sec)
+
+    def wait_session_status(self, cb, session_id, timeout_sec):
+        return self._wait_for_event(cb, _PROXR.Events.RangingSessionStatus.event_id, session_id, timeout_sec)
+
+    # ----- second-device (DUT_R) lifecycle ------------------------------------
+
+    def setup_reflector_device(self):
+        """Launch a second all-devices-app proximity-ranger instance (DUT_R) and
+        record how to commission it onto the DUT's fabric.
+
+        all-devices-app takes --port (not --secured-device-port) and has no
+        --passcode flag (its setup passcode is the SDK default 20202021), so the
+        generic AppServerSubprocess wrapper cannot launch it; the base Subprocess
+        is used with the app's real flags instead. The reflector's shared
+        singletons are kept distinct from the primary DUT and any other host app:
+        a private temp-dir KVS, a reflector-specific discriminator, and its own
+        secure --port (see DECISIONS.md). Returns the reflector node id.
+        """
+        app = self.user_params.get("th_reflector_app_path", None)
+        asserts.assert_true(app is not None and os.path.exists(app),
+                            "Provide the reflector app via --string-arg th_reflector_app_path:<all-devices-app path>")
+
+        self._reflector_storage = tempfile.TemporaryDirectory(prefix="proxr-reflector-")
+        self._reflector_kvs = os.path.join(self._reflector_storage.name, "kvs-reflector")
+        self._reflector_discriminator = random.randint(2048, 4095)
+        # all-devices-app has no --passcode flag; it uses the SDK default passcode.
+        self._reflector_passcode = 20202021
+        self._reflector_port = 5546
+        self.reflector = Subprocess(
+            app, "--device", "proximity-ranger:1",
+            "--KVS", self._reflector_kvs,
+            "--port", str(self._reflector_port),
+            "--discriminator", str(self._reflector_discriminator),
+            output_cb=lambda line, is_stderr: b"[REFLECTOR]" + line)
+        self.reflector.start(expected_output="Server initialization complete", timeout=90)
+
+        self.reflector_node_id = self.dut_node_id + 1
+        return self.reflector_node_id
+
+    async def commission_reflector(self):
+        await self.default_controller.CommissionOnNetwork(
+            nodeId=self.reflector_node_id,
+            setupPinCode=self._reflector_passcode,
+            filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR,
+            filter=self._reflector_discriminator)
+
+    def teardown_reflector_device(self):
+        """Hermetic cleanup: terminate the reflector subprocess and delete its
+        temporary KVS directory, leaving the host in its pre-test state and the
+        test re-runnable. The reflector is a throwaway instance with a fresh KVS
+        per run, so no fabric-removal step is required."""
+        if getattr(self, "reflector", None) is not None:
+            self.reflector.terminate()
+            self.reflector = None
+        if getattr(self, "_reflector_storage", None) is not None:
+            self._reflector_storage.cleanup()
+            self._reflector_storage = None

--- a/src/python_testing/TC_PROXR_2_1.py
+++ b/src/python_testing/TC_PROXR_2_1.py
@@ -36,13 +36,13 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import matter.clusters as Clusters
-import matter.testing.matter_asserts as matter_asserts
 import test_plan_support
 from mobly import asserts
-from TC_PROXRTestBase import (DEVICE_IDENTITY_KEY_LEN, Feature, ProximityRangingTestBase, RangingTechEnum, WIFI_TECHNOLOGIES,
-                              BLTCSModeEnum, BLTCSSecurityLevelEnum)
+from TC_PROXRTestBase import (DEVICE_IDENTITY_KEY_LEN, WIFI_TECHNOLOGIES, BLTCSModeEnum, BLTCSSecurityLevelEnum, Feature,
+                              ProximityRangingTestBase, RangingTechEnum)
 
+import matter.clusters as Clusters
+import matter.testing.matter_asserts as matter_asserts
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterTestCommissionedDevice
 from matter.testing.runner import TestStep, default_matter_test_main

--- a/src/python_testing/TC_PROXR_2_1.py
+++ b/src/python_testing/TC_PROXR_2_1.py
@@ -1,0 +1,174 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device proximity-ranger:1 --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --endpoint 1
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import matter.clusters as Clusters
+import matter.testing.matter_asserts as matter_asserts
+import test_plan_support
+from mobly import asserts
+from TC_PROXRTestBase import (DEVICE_IDENTITY_KEY_LEN, Feature, ProximityRangingTestBase, RangingTechEnum, WIFI_TECHNOLOGIES,
+                              BLTCSModeEnum, BLTCSSecurityLevelEnum)
+
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterTestCommissionedDevice
+from matter.testing.runner import TestStep, default_matter_test_main
+
+_PROXR = Clusters.ProximityRanging
+
+
+class TC_PROXR_2_1(MatterTestCommissionedDevice, ProximityRangingTestBase):
+
+    def desc_TC_PROXR_2_1(self) -> str:
+        return "[TC-PROXR-2.1] Attributes (DUT as Server)"
+
+    def pics_TC_PROXR_2_1(self) -> list[str]:
+        return ["PROXR.S"]
+
+    def steps_TC_PROXR_2_1(self) -> list[TestStep]:
+        return [
+            TestStep(1, test_plan_support.commission_if_required(), is_commissioning=True),
+            TestStep("2a", test_plan_support.read_attribute("RangingCapabilities"),
+                     "Verify a list of RangingCapabilitiesStruct; exactly one element has Technology "
+                     "WiFiRoundTripTimeRanging or WiFiNextGenerationRanging; MaxConcurrentSessions is present and "
+                     "greater than 0."),
+            TestStep("2b", test_plan_support.read_attribute("RangingCapabilities"),
+                     "Verify exactly one element has Technology BluetoothChannelSounding; "
+                     "MaxConcurrentSessions is present and greater than 0."),
+            TestStep("2c", test_plan_support.read_attribute("RangingCapabilities"),
+                     "Verify exactly one element has Technology BLEBeaconRSSIRanging; "
+                     "MaxConcurrentSessions is present and greater than 0."),
+            TestStep("3a", test_plan_support.read_attribute("WiFiDevIK"), "Verify an octstr value of length 16."),
+            TestStep("3b", "TH reads the BLTDevIK, BLTCSSecurityLevel and BLTCSModeCapability attributes from DUT",
+                     "Verify BLTDevIK is an octstr of length 16, BLTCSSecurityLevel is a BLTCSSecurityLevelEnum, "
+                     "BLTCSModeCapability is a BLTCSModeEnum."),
+            TestStep("3c", test_plan_support.read_attribute("BLEDeviceID"), "Verify a valid uint64 value."),
+            TestStep(4, test_plan_support.read_attribute("SessionIDList"), "Verify the list has zero elements."),
+            TestStep(5, test_plan_support.read_attribute("RangingConstraints"),
+                     "If present, verify each element has a Technology (RangingTechEnum) and Role (RangingRoleEnum); "
+                     "BluetoothChannelSounding elements include a BLTCSMode (BLTCSModeEnum); elements with Enabled=false "
+                     "do not include MinRangingInterval, MaxSessionDuration or MaxRangingInstances."),
+        ]
+
+    def _verify_single_capability(self, capabilities, technologies):
+        matter_asserts.assert_list(capabilities, "RangingCapabilities")
+        matching = [c for c in capabilities if c.technology in technologies]
+        asserts.assert_equal(len(matching), 1,
+                             f"Expected exactly one RangingCapabilities element for {technologies}, got {len(matching)}")
+        cap = matching[0]
+        # MaxConcurrentSessions is treated as MANDATORY here: the field is planned to
+        # change from optional to mandatory in the spec, so this test holds devices to
+        # that now. NOTE the deliberate divergence from the current SDK data model,
+        # which still declares `optional int8u maxConcurrentSessions = 6` in
+        # RangingCapabilitiesStruct - do not relax this assertion back to a
+        # present-only check; it is ahead of the data model on purpose.
+        # The bound is the plan's own wording for steps 2a/2b/2c ("Verify the
+        # MaxConcurrentSessions field is greater than 0"), so a device supporting
+        # exactly one concurrent session is conformant.
+        asserts.assert_is_not_none(cap.maxConcurrentSessions,
+                                   "MaxConcurrentSessions must be present (mandatory)")
+        matter_asserts.assert_valid_uint8(cap.maxConcurrentSessions, "MaxConcurrentSessions")
+        asserts.assert_greater(cap.maxConcurrentSessions, 0, "MaxConcurrentSessions must be greater than 0")
+        return cap
+
+    @run_if_endpoint_matches(has_cluster(Clusters.ProximityRanging))
+    async def test_TC_PROXR_2_1(self):
+        endpoint = self.get_endpoint()
+
+        self.step(1)
+
+        self.step("2a")
+        if await self.feature_guard(endpoint, _PROXR, Feature.kWiFiUsdProximityDetection):
+            caps = await self.read_proxr_attribute(_PROXR.Attributes.RangingCapabilities)
+            self._verify_single_capability(caps, WIFI_TECHNOLOGIES)
+
+        self.step("2b")
+        if await self.feature_guard(endpoint, _PROXR, Feature.kBluetoothChannelSounding):
+            caps = await self.read_proxr_attribute(_PROXR.Attributes.RangingCapabilities)
+            self._verify_single_capability(caps, (RangingTechEnum.kBluetoothChannelSounding,))
+
+        self.step("2c")
+        if await self.feature_guard(endpoint, _PROXR, Feature.kBleBeaconRssi):
+            caps = await self.read_proxr_attribute(_PROXR.Attributes.RangingCapabilities)
+            self._verify_single_capability(caps, (RangingTechEnum.kBLEBeaconRSSIRanging,))
+
+        self.step("3a")
+        if await self.feature_guard(endpoint, _PROXR, Feature.kWiFiUsdProximityDetection):
+            wifi_ik = await self.read_proxr_attribute(_PROXR.Attributes.WiFiDevIK)
+            matter_asserts.assert_is_octstr(wifi_ik, "WiFiDevIK")
+            asserts.assert_equal(len(wifi_ik), DEVICE_IDENTITY_KEY_LEN, "WiFiDevIK must be 16 bytes")
+
+        self.step("3b")
+        if await self.feature_guard(endpoint, _PROXR, Feature.kBluetoothChannelSounding):
+            blt_ik = await self.read_proxr_attribute(_PROXR.Attributes.BLTDevIK)
+            matter_asserts.assert_is_octstr(blt_ik, "BLTDevIK")
+            asserts.assert_equal(len(blt_ik), DEVICE_IDENTITY_KEY_LEN, "BLTDevIK must be 16 bytes")
+            sec_level = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel)
+            matter_asserts.assert_valid_enum(sec_level, "BLTCSSecurityLevel", BLTCSSecurityLevelEnum)
+            mode = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSModeCapability)
+            matter_asserts.assert_valid_enum(mode, "BLTCSModeCapability", BLTCSModeEnum)
+
+        self.step("3c")
+        if await self.feature_guard(endpoint, _PROXR, Feature.kBleBeaconRssi):
+            ble_id = await self.read_proxr_attribute(_PROXR.Attributes.BLEDeviceID)
+            matter_asserts.assert_valid_uint64(ble_id, "BLEDeviceID")
+
+        self.step(4)
+        session_ids = await self.read_session_id_list()
+        matter_asserts.assert_list(session_ids, "SessionIDList", max_length=0)
+
+        self.step(5)
+        if await self.attribute_guard(endpoint, _PROXR.Attributes.RangingConstraints):
+            constraints = await self.read_proxr_attribute(_PROXR.Attributes.RangingConstraints)
+            if constraints is not None:
+                for c in constraints:
+                    matter_asserts.assert_valid_enum(c.technology, "RangingConstraint.Technology", RangingTechEnum)
+                    matter_asserts.assert_valid_enum(c.role, "RangingConstraint.Role",
+                                                     _PROXR.Enums.RangingRoleEnum)
+                    # The plan asks to verify a BLTCSMode field on BluetoothChannelSounding
+                    # constraint elements, but RangingConstraintStruct has no BLTCSMode field
+                    # in the cluster definition (see DECISIONS.md), so that sub-check is omitted.
+                    if c.enabled is False:
+                        asserts.assert_is_none(c.minRangingInterval,
+                                               "Disabled RangingConstraint must not include MinRangingInterval")
+                        asserts.assert_is_none(c.maxSessionDuration,
+                                               "Disabled RangingConstraint must not include MaxSessionDuration")
+                        asserts.assert_is_none(c.maxRangingInstances,
+                                               "Disabled RangingConstraint must not include MaxRangingInstances")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PROXR_2_2.py
+++ b/src/python_testing/TC_PROXR_2_2.py
@@ -36,12 +36,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import test_plan_support
+from TC_PROXRTestBase import (DEVICE_IDENTITY_KEY_LEN, LTK_LEN, PMK_LEN, SESSION_KEY_LEN, BLTCSModeEnum, BLTCSSecurityLevelEnum,
+                              Feature, ProximityRangingTestBase, RangingRoleEnum, StatusCodeEnum)
+
 import matter.clusters as Clusters
 import matter.testing.matter_asserts as matter_asserts
-import test_plan_support
-from TC_PROXRTestBase import (BLTCSModeEnum, BLTCSSecurityLevelEnum, DEVICE_IDENTITY_KEY_LEN, Feature, LTK_LEN,
-                              PMK_LEN, ProximityRangingTestBase, RangingRoleEnum, SESSION_KEY_LEN, StatusCodeEnum)
-
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterTestCommissionedDevice
 from matter.testing.runner import TestStep, default_matter_test_main

--- a/src/python_testing/TC_PROXR_2_2.py
+++ b/src/python_testing/TC_PROXR_2_2.py
@@ -1,0 +1,165 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device proximity-ranger:1 --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --endpoint 1
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import matter.clusters as Clusters
+import matter.testing.matter_asserts as matter_asserts
+import test_plan_support
+from TC_PROXRTestBase import (BLTCSModeEnum, BLTCSSecurityLevelEnum, DEVICE_IDENTITY_KEY_LEN, Feature, LTK_LEN,
+                              PMK_LEN, ProximityRangingTestBase, RangingRoleEnum, SESSION_KEY_LEN, StatusCodeEnum)
+
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterTestCommissionedDevice
+from matter.testing.runner import TestStep, default_matter_test_main
+
+_PROXR = Clusters.ProximityRanging
+
+_INFEASIBLE = StatusCodeEnum.kRejectedInfeasibleRanging
+
+
+class TC_PROXR_2_2(MatterTestCommissionedDevice, ProximityRangingTestBase):
+
+    def desc_TC_PROXR_2_2(self) -> str:
+        return "[TC-PROXR-2.2] Processing Infeasible Proximity Ranging Configuration (DUT as Server)"
+
+    def pics_TC_PROXR_2_2(self) -> list[str]:
+        return ["PROXR.S"]
+
+    def steps_TC_PROXR_2_2(self) -> list[TestStep]:
+        reject = "Verify DUT responds with status RejectedInfeasibleRanging."
+        return [
+            TestStep(1, test_plan_support.commission_if_required(), is_commissioning=True),
+            TestStep(2, test_plan_support.read_attribute("RangingCapabilities"),
+                     "Verify a list of RangingCapabilitiesStruct and save the elements."),
+            TestStep(3, test_plan_support.read_attribute("WiFiDevIK"),
+                     "Verify an octstr value and save it."),
+            TestStep(4, "TH reads the BLTDevIK, BLTCSSecurityLevel and BLTCSModeCapability attributes from DUT",
+                     "Verify BLTDevIK octstr, BLTCSSecurityLevel (BLTCSSecurityLevelEnum), "
+                     "BLTCSModeCapability (BLTCSModeEnum); save them."),
+            TestStep(5, test_plan_support.read_attribute("BLEDeviceID"),
+                     "Verify a uint64 value and save it."),
+            TestStep("6a", "If WFUSDPD is not supported, TH sends StartRangingRequest (WiFiRoundTripTimeRanging, "
+                     "WiFiSubscriberRole, random PeerWiFiDevIK/PMK, StartTime 0, EndTime 6).", reject),
+            TestStep("6b", "If WFUSDPD is not supported, TH sends StartRangingRequest (WiFiRoundTripTimeRanging, "
+                     "WiFiPublisherRole, random PeerWiFiDevIK/PMK, StartTime 0, EndTime 6).", reject),
+            TestStep("7a", "If BLTCS is not supported, TH sends StartRangingRequest (BluetoothChannelSounding, "
+                     "BLTInitiatorRole, random PeerBLTDevIK/LTK, highest supported security level and mode, "
+                     "StartTime 0, EndTime 6).", reject),
+            TestStep("7b", "If BLTCS is not supported, TH sends StartRangingRequest (BluetoothChannelSounding, "
+                     "BLTReflectorRole, random PeerBLTDevIK/LTK, highest supported security level and mode, "
+                     "StartTime 0, EndTime 6).", reject),
+            TestStep("8a", "If BLERBC is not supported, TH sends StartRangingRequest (BLEBeaconRSSIRanging, "
+                     "BLEScanningRole, random PeerBLEDeviceID, BLEDeviceIDObfuscation, octstr SessionKey, "
+                     "StartTime 0, EndTime 6).", reject),
+            TestStep("8b", "If BLERBC is not supported, TH sends StartRangingRequest (BLEBeaconRSSIRanging, "
+                     "BLEBeaconRole, random PeerBLEDeviceID, BLEDeviceIDObfuscation, octstr SessionKey, "
+                     "StartTime 0, EndTime 6).", reject),
+        ]
+
+    @run_if_endpoint_matches(has_cluster(Clusters.ProximityRanging))
+    async def test_TC_PROXR_2_2(self):
+        endpoint = self.get_endpoint()
+        feature_map = await self.read_feature_map()
+        wifi = bool(feature_map & Feature.kWiFiUsdProximityDetection)
+        blt = bool(feature_map & Feature.kBluetoothChannelSounding)
+        ble = bool(feature_map & Feature.kBleBeaconRssi)
+
+        self.step(1)
+
+        self.step(2)
+        caps = await self.read_proxr_attribute(_PROXR.Attributes.RangingCapabilities)
+        matter_asserts.assert_list(caps, "RangingCapabilities", min_length=1)
+
+        self.step(3)
+        if await self.feature_guard(endpoint, _PROXR, Feature.kWiFiUsdProximityDetection):
+            wifi_ik = await self.read_proxr_attribute(_PROXR.Attributes.WiFiDevIK)
+            matter_asserts.assert_is_octstr(wifi_ik, "WiFiDevIK")
+
+        self.step(4)
+        if await self.feature_guard(endpoint, _PROXR, Feature.kBluetoothChannelSounding):
+            blt_ik = await self.read_proxr_attribute(_PROXR.Attributes.BLTDevIK)
+            matter_asserts.assert_is_octstr(blt_ik, "BLTDevIK")
+            matter_asserts.assert_valid_enum(
+                await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel), "BLTCSSecurityLevel",
+                BLTCSSecurityLevelEnum)
+            matter_asserts.assert_valid_enum(
+                await self.read_proxr_attribute(_PROXR.Attributes.BLTCSModeCapability), "BLTCSModeCapability",
+                BLTCSModeEnum)
+
+        self.step(5)
+        if await self.feature_guard(endpoint, _PROXR, Feature.kBleBeaconRssi):
+            matter_asserts.assert_valid_uint64(
+                await self.read_proxr_attribute(_PROXR.Attributes.BLEDeviceID), "BLEDeviceID")
+
+        # Steps 6-8 are gated on the NEGATED feature PICS: they run only when the DUT
+        # does NOT support the corresponding feature (so the technology-specific role
+        # config is infeasible). The all-devices-app enables all three features, so on
+        # that app every one of these steps is correctly skipped (see DECISIONS.md).
+        rnd = self.random_secret
+
+        for step, role in [("6a", RangingRoleEnum.kWiFiSubscriberRole), ("6b", RangingRoleEnum.kWiFiPublisherRole)]:
+            if wifi:
+                self.skip_step(step)
+            else:
+                self.step(step)
+                await self.expect_start_ranging_status(
+                    self.build_wifi_request(role=role, peer_wifi_ik=rnd(DEVICE_IDENTITY_KEY_LEN), pmk=rnd(PMK_LEN)),
+                    _INFEASIBLE, endpoint=endpoint)
+
+        for step, role in [("7a", RangingRoleEnum.kBLTInitiatorRole), ("7b", RangingRoleEnum.kBLTReflectorRole)]:
+            if blt:
+                self.skip_step(step)
+            else:
+                self.step(step)
+                await self.expect_start_ranging_status(
+                    self.build_blt_request(role=role, peer_blt_ik=rnd(DEVICE_IDENTITY_KEY_LEN), ltk=rnd(LTK_LEN),
+                                           security_level=BLTCSSecurityLevelEnum.kBLTCSSecurityLevelThree,
+                                           mode=BLTCSModeEnum.kBoth),
+                    _INFEASIBLE, endpoint=endpoint)
+
+        for step, role in [("8a", RangingRoleEnum.kBLEScanningRole), ("8b", RangingRoleEnum.kBLEBeaconRole)]:
+            if ble:
+                self.skip_step(step)
+            else:
+                self.step(step)
+                await self.expect_start_ranging_status(
+                    self.build_ble_request(role=role, peer_ble_device_id=0x1122334455667788, session_key=rnd(SESSION_KEY_LEN)),
+                    _INFEASIBLE, endpoint=endpoint)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PROXR_2_3.py
+++ b/src/python_testing/TC_PROXR_2_3.py
@@ -40,15 +40,14 @@
 
 import logging
 
+from mobly import asserts
+from TC_PROXRTestBase import (LTK_LEN, PMK_LEN, SESSION_KEY_LEN, SIMULATED_RANGING_LATENCY_S, UNKNOWN_PEER_BLE_DEVICE_ID,
+                              UNKNOWN_PEER_DEV_IK, WIFI_TECHNOLOGIES, BLTCSModeEnum, Feature, ProximityRangingTestBase,
+                              RangingRoleEnum, RangingSessionStatusEnum, RangingTechEnum, StatusCodeEnum)
+
 import matter.clusters as Clusters
 import matter.testing.matter_asserts as matter_asserts
-from mobly import asserts
 from matter.clusters.Types import NullValue
-from TC_PROXRTestBase import (BLTCSModeEnum, LTK_LEN, PMK_LEN, ProximityRangingTestBase, RangingRoleEnum,
-                              RangingTechEnum, RangingSessionStatusEnum, SESSION_KEY_LEN,
-                              SIMULATED_RANGING_LATENCY_S, WIFI_TECHNOLOGIES,
-                              UNKNOWN_PEER_BLE_DEVICE_ID, UNKNOWN_PEER_DEV_IK, Feature, StatusCodeEnum)
-
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterTestCommissionedDevice
 from matter.testing.runner import TestStep, default_matter_test_main
@@ -327,6 +326,7 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
         if wifi_tech is not None:
             self.step(6)
             pmk = rnd(PMK_LEN)
+
             def _v_wifi(d):
                 self._validate_common_measurement(d)
                 asserts.assert_equal(d.wiFiDevIK, self.wifi_ik_r, "RangingResult WiFiDevIK must equal DUT_R's WiFiDevIK")
@@ -343,6 +343,7 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
         async def _blt_instant(with_mode):
             ltk = rnd(LTK_LEN)
             mode = self.blt_mode if with_mode else None
+
             def _v_blt(d):
                 self._validate_common_measurement(d)
                 asserts.assert_equal(d.BLTDevIK, self.blt_ik_r, "RangingResult BLTDevIK must equal DUT_R's BLTDevIK")
@@ -366,6 +367,7 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
         if ble_tech is not None:
             self.step(8)
             sk = rnd(SESSION_KEY_LEN)
+
             def _v_ble(d):
                 self.assert_time_of_measurement_present(d)
                 asserts.assert_equal(d.BLEDeviceID, self.ble_id_r, "RangingResult BLEDeviceID must equal DUT_R's")
@@ -424,6 +426,7 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
         if wifi_tech is not None:
             self.step("12a")
             pmk = rnd(PMK_LEN)
+
             def _v_wifi2(d):
                 self._validate_common_measurement(d)
                 asserts.assert_equal(d.wiFiDevIK, self.wifi_ik_r, "RangingResult WiFiDevIK must equal DUT_R's WiFiDevIK")
@@ -442,6 +445,7 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
         if blt_runs:
             self.step("13a")
             ltk = rnd(LTK_LEN)
+
             def _v_blt2(d):
                 self._validate_common_measurement(d)
                 asserts.assert_equal(d.BLTDevIK, self.blt_ik_r, "RangingResult BLTDevIK must equal DUT_R's BLTDevIK")
@@ -461,6 +465,7 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
         if ble_tech is not None:
             self.step("14a")
             sk = rnd(SESSION_KEY_LEN)
+
             def _v_ble2(d):
                 self.assert_time_of_measurement_present(d)
                 asserts.assert_equal(d.BLEDeviceID, self.ble_id_r, "RangingResult BLEDeviceID must equal DUT_R's")

--- a/src/python_testing/TC_PROXR_2_3.py
+++ b/src/python_testing/TC_PROXR_2_3.py
@@ -508,11 +508,16 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
         # reject" Expected Outcome in steps 15/17 is correct. See DECISIONS.md.
         if wifi_tech is not None:
             self.step(15)
+            # One PMK shared by both requests of the pair, as in every other step:
+            # the plan requires the PMK be "a random number common for both DUT_I
+            # and DUT_R". Two independent rnd() calls here would hand the peers
+            # different credentials.
+            pmk = rnd(PMK_LEN)
             await self._expect_both_infeasible(
                 self.build_wifi_request(role=RangingRoleEnum.kWiFiSubscriberRole, peer_wifi_ik=self.wifi_ik_r,
-                                        pmk=rnd(PMK_LEN), min_distance=1000, max_distance=1, technology=wifi_tech),
+                                        pmk=pmk, min_distance=1000, max_distance=1, technology=wifi_tech),
                 self.build_wifi_request(role=RangingRoleEnum.kWiFiPublisherRole, peer_wifi_ik=self.wifi_ik_i,
-                                        pmk=rnd(PMK_LEN), min_distance=1000, max_distance=1, technology=wifi_tech))
+                                        pmk=pmk, min_distance=1000, max_distance=1, technology=wifi_tech))
         else:
             self._skip(15, wifi_reason)
 

--- a/src/python_testing/TC_PROXR_2_3.py
+++ b/src/python_testing/TC_PROXR_2_3.py
@@ -1,0 +1,522 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device proximity-ranger:1 --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --endpoint 1
+#       --string-arg th_reflector_app_path:${ALL_DEVICES_APP}
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+#     timeout: 900
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+import matter.clusters as Clusters
+import matter.testing.matter_asserts as matter_asserts
+from mobly import asserts
+from matter.clusters.Types import NullValue
+from TC_PROXRTestBase import (BLTCSModeEnum, LTK_LEN, PMK_LEN, ProximityRangingTestBase, RangingRoleEnum,
+                              RangingTechEnum, RangingSessionStatusEnum, SESSION_KEY_LEN,
+                              SIMULATED_RANGING_LATENCY_S, WIFI_TECHNOLOGIES,
+                              UNKNOWN_PEER_BLE_DEVICE_ID, UNKNOWN_PEER_DEV_IK, Feature, StatusCodeEnum)
+
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterTestCommissionedDevice
+from matter.testing.runner import TestStep, default_matter_test_main
+
+logger = logging.getLogger(__name__)
+
+_PROXR = Clusters.ProximityRanging
+_INSTANT_END_TIME_S = 6
+# EndTime (6 s) + measurement latency (3 s) plus generous slack for CI scheduling.
+_EVENT_TIMEOUT_S = _INSTANT_END_TIME_S + SIMULATED_RANGING_LATENCY_S + 15
+
+
+class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
+    # SessionIDList mutates as sessions start/stop; the background wildcard
+    # subscription (primary DUT only) cannot track it and does not cover the
+    # reflector node, so it is disabled for this test.
+    disable_wildcard_subscription = True
+
+    @property
+    def default_timeout(self) -> int:
+        # Instant ranging drives many sequential ~6-9 s event waits across three
+        # technologies and two devices; the 90 s default is not enough.
+        return 600
+
+    def setup_class(self):
+        super().setup_class()
+        self.setup_reflector_device()
+
+    def teardown_class(self):
+        self.teardown_reflector_device()
+        super().teardown_class()
+
+    def desc_TC_PROXR_2_3(self) -> str:
+        return "[TC-PROXR-2.3] Instant Proximity Ranging Functionality (DUT as Server)"
+
+    def pics_TC_PROXR_2_3(self) -> list[str]:
+        return ["PROXR.S"]
+
+    def steps_TC_PROXR_2_3(self) -> list[TestStep]:
+        resp = "Verify both DUT_I and DUT_R respond with a StartRangingResponse whose SessionID is a non-zero uint8; save both."
+        return [
+            TestStep(1, "Commission DUT_I and DUT_R to TH", is_commissioning=True),
+            TestStep(2, "TH reads RangingCapabilities from DUT_I and DUT_R",
+                     "Verify both respond with a list of RangingCapabilitiesStruct and save the elements."),
+            TestStep(3, "TH reads WiFiDevIK from DUT_I and DUT_R", "Verify octstr values and save both."),
+            TestStep(4, "TH reads BLTDevIK, BLTCSSecurityLevel, BLTCSModeCapability from DUT_I and DUT_R",
+                     "Verify octstr/enum values and save all."),
+            TestStep(5, "TH reads BLEDeviceID from DUT_I and DUT_R", "Verify uint64 values and save both."),
+            TestStep(6, "TH sends StartRangingRequest (WiFiRoundTripTimeRanging) to DUT_I (WiFiSubscriberRole, "
+                     "PeerWiFiDevIK=DUT_R's WiFiDevIK) and DUT_R (WiFiPublisherRole, PeerWiFiDevIK=DUT_I's WiFiDevIK), "
+                     "common PMK, StartTime 0, EndTime 6.",
+                     resp + " Verify DUT_I sends RangingResult (SessionID matches, WiFiDevIK equals DUT_R's WiFiDevIK, "
+                     "Distance is uint16). Verify DUT_R sends RangingSessionStatus SessionEndTimeReached."),
+            TestStep("7a", "TH sends StartRangingRequest (BluetoothChannelSounding) to DUT_I (BLTInitiatorRole) and "
+                     "DUT_R (BLTReflectorRole) with peer BLTDevIKs crossed, common LTK, highest common security level "
+                     "and mode, StartTime 0, EndTime 6.",
+                     resp + " Verify DUT_I sends RangingResult (BLTDevIK equals DUT_R's, Distance is uint16). "
+                     "Verify DUT_R sends RangingSessionStatus SessionEndTimeReached."),
+            TestStep("7b", "Repeat 7a without the BLTCSMode field in the role config.",
+                     resp + " Verify DUT_I sends RangingResult and DUT_R sends RangingSessionStatus "
+                     "SessionEndTimeReached."),
+            TestStep(8, "TH sends StartRangingRequest (BLEBeaconRSSIRanging) to DUT_I (BLEScanningRole) and DUT_R "
+                     "(BLEBeaconRole) with peer BLEDeviceIDs crossed, BLEDeviceIDObfuscation, common SessionKey, "
+                     "StartTime 0, EndTime 6.",
+                     resp + " Verify DUT_I sends RangingResult (BLEDeviceID equals DUT_R's, RSSI and TxPower are int8). "
+                     "Verify DUT_R sends RangingSessionStatus SessionEndTimeReached."),
+            TestStep(9, "TH sends StartRangingRequest (WiFiRoundTripTimeRanging) to DUT_I with PeerWiFiDevIK set to a "
+                     "value different from DUT_R's WiFiDevIK (the unknown-peer sentinel), and to DUT_R normally.",
+                     resp + " Verify DUT_I sends RangingSessionStatus with Status PeerNotFound."),
+            TestStep(10, "TH sends StartRangingRequest (BluetoothChannelSounding) to DUT_I with PeerBLTDevIK different "
+                     "from DUT_R's (unknown-peer sentinel), and to DUT_R normally.",
+                     resp + " Verify DUT_I sends RangingSessionStatus with Status PeerNotFound."),
+            TestStep(11, "TH sends StartRangingRequest (BLEBeaconRSSIRanging) to DUT_I with PeerBLEDeviceID different "
+                     "from DUT_R's (unknown-peer sentinel), and to DUT_R normally.",
+                     resp + " Verify DUT_I sends RangingSessionStatus with Status PeerNotFound."),
+            TestStep("12a", "TH sends StartRangingRequest (WiFiRoundTripTimeRanging) to DUT_I with a ReportingCondition "
+                     "of MinDistanceCondition 1 cm and MaxDistanceCondition 1000 cm, and to DUT_R normally.",
+                     resp + " Verify DUT_I sends a RangingResult (Distance is uint16)."),
+            TestStep("12b", "TH reads SessionIDList from DUT_I and DUT_R after EndTime has passed.",
+                     "Verify neither list includes the expired SessionID."),
+            TestStep("13a", "TH sends StartRangingRequest (BluetoothChannelSounding) to DUT_I with a ReportingCondition "
+                     "of MinDistanceCondition 1 cm and MaxDistanceCondition 1000 cm, and to DUT_R normally.",
+                     resp + " Verify DUT_I sends a RangingResult (Distance is uint16)."),
+            TestStep("13b", "TH reads SessionIDList from DUT_I and DUT_R after EndTime has passed.",
+                     "Verify neither list includes the expired SessionID."),
+            TestStep("14a", "TH sends StartRangingRequest (BLEBeaconRSSIRanging) to DUT_I with a ReportingCondition of "
+                     "MinDistanceCondition 1 cm and MaxDistanceCondition 1000 cm, and to DUT_R normally.",
+                     resp + " Verify DUT_I sends a RangingResult (RSSI and TxPower are int8). The BLE Beacon frame "
+                     "format check is not observable over the Matter interaction (see DECISIONS.md)."),
+            TestStep("14b", "TH reads SessionIDList from DUT_I and DUT_R after EndTime has passed.",
+                     "Verify neither list includes the expired SessionID."),
+            TestStep(15, "TH sends StartRangingRequest (WiFiRoundTripTimeRanging) to DUT_I and DUT_R, both with a "
+                     "ReportingCondition of MinDistanceCondition 1000 cm and MaxDistanceCondition 1 cm.",
+                     "Verify both DUT_I and DUT_R respond with status RejectedInfeasibleRanging, and DUT_I does not "
+                     "send a RangingResult."),
+            TestStep(16, "TH sends StartRangingRequest (BluetoothChannelSounding) to DUT_I and DUT_R, both with a "
+                     "ReportingCondition of MinDistanceCondition 1000 cm and MaxDistanceCondition 1 cm.",
+                     "Verify both DUT_I and DUT_R respond with status RejectedInfeasibleRanging, and DUT_I does not "
+                     "send a RangingResult."),
+            TestStep(17, "TH sends StartRangingRequest (BLEBeaconRSSIRanging) to DUT_I and DUT_R, both with a "
+                     "ReportingCondition of MinDistanceCondition 1000 cm and MaxDistanceCondition 1 cm.",
+                     "Verify both DUT_I and DUT_R respond with status RejectedInfeasibleRanging, and DUT_I does not "
+                     "send a RangingResult."),
+        ]
+
+    # ---- assertions / helpers -------------------------------------------------
+
+    def _assert_session_id(self, session_id):
+        matter_asserts.assert_valid_uint8(session_id, "SessionID")
+        asserts.assert_not_equal(session_id, 0, "SessionID must be non-zero")
+
+    def _validate_common_measurement(self, data):
+        asserts.assert_false(data.distance is NullValue, "Distance must not be null")
+        matter_asserts.assert_valid_uint16(data.distance, "Distance")
+        # The plan requires every RangingResult to carry TimeOfMeasurement or
+        # TimeOfMeasurementOffset; this is a hard requirement (see the shared
+        # helper). The reference all-devices-app reports a deterministic
+        # TimeOfMeasurementOffset (LoggingRangingAdapter.cpp BuildMeasurement).
+        self.assert_time_of_measurement_present(data)
+
+    async def _instant_pair(self, cmd_i, cmd_r, validate_result):
+        """Run one instant-ranging exchange: send to both DUTs, verify DUT_I's
+        RangingResult and DUT_R's SessionEndTimeReached. Returns (resp_i, resp_r)."""
+        cb_i = await self.subscribe_proxr_events(self.dut_node_id)
+        cb_r = await self.subscribe_proxr_events(self.reflector_node_id)
+        try:
+            resp_i = await self.send_start_ranging(cmd_i, node_id=self.dut_node_id)
+            resp_r = await self.send_start_ranging(cmd_r, node_id=self.reflector_node_id)
+            self._assert_session_id(resp_i.sessionID)
+            self._assert_session_id(resp_r.sessionID)
+
+            result = self.wait_ranging_result(cb_i, resp_i.sessionID, _EVENT_TIMEOUT_S)
+            validate_result(result.rangingResultData)
+
+            status = self.wait_session_status(cb_r, resp_r.sessionID, _EVENT_TIMEOUT_S)
+            asserts.assert_equal(status.status, RangingSessionStatusEnum.kSessionEndTimeReached,
+                                 "DUT_R must report SessionEndTimeReached")
+            return resp_i, resp_r
+        finally:
+            cb_i.cancel()
+            cb_r.cancel()
+
+    async def _peer_not_found(self, cmd_i, cmd_r):
+        cb_i = await self.subscribe_proxr_events(self.dut_node_id)
+        cb_r = await self.subscribe_proxr_events(self.reflector_node_id)
+        try:
+            resp_i = await self.send_start_ranging(cmd_i, node_id=self.dut_node_id)
+            resp_r = await self.send_start_ranging(cmd_r, node_id=self.reflector_node_id)
+            self._assert_session_id(resp_i.sessionID)
+            self._assert_session_id(resp_r.sessionID)
+            status = self.wait_session_status(cb_i, resp_i.sessionID, _EVENT_TIMEOUT_S)
+            asserts.assert_equal(status.status, RangingSessionStatusEnum.kPeerNotFound,
+                                 "DUT_I must report PeerNotFound for an unknown peer")
+        finally:
+            cb_i.cancel()
+            cb_r.cancel()
+
+    async def _expect_both_infeasible(self, cmd_i, cmd_r):
+        """Steps 15/16/17: BOTH DUT_I and DUT_R receive a StartRangingRequest
+        carrying the infeasible ReportingCondition (MinDistanceCondition 1000 cm >
+        MaxDistanceCondition 1 cm), so BOTH must reject it with
+        RejectedInfeasibleRanging, and DUT_I must emit no RangingResult.
+
+        The plan's procedure column omits the ReportingCondition from the DUT_R
+        request in all three steps; that is a copy-paste error in the procedure,
+        not in the Expected Outcome (human ruling, see DECISIONS.md). The Expected
+        Outcome for steps 15 and 17 -- "both DUT_I and DUT_R respond with ...
+        RejectedInfeasibleRanging" -- is therefore the CORRECT expectation, and it
+        is step 16's "only DUT_I" wording that should be widened to both.
+
+        No session is ever created here (both requests are rejected), so there is
+        nothing to clean up."""
+        cb_i = await self.subscribe_proxr_events(self.dut_node_id)
+        try:
+            await self.expect_start_ranging_status(cmd_i, StatusCodeEnum.kRejectedInfeasibleRanging,
+                                                   node_id=self.dut_node_id)
+            await self.expect_start_ranging_status(cmd_r, StatusCodeEnum.kRejectedInfeasibleRanging,
+                                                   node_id=self.reflector_node_id)
+            cb_i.wait_for_event_expect_no_report(timeout_sec=SIMULATED_RANGING_LATENCY_S + 2)
+        finally:
+            cb_i.cancel()
+
+    async def _assert_sessions_gone(self, session_i, session_r):
+        i_list = await self.read_session_id_list(node_id=self.dut_node_id)
+        r_list = await self.read_session_id_list(node_id=self.reflector_node_id)
+        asserts.assert_not_in(session_i, i_list, "Expired DUT_I SessionID must not be in SessionIDList")
+        asserts.assert_not_in(session_r, r_list, "Expired DUT_R SessionID must not be in SessionIDList")
+
+    def _skip(self, step_id, reason):
+        logger.info("Skipping step %s: %s", step_id, reason)
+        self.skip_step(step_id)
+
+    @run_if_endpoint_matches(has_cluster(Clusters.ProximityRanging))
+    async def test_TC_PROXR_2_3(self):
+        self.endpoint = self.get_endpoint()
+        rnd = self.random_secret
+
+        self.step(1)
+        await self.commission_reflector()
+
+        self.step(2)
+        caps_i = await self.read_proxr_attribute(_PROXR.Attributes.RangingCapabilities, node_id=self.dut_node_id)
+        caps_r = await self.read_proxr_attribute(_PROXR.Attributes.RangingCapabilities, node_id=self.reflector_node_id)
+        matter_asserts.assert_list(caps_i, "DUT_I RangingCapabilities", min_length=1)
+        matter_asserts.assert_list(caps_r, "DUT_R RangingCapabilities", min_length=1)
+
+        # A technology block runs only when BOTH DUTs support it. Read each DUT's
+        # FeatureMap directly (feature_guard evaluates only the primary DUT) and
+        # negotiate, per feature family, the technology common to DUT_I and DUT_R
+        # plus the initiator/responder role support the plan requires. Skipped
+        # blocks are logged with an explicit reason.
+        fmap_i = await self.read_feature_map(node_id=self.dut_node_id)
+        fmap_r = await self.read_feature_map(node_id=self.reflector_node_id)
+        wifi_tech, wifi_reason = self.negotiate_block(
+            caps_i=caps_i, caps_r=caps_r, fmap_i=fmap_i, fmap_r=fmap_r,
+            feature_bit=Feature.kWiFiUsdProximityDetection, candidate_technologies=WIFI_TECHNOLOGIES)
+        blt_tech, blt_reason = self.negotiate_block(
+            caps_i=caps_i, caps_r=caps_r, fmap_i=fmap_i, fmap_r=fmap_r,
+            feature_bit=Feature.kBluetoothChannelSounding,
+            candidate_technologies=(RangingTechEnum.kBluetoothChannelSounding,))
+        ble_tech, ble_reason = self.negotiate_block(
+            caps_i=caps_i, caps_r=caps_r, fmap_i=fmap_i, fmap_r=fmap_r,
+            feature_bit=Feature.kBleBeaconRssi, candidate_technologies=(RangingTechEnum.kBLEBeaconRSSIRanging,))
+
+        # ---- Step 3: WiFi identities ----
+        if wifi_tech is not None:
+            self.step(3)
+            self.wifi_ik_i = await self.read_proxr_attribute(_PROXR.Attributes.WiFiDevIK, node_id=self.dut_node_id)
+            self.wifi_ik_r = await self.read_proxr_attribute(_PROXR.Attributes.WiFiDevIK, node_id=self.reflector_node_id)
+            matter_asserts.assert_is_octstr(self.wifi_ik_i, "DUT_I WiFiDevIK")
+            matter_asserts.assert_is_octstr(self.wifi_ik_r, "DUT_R WiFiDevIK")
+        else:
+            self._skip(3, wifi_reason)
+
+        # ---- Step 4: BLTCS identities, security level, negotiated mode ----
+        self.blt_mode = None
+        if blt_tech is not None:
+            self.step(4)
+            self.blt_ik_i = await self.read_proxr_attribute(_PROXR.Attributes.BLTDevIK, node_id=self.dut_node_id)
+            self.blt_ik_r = await self.read_proxr_attribute(_PROXR.Attributes.BLTDevIK, node_id=self.reflector_node_id)
+            matter_asserts.assert_is_octstr(self.blt_ik_i, "DUT_I BLTDevIK")
+            matter_asserts.assert_is_octstr(self.blt_ik_r, "DUT_R BLTDevIK")
+            # BLTCSSecurityLevel: min() of the two devices' reported values, read
+            # as "the highest level supported by both". This assumes the levels
+            # are totally ordered AND that a device supports every level at or
+            # below its reported maximum -- an assumption the plan does not state.
+            level_i = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel, node_id=self.dut_node_id)
+            level_r = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel, node_id=self.reflector_node_id)
+            self.blt_level = min(level_i, level_r)
+            # BLTCSMode: negotiate a mode supported by BOTH devices from their
+            # BLTCSModeCapability values (the plan's "a mode supported by both").
+            mode_i = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSModeCapability, node_id=self.dut_node_id)
+            mode_r = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSModeCapability, node_id=self.reflector_node_id)
+            matter_asserts.assert_valid_enum(mode_i, "DUT_I BLTCSModeCapability", BLTCSModeEnum)
+            matter_asserts.assert_valid_enum(mode_r, "DUT_R BLTCSModeCapability", BLTCSModeEnum)
+            self.blt_mode = self.negotiate_bltcs_mode(mode_i, mode_r)
+        else:
+            self._skip(4, blt_reason)
+
+        # BLTCS ranging additionally needs a mode both devices support.
+        if blt_tech is not None and self.blt_mode is None:
+            blt_reason = "DUT_I and DUT_R BLTCSModeCapability values do not intersect"
+        blt_runs = blt_tech is not None and self.blt_mode is not None
+
+        # ---- Step 5: BLE identities ----
+        if ble_tech is not None:
+            self.step(5)
+            self.ble_id_i = await self.read_proxr_attribute(_PROXR.Attributes.BLEDeviceID, node_id=self.dut_node_id)
+            self.ble_id_r = await self.read_proxr_attribute(_PROXR.Attributes.BLEDeviceID, node_id=self.reflector_node_id)
+            matter_asserts.assert_valid_uint64(self.ble_id_i, "DUT_I BLEDeviceID")
+            matter_asserts.assert_valid_uint64(self.ble_id_r, "DUT_R BLEDeviceID")
+        else:
+            self._skip(5, ble_reason)
+
+        # ---- Step 6: WiFi instant, happy path ----
+        if wifi_tech is not None:
+            self.step(6)
+            pmk = rnd(PMK_LEN)
+            def _v_wifi(d):
+                self._validate_common_measurement(d)
+                asserts.assert_equal(d.wiFiDevIK, self.wifi_ik_r, "RangingResult WiFiDevIK must equal DUT_R's WiFiDevIK")
+            await self._instant_pair(
+                self.build_wifi_request(role=RangingRoleEnum.kWiFiSubscriberRole, peer_wifi_ik=self.wifi_ik_r,
+                                        pmk=pmk, technology=wifi_tech),
+                self.build_wifi_request(role=RangingRoleEnum.kWiFiPublisherRole, peer_wifi_ik=self.wifi_ik_i,
+                                        pmk=pmk, technology=wifi_tech),
+                _v_wifi)
+        else:
+            self._skip(6, wifi_reason)
+
+        # ---- Step 7a/7b: BLTCS instant, happy path (7b repeats without BLTCSMode) ----
+        async def _blt_instant(with_mode):
+            ltk = rnd(LTK_LEN)
+            mode = self.blt_mode if with_mode else None
+            def _v_blt(d):
+                self._validate_common_measurement(d)
+                asserts.assert_equal(d.BLTDevIK, self.blt_ik_r, "RangingResult BLTDevIK must equal DUT_R's BLTDevIK")
+            await self._instant_pair(
+                self.build_blt_request(role=RangingRoleEnum.kBLTInitiatorRole, peer_blt_ik=self.blt_ik_r, ltk=ltk,
+                                       security_level=self.blt_level, mode=mode),
+                self.build_blt_request(role=RangingRoleEnum.kBLTReflectorRole, peer_blt_ik=self.blt_ik_i, ltk=ltk,
+                                       security_level=self.blt_level, mode=mode),
+                _v_blt)
+
+        if blt_runs:
+            self.step("7a")
+            await _blt_instant(with_mode=True)
+            self.step("7b")
+            await _blt_instant(with_mode=False)
+        else:
+            self._skip("7a", blt_reason)
+            self._skip("7b", blt_reason)
+
+        # ---- Step 8: BLE instant, happy path ----
+        if ble_tech is not None:
+            self.step(8)
+            sk = rnd(SESSION_KEY_LEN)
+            def _v_ble(d):
+                self.assert_time_of_measurement_present(d)
+                asserts.assert_equal(d.BLEDeviceID, self.ble_id_r, "RangingResult BLEDeviceID must equal DUT_R's")
+                asserts.assert_false(d.rssi is None or d.rssi is NullValue, "RSSI must be present")
+                matter_asserts.assert_valid_int8(d.rssi, "RSSI")
+                asserts.assert_false(d.txPower is None or d.txPower is NullValue, "TxPower must be present")
+                matter_asserts.assert_valid_int8(d.txPower, "TxPower")
+            await self._instant_pair(
+                self.build_ble_request(role=RangingRoleEnum.kBLEScanningRole, peer_ble_device_id=self.ble_id_r,
+                                       session_key=sk),
+                self.build_ble_request(role=RangingRoleEnum.kBLEBeaconRole, peer_ble_device_id=self.ble_id_i,
+                                       session_key=sk),
+                _v_ble)
+        else:
+            self._skip(8, ble_reason)
+
+        # ---- Steps 9/10/11: PeerNotFound ----
+        # Only DUT_I's request carries the unknown-peer sentinel; DUT_R is configured
+        # normally with DUT_I's real identity, as the step procedure states. Giving
+        # DUT_R the sentinel too would observe PeerNotFound against a pair where
+        # neither side knows the other, which is not the scenario under test.
+        if wifi_tech is not None:
+            self.step(9)
+            pmk = rnd(PMK_LEN)
+            await self._peer_not_found(
+                self.build_wifi_request(role=RangingRoleEnum.kWiFiSubscriberRole, peer_wifi_ik=UNKNOWN_PEER_DEV_IK,
+                                        pmk=pmk, technology=wifi_tech),
+                self.build_wifi_request(role=RangingRoleEnum.kWiFiPublisherRole, peer_wifi_ik=self.wifi_ik_i,
+                                        pmk=pmk, technology=wifi_tech))
+        else:
+            self._skip(9, wifi_reason)
+
+        if blt_runs:
+            self.step(10)
+            ltk = rnd(LTK_LEN)
+            await self._peer_not_found(
+                self.build_blt_request(role=RangingRoleEnum.kBLTInitiatorRole, peer_blt_ik=UNKNOWN_PEER_DEV_IK, ltk=ltk,
+                                       security_level=self.blt_level, mode=self.blt_mode),
+                self.build_blt_request(role=RangingRoleEnum.kBLTReflectorRole, peer_blt_ik=self.blt_ik_i, ltk=ltk,
+                                       security_level=self.blt_level, mode=self.blt_mode))
+        else:
+            self._skip(10, blt_reason)
+
+        if ble_tech is not None:
+            self.step(11)
+            sk = rnd(SESSION_KEY_LEN)
+            await self._peer_not_found(
+                self.build_ble_request(role=RangingRoleEnum.kBLEScanningRole,
+                                       peer_ble_device_id=UNKNOWN_PEER_BLE_DEVICE_ID, session_key=sk),
+                self.build_ble_request(role=RangingRoleEnum.kBLEBeaconRole,
+                                       peer_ble_device_id=self.ble_id_i, session_key=sk))
+        else:
+            self._skip(11, ble_reason)
+
+        # ---- Steps 12/13/14: permissive ReportingCondition -> RangingResult, then session cleanup ----
+        if wifi_tech is not None:
+            self.step("12a")
+            pmk = rnd(PMK_LEN)
+            def _v_wifi2(d):
+                self._validate_common_measurement(d)
+                asserts.assert_equal(d.wiFiDevIK, self.wifi_ik_r, "RangingResult WiFiDevIK must equal DUT_R's WiFiDevIK")
+            resp_i, resp_r = await self._instant_pair(
+                self.build_wifi_request(role=RangingRoleEnum.kWiFiSubscriberRole, peer_wifi_ik=self.wifi_ik_r, pmk=pmk,
+                                        min_distance=1, max_distance=1000, technology=wifi_tech),
+                self.build_wifi_request(role=RangingRoleEnum.kWiFiPublisherRole, peer_wifi_ik=self.wifi_ik_i, pmk=pmk,
+                                        technology=wifi_tech),
+                _v_wifi2)
+            self.step("12b")
+            await self._assert_sessions_gone(resp_i.sessionID, resp_r.sessionID)
+        else:
+            self._skip("12a", wifi_reason)
+            self._skip("12b", wifi_reason)
+
+        if blt_runs:
+            self.step("13a")
+            ltk = rnd(LTK_LEN)
+            def _v_blt2(d):
+                self._validate_common_measurement(d)
+                asserts.assert_equal(d.BLTDevIK, self.blt_ik_r, "RangingResult BLTDevIK must equal DUT_R's BLTDevIK")
+            resp_i, resp_r = await self._instant_pair(
+                self.build_blt_request(role=RangingRoleEnum.kBLTInitiatorRole, peer_blt_ik=self.blt_ik_r, ltk=ltk,
+                                       security_level=self.blt_level, mode=self.blt_mode,
+                                       min_distance=1, max_distance=1000),
+                self.build_blt_request(role=RangingRoleEnum.kBLTReflectorRole, peer_blt_ik=self.blt_ik_i, ltk=ltk,
+                                       security_level=self.blt_level, mode=self.blt_mode),
+                _v_blt2)
+            self.step("13b")
+            await self._assert_sessions_gone(resp_i.sessionID, resp_r.sessionID)
+        else:
+            self._skip("13a", blt_reason)
+            self._skip("13b", blt_reason)
+
+        if ble_tech is not None:
+            self.step("14a")
+            sk = rnd(SESSION_KEY_LEN)
+            def _v_ble2(d):
+                self.assert_time_of_measurement_present(d)
+                asserts.assert_equal(d.BLEDeviceID, self.ble_id_r, "RangingResult BLEDeviceID must equal DUT_R's")
+                matter_asserts.assert_valid_int8(d.rssi, "RSSI")
+                matter_asserts.assert_valid_int8(d.txPower, "TxPower")
+            resp_i, resp_r = await self._instant_pair(
+                self.build_ble_request(role=RangingRoleEnum.kBLEScanningRole, peer_ble_device_id=self.ble_id_r,
+                                       session_key=sk, min_distance=1, max_distance=1000),
+                self.build_ble_request(role=RangingRoleEnum.kBLEBeaconRole, peer_ble_device_id=self.ble_id_i,
+                                       session_key=sk),
+                _v_ble2)
+            self.step("14b")
+            await self._assert_sessions_gone(resp_i.sessionID, resp_r.sessionID)
+        else:
+            self._skip("14a", ble_reason)
+            self._skip("14b", ble_reason)
+
+        # ---- Steps 15/16/17: BOTH DUTs get the infeasible ReportingCondition
+        # (min 1000 cm > max 1 cm) and BOTH must reject with RejectedInfeasibleRanging;
+        # DUT_I must emit no RangingResult. The plan's procedure column omits the
+        # ReportingCondition from the DUT_R request (copy-paste error); the "both
+        # reject" Expected Outcome in steps 15/17 is correct. See DECISIONS.md.
+        if wifi_tech is not None:
+            self.step(15)
+            await self._expect_both_infeasible(
+                self.build_wifi_request(role=RangingRoleEnum.kWiFiSubscriberRole, peer_wifi_ik=self.wifi_ik_r,
+                                        pmk=rnd(PMK_LEN), min_distance=1000, max_distance=1, technology=wifi_tech),
+                self.build_wifi_request(role=RangingRoleEnum.kWiFiPublisherRole, peer_wifi_ik=self.wifi_ik_i,
+                                        pmk=rnd(PMK_LEN), min_distance=1000, max_distance=1, technology=wifi_tech))
+        else:
+            self._skip(15, wifi_reason)
+
+        if blt_runs:
+            self.step(16)
+            ltk = rnd(LTK_LEN)
+            await self._expect_both_infeasible(
+                self.build_blt_request(role=RangingRoleEnum.kBLTInitiatorRole, peer_blt_ik=self.blt_ik_r, ltk=ltk,
+                                       security_level=self.blt_level, mode=self.blt_mode,
+                                       min_distance=1000, max_distance=1),
+                self.build_blt_request(role=RangingRoleEnum.kBLTReflectorRole, peer_blt_ik=self.blt_ik_i, ltk=ltk,
+                                       security_level=self.blt_level, mode=self.blt_mode,
+                                       min_distance=1000, max_distance=1))
+        else:
+            self._skip(16, blt_reason)
+
+        if ble_tech is not None:
+            self.step(17)
+            sk = rnd(SESSION_KEY_LEN)
+            await self._expect_both_infeasible(
+                self.build_ble_request(role=RangingRoleEnum.kBLEScanningRole, peer_ble_device_id=self.ble_id_r,
+                                       session_key=sk, min_distance=1000, max_distance=1),
+                self.build_ble_request(role=RangingRoleEnum.kBLEBeaconRole, peer_ble_device_id=self.ble_id_i,
+                                       session_key=sk, min_distance=1000, max_distance=1))
+        else:
+            self._skip(17, ble_reason)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PROXR_2_3.py
+++ b/src/python_testing/TC_PROXR_2_3.py
@@ -42,8 +42,9 @@ import logging
 
 from mobly import asserts
 from TC_PROXRTestBase import (LTK_LEN, PMK_LEN, SESSION_KEY_LEN, SIMULATED_RANGING_LATENCY_S, UNKNOWN_PEER_BLE_DEVICE_ID,
-                              UNKNOWN_PEER_DEV_IK, WIFI_TECHNOLOGIES, BLTCSModeEnum, Feature, ProximityRangingTestBase,
-                              RangingRoleEnum, RangingSessionStatusEnum, RangingTechEnum, StatusCodeEnum)
+                              UNKNOWN_PEER_DEV_IK, WIFI_TECHNOLOGIES, BLTCSModeEnum, BLTCSSecurityLevelEnum, Feature,
+                              ProximityRangingTestBase, RangingRoleEnum, RangingSessionStatusEnum, RangingTechEnum,
+                              StatusCodeEnum)
 
 import matter.clusters as Clusters
 import matter.testing.matter_asserts as matter_asserts
@@ -201,6 +202,11 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
             status = self.wait_session_status(cb_i, resp_i.sessionID, _EVENT_TIMEOUT_S)
             asserts.assert_equal(status.status, RangingSessionStatusEnum.kPeerNotFound,
                                  "DUT_I must report PeerNotFound for an unknown peer")
+            # DUT_R received a feasible request (its peer is DUT_I's real identity),
+            # so its session runs to EndTime rather than ending on PeerNotFound. We
+            # only wait on DUT_I here, so stop DUT_R's session for hermetic cleanup;
+            # tolerate it having already self-terminated.
+            await self.stop_ranging_best_effort(resp_r.sessionID, node_id=self.reflector_node_id)
         finally:
             cb_i.cancel()
             cb_r.cancel()
@@ -296,6 +302,18 @@ class TC_PROXR_2_3(MatterTestCommissionedDevice, ProximityRangingTestBase):
             # below its reported maximum -- an assumption the plan does not state.
             level_i = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel, node_id=self.dut_node_id)
             level_r = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel, node_id=self.reflector_node_id)
+            # Validate both reported values are known enum members before taking
+            # min(). assert_valid_enum only type-checks, and the SDK coerces any
+            # out-of-range decoded value to kUnknownEnumValue (a valid member), so
+            # the type check alone is vacuous; also reject kUnknownEnumValue so an
+            # out-of-range or unknown level fails here rather than silently
+            # participating in the negotiation below.
+            matter_asserts.assert_valid_enum(level_i, "DUT_I BLTCSSecurityLevel", BLTCSSecurityLevelEnum)
+            matter_asserts.assert_valid_enum(level_r, "DUT_R BLTCSSecurityLevel", BLTCSSecurityLevelEnum)
+            asserts.assert_not_equal(level_i, BLTCSSecurityLevelEnum.kUnknownEnumValue,
+                                     "DUT_I BLTCSSecurityLevel must be a known (in-range) value")
+            asserts.assert_not_equal(level_r, BLTCSSecurityLevelEnum.kUnknownEnumValue,
+                                     "DUT_R BLTCSSecurityLevel must be a known (in-range) value")
             self.blt_level = min(level_i, level_r)
             # BLTCSMode: negotiate a mode supported by BOTH devices from their
             # BLTCSModeCapability values (the plan's "a mode supported by both").

--- a/src/python_testing/TC_PROXR_2_3.py
+++ b/src/python_testing/TC_PROXR_2_3.py
@@ -43,8 +43,7 @@ import logging
 from mobly import asserts
 from TC_PROXRTestBase import (LTK_LEN, PMK_LEN, SESSION_KEY_LEN, SIMULATED_RANGING_LATENCY_S, UNKNOWN_PEER_BLE_DEVICE_ID,
                               UNKNOWN_PEER_DEV_IK, WIFI_TECHNOLOGIES, BLTCSModeEnum, BLTCSSecurityLevelEnum, Feature,
-                              ProximityRangingTestBase, RangingRoleEnum, RangingSessionStatusEnum, RangingTechEnum,
-                              StatusCodeEnum)
+                              ProximityRangingTestBase, RangingRoleEnum, RangingSessionStatusEnum, RangingTechEnum, StatusCodeEnum)
 
 import matter.clusters as Clusters
 import matter.testing.matter_asserts as matter_asserts

--- a/src/python_testing/TC_PROXR_2_4.py
+++ b/src/python_testing/TC_PROXR_2_4.py
@@ -1,0 +1,428 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device proximity-ranger:1 --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --endpoint 1
+#       --string-arg th_reflector_app_path:${ALL_DEVICES_APP}
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+#     timeout: 900
+# === END CI TEST ARGUMENTS ===
+
+import asyncio
+import logging
+import time
+
+import matter.clusters as Clusters
+import matter.testing.matter_asserts as matter_asserts
+from mobly import asserts
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError, Status
+from TC_PROXRTestBase import (BLTCSModeEnum, Feature, LTK_LEN, PMK_LEN, ProximityRangingTestBase, RangingRoleEnum,
+                              RangingTechEnum, SESSION_KEY_LEN, SIMULATED_RANGING_LATENCY_S, WIFI_TECHNOLOGIES)
+
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterTestCommissionedDevice
+from matter.testing.runner import TestStep, default_matter_test_main
+
+logger = logging.getLogger(__name__)
+
+_PROXR = Clusters.ProximityRanging
+_PERIODIC_INTERVAL_S = 3
+_PERIODIC_END_TIME_S = 600
+# Cadence bounds: the plan requires a RangingResult "once every approximately 3 s
+# within a +/- 3 s deviation". Taken arithmetically that upper tolerance gives a
+# 6 s ceiling, which is what _PERIODIC_INTERVAL_MAX_S enforces.
+#
+# The lower bound is NOT interval - tolerance. That would be 0 s, and an
+# assert_greater_equal(gap, 0) against a monotonic clock can never fail, so a
+# device that emitted every result back-to-back would pass a check whose whole
+# purpose is to verify a ~3 s cadence. The plan states a symmetric deviation
+# around 3 s; it nowhere states that gaps at or near zero are acceptable, so the
+# floor is set to half the interval. That still admits a device running fast
+# within the plan's spirit while failing one that does not pace its results at
+# all. Both bounds are derived from the interval, not magic numbers.
+_PERIODIC_INTERVAL_TOLERANCE_S = _PERIODIC_INTERVAL_S
+_PERIODIC_INTERVAL_MIN_S = _PERIODIC_INTERVAL_S / 2
+_PERIODIC_INTERVAL_MAX_S = _PERIODIC_INTERVAL_S + _PERIODIC_INTERVAL_TOLERANCE_S
+# Collect at least three RangingResults so at least two inter-arrival intervals
+# are available for the cadence check.
+_PERIODIC_MIN_RESULTS = 3
+# The per-event wait bounds LIVENESS only (generous so CI scheduling jitter does
+# not fail the test); it deliberately does NOT enforce the cadence -- correctness
+# is bound by the inter-arrival gap assertion in _collect_and_check_cadence.
+# These are different checks.
+_PERIODIC_EVENT_TIMEOUT_S = SIMULATED_RANGING_LATENCY_S + _PERIODIC_INTERVAL_S + 12
+
+
+class TC_PROXR_2_4(MatterTestCommissionedDevice, ProximityRangingTestBase):
+    disable_wildcard_subscription = True
+
+    @property
+    def default_timeout(self) -> int:
+        # Periodic ranging collects multiple ~3 s-spaced events and waits out
+        # quiet windows after each stop; the 90 s default is not enough.
+        return 600
+
+    def setup_class(self):
+        super().setup_class()
+        self.setup_reflector_device()
+
+    def teardown_class(self):
+        self.teardown_reflector_device()
+        super().teardown_class()
+
+    def desc_TC_PROXR_2_4(self) -> str:
+        return "[TC-PROXR-2.4] Periodic Proximity Ranging Functionality (DUT as Server)"
+
+    def pics_TC_PROXR_2_4(self) -> list[str]:
+        # The plan lists a top-level {PICS_SA_PERIODIC} = PROXR.S.A0000(PeriodicRangingSupport),
+        # but PeriodicRangingSupport is a field of RangingCapabilitiesStruct (A0000), not an
+        # attribute-level PICS code. Periodic support is instead read from the device per
+        # technology (step 2) and used to gate the technology branches (see DECISIONS.md).
+        return ["PROXR.S"]
+
+    def steps_TC_PROXR_2_4(self) -> list[TestStep]:
+        def block(prefix, tech):
+            resp = ("Verify both DUT_I and DUT_R respond with a StartRangingResponse whose SessionID is a "
+                    "non-zero uint8; save both. Verify DUT_I sends a RangingResult roughly every 3 s.")
+            return [
+                TestStep(f"{prefix}a", f"TH sends periodic StartRangingRequest ({tech}) to DUT_I (active) and DUT_R "
+                         "(responder), StartTime 0, EndTime 600, RangingInstanceInterval 3.", resp),
+                TestStep(f"{prefix}b", "TH reads SessionIDList from DUT_I and DUT_R.",
+                         "Verify each list includes the corresponding SessionID."),
+                TestStep(f"{prefix}c", "TH sends StopRangingRequest to DUT_I and DUT_R with their SessionIDs.",
+                         "Verify DUT_I sends no further RangingResult."),
+                TestStep(f"{prefix}d", "TH reads SessionIDList from DUT_I and DUT_R.",
+                         "Verify neither list includes the terminated SessionID."),
+                TestStep(f"{prefix}e", f"TH sends a new periodic StartRangingRequest ({tech}) to DUT_I and DUT_R.",
+                         "Verify both respond with a non-zero uint8 SessionID that is higher than the previous one "
+                         "(or wrapped). Verify DUT_I sends a RangingResult roughly every 3 s."),
+                TestStep(f"{prefix}f", "TH reads SessionIDList from DUT_I and DUT_R.",
+                         "Verify each list includes the corresponding SessionID."),
+                TestStep(f"{prefix}g", "TH sends StopRangingRequest to DUT_I with a SessionID different from the "
+                         "active one.", "Verify DUT_I responds with status INVALID_IN_STATE."),
+                TestStep(f"{prefix}h", "TH sends StopRangingRequest to DUT_I and DUT_R with their SessionIDs.",
+                         "Verify DUT_I sends no further RangingResult."),
+            ]
+        steps = [
+            TestStep(1, "Commission DUT_I and DUT_R to TH", is_commissioning=True),
+            TestStep(2, "TH reads RangingCapabilities from DUT_I and DUT_R",
+                     "Verify both respond with a list of RangingCapabilitiesStruct; for each technology exercised "
+                     "below, PeriodicRangingSupport is true; save the elements."),
+            TestStep(3, "TH reads WiFiDevIK from DUT_I and DUT_R", "Verify octstr values and save both."),
+            TestStep(4, "TH reads BLTDevIK, BLTCSSecurityLevel, BLTCSModeCapability from DUT_I and DUT_R",
+                     "Verify octstr/enum values and save all."),
+            TestStep(5, "TH reads BLEDeviceID from DUT_I and DUT_R", "Verify uint64 values and save both."),
+        ]
+        steps += block(6, "WiFiRoundTripTimeRanging")
+        steps += block(7, "BluetoothChannelSounding")
+        steps += block(8, "BLEBeaconRSSIRanging")
+        return steps
+
+    # ---- helpers --------------------------------------------------------------
+
+    def _assert_session_id(self, session_id):
+        matter_asserts.assert_valid_uint8(session_id, "SessionID")
+        asserts.assert_not_equal(session_id, 0, "SessionID must be non-zero")
+
+    def _skip(self, step_id, reason):
+        logger.info("Skipping step %s: %s", step_id, reason)
+        self.skip_step(step_id)
+
+    async def _collect_and_check_cadence(self, cb, session_id, validate):
+        """Collect at least _PERIODIC_MIN_RESULTS RangingResults for this session,
+        timestamping each as it is dequeued, and assert every inter-arrival gap is
+        within [_PERIODIC_INTERVAL_MIN_S, _PERIODIC_INTERVAL_MAX_S]. The bounds are
+        asymmetric on purpose: the ceiling is the plan's interval + tolerance, while
+        the floor is half the interval so that a device emitting results
+        back-to-back FAILS instead of trivially satisfying a zero floor. The first
+        gap is measured between the first two ranging INSTANCES (not from session
+        start), so the stub's initial ~3 s measurement latency before the first
+        result is never counted as an interval. The per-event timeout bounds
+        liveness; this gap check is what binds the cadence's correctness."""
+        timestamps = []
+        for _ in range(_PERIODIC_MIN_RESULTS):
+            result = self.wait_ranging_result(cb, session_id, _PERIODIC_EVENT_TIMEOUT_S)
+            timestamps.append(time.monotonic())
+            validate(result.rangingResultData)
+        intervals = [later - earlier for earlier, later in zip(timestamps, timestamps[1:])]
+        asserts.assert_greater_equal(len(intervals), 2,
+                                     "Need at least two inter-arrival intervals to validate the periodic cadence")
+        for idx, gap in enumerate(intervals):
+            asserts.assert_greater_equal(
+                gap, _PERIODIC_INTERVAL_MIN_S,
+                f"Periodic RangingResult interval #{idx} was {gap:.2f}s, below the minimum "
+                f"{_PERIODIC_INTERVAL_MIN_S}s (half the {_PERIODIC_INTERVAL_S}s cadence); results are not being paced")
+            asserts.assert_less_equal(
+                gap, _PERIODIC_INTERVAL_MAX_S,
+                f"Periodic RangingResult interval #{idx} was {gap:.2f}s, above the maximum "
+                f"{_PERIODIC_INTERVAL_MAX_S}s (cadence {_PERIODIC_INTERVAL_S}s + {_PERIODIC_INTERVAL_TOLERANCE_S}s)")
+
+    async def _expect_no_more_results(self, cb):
+        # Let any measurement already in flight land, drain, then require a quiet
+        # window longer than one full ranging cadence.
+        await asyncio.sleep(SIMULATED_RANGING_LATENCY_S + 1)
+        cb.flush_events()
+        cb.wait_for_event_expect_no_report(timeout_sec=SIMULATED_RANGING_LATENCY_S + _PERIODIC_INTERVAL_S + 2)
+
+    def _assert_periodic_supported(self, caps_i, caps_r, tech):
+        """Plan step 2: for each technology exercised, PeriodicRangingSupport is
+        true. Assert it on BOTH DUT_I's and DUT_R's capability element for the
+        negotiated technology of a block that actually runs, so a DUT that claims
+        periodic support but reports false fails here rather than passing
+        vacuously."""
+        cap_i = self.capability_for_technology(caps_i, tech)
+        cap_r = self.capability_for_technology(caps_r, tech)
+        asserts.assert_true(cap_i is not None and cap_i.periodicRangingSupport,
+                            f"DUT_I must report PeriodicRangingSupport=true for {tech.name}")
+        asserts.assert_true(cap_r is not None and cap_r.periodicRangingSupport,
+                            f"DUT_R must report PeriodicRangingSupport=true for {tech.name}")
+
+    async def _run_periodic_block(self, prefix, tech, reason, make_i, make_r, validate, caps_i, caps_r):
+        step_ids = [f"{prefix}{s}" for s in "abcdefgh"]
+        if tech is None:
+            for s in step_ids:
+                self._skip(s, reason)
+            return
+
+        cb_i = await self.subscribe_proxr_events(self.dut_node_id)
+        cb_r = await self.subscribe_proxr_events(self.reflector_node_id)
+        try:
+            # a: start periodic, collect >= 3 results and check the ~3 s cadence
+            self.step(f"{prefix}a")
+            self._assert_periodic_supported(caps_i, caps_r, tech)
+            resp_i = await self.send_start_ranging(make_i(), node_id=self.dut_node_id)
+            resp_r = await self.send_start_ranging(make_r(), node_id=self.reflector_node_id)
+            self._assert_session_id(resp_i.sessionID)
+            self._assert_session_id(resp_r.sessionID)
+            await self._collect_and_check_cadence(cb_i, resp_i.sessionID, validate)
+
+            # b: SessionIDList includes both
+            self.step(f"{prefix}b")
+            asserts.assert_in(resp_i.sessionID, await self.read_session_id_list(node_id=self.dut_node_id),
+                              "DUT_I SessionIDList must include the active SessionID")
+            asserts.assert_in(resp_r.sessionID, await self.read_session_id_list(node_id=self.reflector_node_id),
+                              "DUT_R SessionIDList must include the active SessionID")
+
+            # c: stop both, no further results
+            self.step(f"{prefix}c")
+            await self.send_stop_ranging(resp_i.sessionID, node_id=self.dut_node_id)
+            await self.send_stop_ranging(resp_r.sessionID, node_id=self.reflector_node_id)
+            await self._expect_no_more_results(cb_i)
+
+            # d: SessionIDList excludes both
+            self.step(f"{prefix}d")
+            asserts.assert_not_in(resp_i.sessionID, await self.read_session_id_list(node_id=self.dut_node_id),
+                                  "DUT_I SessionIDList must not include the terminated SessionID")
+            asserts.assert_not_in(resp_r.sessionID, await self.read_session_id_list(node_id=self.reflector_node_id),
+                                  "DUT_R SessionIDList must not include the terminated SessionID")
+
+            # e: restart; new session id differs; collect >= 2 results
+            self.step(f"{prefix}e")
+            resp_i2 = await self.send_start_ranging(make_i(), node_id=self.dut_node_id)
+            resp_r2 = await self.send_start_ranging(make_r(), node_id=self.reflector_node_id)
+            self._assert_session_id(resp_i2.sessionID)
+            self._assert_session_id(resp_r2.sessionID)
+            asserts.assert_not_equal(resp_i2.sessionID, resp_i.sessionID,
+                                     "New DUT_I SessionID must differ from the previous one")
+            await self._collect_and_check_cadence(cb_i, resp_i2.sessionID, validate)
+
+            # f: SessionIDList includes both new ids
+            self.step(f"{prefix}f")
+            asserts.assert_in(resp_i2.sessionID, await self.read_session_id_list(node_id=self.dut_node_id),
+                              "DUT_I SessionIDList must include the new SessionID")
+            asserts.assert_in(resp_r2.sessionID, await self.read_session_id_list(node_id=self.reflector_node_id),
+                              "DUT_R SessionIDList must include the new SessionID")
+
+            # g: stop wrong id -> INVALID_IN_STATE
+            self.step(f"{prefix}g")
+            wrong = (resp_i2.sessionID % 255) + 1
+            if wrong == resp_i2.sessionID:
+                wrong = (wrong % 255) + 1
+            try:
+                await self.send_stop_ranging(wrong, node_id=self.dut_node_id)
+                asserts.fail("StopRangingRequest with an inactive SessionID should fail with INVALID_IN_STATE")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.InvalidInState,
+                                     "StopRangingRequest with inactive SessionID must return INVALID_IN_STATE")
+
+            # h: stop correct ids, no further results
+            self.step(f"{prefix}h")
+            await self.send_stop_ranging(resp_i2.sessionID, node_id=self.dut_node_id)
+            await self.send_stop_ranging(resp_r2.sessionID, node_id=self.reflector_node_id)
+            await self._expect_no_more_results(cb_i)
+        finally:
+            cb_i.cancel()
+            cb_r.cancel()
+
+    @run_if_endpoint_matches(has_cluster(Clusters.ProximityRanging))
+    async def test_TC_PROXR_2_4(self):
+        self.endpoint = self.get_endpoint()
+        rnd = self.random_secret
+
+        self.step(1)
+        await self.commission_reflector()
+
+        self.step(2)
+        caps_i = await self.read_proxr_attribute(_PROXR.Attributes.RangingCapabilities, node_id=self.dut_node_id)
+        caps_r = await self.read_proxr_attribute(_PROXR.Attributes.RangingCapabilities, node_id=self.reflector_node_id)
+        matter_asserts.assert_list(caps_i, "DUT_I RangingCapabilities", min_length=1)
+        matter_asserts.assert_list(caps_r, "DUT_R RangingCapabilities", min_length=1)
+
+        # Negotiate, per feature family, the technology common to DUT_I and DUT_R
+        # plus the initiator/responder role support the plan requires, reading each
+        # DUT's FeatureMap directly (feature_guard sees only the primary DUT). A
+        # periodic block additionally requires periodic support to be advertised
+        # (require_periodic); the plan's step-2 "PeriodicRangingSupport is true on
+        # both" is asserted per running block in _run_periodic_block. Blocks that
+        # skip are logged with an explicit reason.
+        fmap_i = await self.read_feature_map(node_id=self.dut_node_id)
+        fmap_r = await self.read_feature_map(node_id=self.reflector_node_id)
+        wifi_tech, wifi_reason = self.negotiate_block(
+            caps_i=caps_i, caps_r=caps_r, fmap_i=fmap_i, fmap_r=fmap_r,
+            feature_bit=Feature.kWiFiUsdProximityDetection, candidate_technologies=WIFI_TECHNOLOGIES,
+            require_periodic=True)
+        blt_tech, blt_reason = self.negotiate_block(
+            caps_i=caps_i, caps_r=caps_r, fmap_i=fmap_i, fmap_r=fmap_r,
+            feature_bit=Feature.kBluetoothChannelSounding,
+            candidate_technologies=(RangingTechEnum.kBluetoothChannelSounding,), require_periodic=True)
+        ble_tech, ble_reason = self.negotiate_block(
+            caps_i=caps_i, caps_r=caps_r, fmap_i=fmap_i, fmap_r=fmap_r,
+            feature_bit=Feature.kBleBeaconRssi, candidate_technologies=(RangingTechEnum.kBLEBeaconRSSIRanging,),
+            require_periodic=True)
+
+        # ---- Step 3: WiFi identities ----
+        if wifi_tech is not None:
+            self.step(3)
+            self.wifi_ik_i = await self.read_proxr_attribute(_PROXR.Attributes.WiFiDevIK, node_id=self.dut_node_id)
+            self.wifi_ik_r = await self.read_proxr_attribute(_PROXR.Attributes.WiFiDevIK, node_id=self.reflector_node_id)
+            matter_asserts.assert_is_octstr(self.wifi_ik_i, "DUT_I WiFiDevIK")
+            matter_asserts.assert_is_octstr(self.wifi_ik_r, "DUT_R WiFiDevIK")
+        else:
+            self._skip(3, wifi_reason)
+
+        # ---- Step 4: BLTCS identities, security level, negotiated mode ----
+        self.blt_mode = None
+        if blt_tech is not None:
+            self.step(4)
+            self.blt_ik_i = await self.read_proxr_attribute(_PROXR.Attributes.BLTDevIK, node_id=self.dut_node_id)
+            self.blt_ik_r = await self.read_proxr_attribute(_PROXR.Attributes.BLTDevIK, node_id=self.reflector_node_id)
+            matter_asserts.assert_is_octstr(self.blt_ik_i, "DUT_I BLTDevIK")
+            matter_asserts.assert_is_octstr(self.blt_ik_r, "DUT_R BLTDevIK")
+            # BLTCSSecurityLevel: min() of the two devices' reported values, read
+            # as "the highest level supported by both". This assumes the levels
+            # are totally ordered AND that a device supports every level at or
+            # below its reported maximum -- an assumption the plan does not state.
+            level_i = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel, node_id=self.dut_node_id)
+            level_r = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel, node_id=self.reflector_node_id)
+            self.blt_level = min(level_i, level_r)
+            # BLTCSMode: negotiate a mode supported by BOTH devices (the plan's "a
+            # mode supported by both") from their BLTCSModeCapability values.
+            mode_i = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSModeCapability, node_id=self.dut_node_id)
+            mode_r = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSModeCapability, node_id=self.reflector_node_id)
+            matter_asserts.assert_valid_enum(mode_i, "DUT_I BLTCSModeCapability", BLTCSModeEnum)
+            matter_asserts.assert_valid_enum(mode_r, "DUT_R BLTCSModeCapability", BLTCSModeEnum)
+            self.blt_mode = self.negotiate_bltcs_mode(mode_i, mode_r)
+        else:
+            self._skip(4, blt_reason)
+
+        # BLTCS periodic ranging additionally needs a mode both devices support.
+        if blt_tech is not None and self.blt_mode is None:
+            blt_reason = "DUT_I and DUT_R BLTCSModeCapability values do not intersect"
+        blt_run_tech = blt_tech if (blt_tech is not None and self.blt_mode is not None) else None
+
+        # ---- Step 5: BLE identities ----
+        if ble_tech is not None:
+            self.step(5)
+            self.ble_id_i = await self.read_proxr_attribute(_PROXR.Attributes.BLEDeviceID, node_id=self.dut_node_id)
+            self.ble_id_r = await self.read_proxr_attribute(_PROXR.Attributes.BLEDeviceID, node_id=self.reflector_node_id)
+            matter_asserts.assert_valid_uint64(self.ble_id_i, "DUT_I BLEDeviceID")
+            matter_asserts.assert_valid_uint64(self.ble_id_r, "DUT_R BLEDeviceID")
+        else:
+            self._skip(5, ble_reason)
+
+        # The plan gives RangingInstanceInterval to DUT_I (the active initiator)
+        # only; DUT_R's request lists just StartTime 0 and EndTime 600 (interval
+        # omitted). The responder makers therefore pass interval=None.
+        def _v_wifi(d):
+            self.assert_time_of_measurement_present(d)
+            asserts.assert_false(d.distance is NullValue, "Distance must not be null")
+            matter_asserts.assert_valid_uint16(d.distance, "Distance")
+            asserts.assert_equal(d.wiFiDevIK, self.wifi_ik_r, "RangingResult WiFiDevIK must equal DUT_R's WiFiDevIK")
+
+        def _mk_wifi(role, peer, interval):
+            return lambda: self.build_wifi_request(role=role, peer_wifi_ik=peer, pmk=rnd(PMK_LEN),
+                                                   start_time=0, end_time=_PERIODIC_END_TIME_S,
+                                                   interval=interval, technology=wifi_tech)
+        await self._run_periodic_block(
+            6, wifi_tech, wifi_reason,
+            _mk_wifi(RangingRoleEnum.kWiFiSubscriberRole, getattr(self, "wifi_ik_r", b"\x00" * 16), _PERIODIC_INTERVAL_S),
+            _mk_wifi(RangingRoleEnum.kWiFiPublisherRole, getattr(self, "wifi_ik_i", b"\x00" * 16), None),
+            _v_wifi, caps_i, caps_r)
+
+        def _v_blt(d):
+            self.assert_time_of_measurement_present(d)
+            asserts.assert_false(d.distance is NullValue, "Distance must not be null")
+            matter_asserts.assert_valid_uint16(d.distance, "Distance")
+            asserts.assert_equal(d.BLTDevIK, self.blt_ik_r, "RangingResult BLTDevIK must equal DUT_R's BLTDevIK")
+
+        def _mk_blt(role, peer, interval):
+            return lambda: self.build_blt_request(role=role, peer_blt_ik=peer, ltk=rnd(LTK_LEN),
+                                                  security_level=getattr(self, "blt_level", 0), mode=self.blt_mode,
+                                                  start_time=0, end_time=_PERIODIC_END_TIME_S,
+                                                  interval=interval)
+        await self._run_periodic_block(
+            7, blt_run_tech, blt_reason,
+            _mk_blt(RangingRoleEnum.kBLTInitiatorRole, getattr(self, "blt_ik_r", b"\x00" * 16), _PERIODIC_INTERVAL_S),
+            _mk_blt(RangingRoleEnum.kBLTReflectorRole, getattr(self, "blt_ik_i", b"\x00" * 16), None),
+            _v_blt, caps_i, caps_r)
+
+        def _v_ble(d):
+            self.assert_time_of_measurement_present(d)
+            asserts.assert_equal(d.BLEDeviceID, self.ble_id_r, "RangingResult BLEDeviceID must equal DUT_R's")
+            matter_asserts.assert_valid_int8(d.rssi, "RSSI")
+            matter_asserts.assert_valid_int8(d.txPower, "TxPower")
+
+        def _mk_ble(role, peer, interval):
+            return lambda: self.build_ble_request(role=role, peer_ble_device_id=peer, session_key=rnd(SESSION_KEY_LEN),
+                                                  start_time=0, end_time=_PERIODIC_END_TIME_S,
+                                                  interval=interval)
+        await self._run_periodic_block(
+            8, ble_tech, ble_reason,
+            _mk_ble(RangingRoleEnum.kBLEScanningRole, getattr(self, "ble_id_r", 0), _PERIODIC_INTERVAL_S),
+            _mk_ble(RangingRoleEnum.kBLEBeaconRole, getattr(self, "ble_id_i", 0), None),
+            _v_ble, caps_i, caps_r)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PROXR_2_4.py
+++ b/src/python_testing/TC_PROXR_2_4.py
@@ -42,14 +42,14 @@ import asyncio
 import logging
 import time
 
+from mobly import asserts
+from TC_PROXRTestBase import (LTK_LEN, PMK_LEN, SESSION_KEY_LEN, SIMULATED_RANGING_LATENCY_S, WIFI_TECHNOLOGIES, BLTCSModeEnum,
+                              Feature, ProximityRangingTestBase, RangingRoleEnum, RangingTechEnum)
+
 import matter.clusters as Clusters
 import matter.testing.matter_asserts as matter_asserts
-from mobly import asserts
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
-from TC_PROXRTestBase import (BLTCSModeEnum, Feature, LTK_LEN, PMK_LEN, ProximityRangingTestBase, RangingRoleEnum,
-                              RangingTechEnum, SESSION_KEY_LEN, SIMULATED_RANGING_LATENCY_S, WIFI_TECHNOLOGIES)
-
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterTestCommissionedDevice
 from matter.testing.runner import TestStep, default_matter_test_main

--- a/src/python_testing/TC_PROXR_2_4.py
+++ b/src/python_testing/TC_PROXR_2_4.py
@@ -394,20 +394,38 @@ class TC_PROXR_2_4(MatterTestCommissionedDevice, ProximityRangingTestBase):
         # The plan gives RangingInstanceInterval to DUT_I (the active initiator)
         # only; DUT_R's request lists just StartTime 0 and EndTime 600 (interval
         # omitted). The responder makers therefore pass interval=None.
+        #
+        # Key material is generated ONCE PER TECHNOLOGY here and captured by both
+        # makers of the pair. The plan requires the PMK / LTK / SessionKey to be
+        # "a random number common for both DUT_I and DUT_R"; generating inside the
+        # maker lambda (which is invoked separately per role) handed the initiator
+        # and the reflector DIFFERENT credentials, so the peers could not agree on
+        # the same ranging session.
+        #
+        # Peer identities are looked up by attribute NAME at invocation time with
+        # no getattr default. A maker is constructed even for a block that will
+        # skip, but only INVOKED for a block that runs, and a running block implies
+        # steps 3/4/5 stored the identity. A missing attribute is therefore a real
+        # defect and must raise, not silently substitute 16 zero bytes: zeros would
+        # satisfy the 16-byte length guard and reach the DUT as a valid-looking
+        # wrong identity (and a defaulted BLTCSSecurityLevel of 0 is the Unknown
+        # level, which the step-4 validation exists to reject).
         def _v_wifi(d):
             self.assert_time_of_measurement_present(d)
             asserts.assert_false(d.distance is NullValue, "Distance must not be null")
             matter_asserts.assert_valid_uint16(d.distance, "Distance")
             asserts.assert_equal(d.wiFiDevIK, self.wifi_ik_r, "RangingResult WiFiDevIK must equal DUT_R's WiFiDevIK")
 
-        def _mk_wifi(role, peer, interval):
-            return lambda: self.build_wifi_request(role=role, peer_wifi_ik=peer, pmk=rnd(PMK_LEN),
+        wifi_pmk = rnd(PMK_LEN)
+
+        def _mk_wifi(role, peer_attr, interval):
+            return lambda: self.build_wifi_request(role=role, peer_wifi_ik=getattr(self, peer_attr), pmk=wifi_pmk,
                                                    start_time=0, end_time=_PERIODIC_END_TIME_S,
                                                    interval=interval, technology=wifi_tech)
         await self._run_periodic_block(
             6, wifi_tech, wifi_reason,
-            _mk_wifi(RangingRoleEnum.kWiFiSubscriberRole, getattr(self, "wifi_ik_r", b"\x00" * 16), _PERIODIC_INTERVAL_S),
-            _mk_wifi(RangingRoleEnum.kWiFiPublisherRole, getattr(self, "wifi_ik_i", b"\x00" * 16), None),
+            _mk_wifi(RangingRoleEnum.kWiFiSubscriberRole, "wifi_ik_r", _PERIODIC_INTERVAL_S),
+            _mk_wifi(RangingRoleEnum.kWiFiPublisherRole, "wifi_ik_i", None),
             _v_wifi, caps_i, caps_r)
 
         def _v_blt(d):
@@ -416,15 +434,17 @@ class TC_PROXR_2_4(MatterTestCommissionedDevice, ProximityRangingTestBase):
             matter_asserts.assert_valid_uint16(d.distance, "Distance")
             asserts.assert_equal(d.BLTDevIK, self.blt_ik_r, "RangingResult BLTDevIK must equal DUT_R's BLTDevIK")
 
-        def _mk_blt(role, peer, interval):
-            return lambda: self.build_blt_request(role=role, peer_blt_ik=peer, ltk=rnd(LTK_LEN),
-                                                  security_level=getattr(self, "blt_level", 0), mode=self.blt_mode,
+        blt_ltk = rnd(LTK_LEN)
+
+        def _mk_blt(role, peer_attr, interval):
+            return lambda: self.build_blt_request(role=role, peer_blt_ik=getattr(self, peer_attr), ltk=blt_ltk,
+                                                  security_level=self.blt_level, mode=self.blt_mode,
                                                   start_time=0, end_time=_PERIODIC_END_TIME_S,
                                                   interval=interval)
         await self._run_periodic_block(
             7, blt_run_tech, blt_reason,
-            _mk_blt(RangingRoleEnum.kBLTInitiatorRole, getattr(self, "blt_ik_r", b"\x00" * 16), _PERIODIC_INTERVAL_S),
-            _mk_blt(RangingRoleEnum.kBLTReflectorRole, getattr(self, "blt_ik_i", b"\x00" * 16), None),
+            _mk_blt(RangingRoleEnum.kBLTInitiatorRole, "blt_ik_r", _PERIODIC_INTERVAL_S),
+            _mk_blt(RangingRoleEnum.kBLTReflectorRole, "blt_ik_i", None),
             _v_blt, caps_i, caps_r)
 
         def _v_ble(d):
@@ -433,14 +453,17 @@ class TC_PROXR_2_4(MatterTestCommissionedDevice, ProximityRangingTestBase):
             matter_asserts.assert_valid_int8(d.rssi, "RSSI")
             matter_asserts.assert_valid_int8(d.txPower, "TxPower")
 
-        def _mk_ble(role, peer, interval):
-            return lambda: self.build_ble_request(role=role, peer_ble_device_id=peer, session_key=rnd(SESSION_KEY_LEN),
+        ble_session_key = rnd(SESSION_KEY_LEN)
+
+        def _mk_ble(role, peer_attr, interval):
+            return lambda: self.build_ble_request(role=role, peer_ble_device_id=getattr(self, peer_attr),
+                                                  session_key=ble_session_key,
                                                   start_time=0, end_time=_PERIODIC_END_TIME_S,
                                                   interval=interval)
         await self._run_periodic_block(
             8, ble_tech, ble_reason,
-            _mk_ble(RangingRoleEnum.kBLEScanningRole, getattr(self, "ble_id_r", 0), _PERIODIC_INTERVAL_S),
-            _mk_ble(RangingRoleEnum.kBLEBeaconRole, getattr(self, "ble_id_i", 0), None),
+            _mk_ble(RangingRoleEnum.kBLEScanningRole, "ble_id_r", _PERIODIC_INTERVAL_S),
+            _mk_ble(RangingRoleEnum.kBLEBeaconRole, "ble_id_i", None),
             _v_ble, caps_i, caps_r)
 
 

--- a/src/python_testing/TC_PROXR_2_4.py
+++ b/src/python_testing/TC_PROXR_2_4.py
@@ -44,7 +44,7 @@ import time
 
 from mobly import asserts
 from TC_PROXRTestBase import (LTK_LEN, PMK_LEN, SESSION_KEY_LEN, SIMULATED_RANGING_LATENCY_S, WIFI_TECHNOLOGIES, BLTCSModeEnum,
-                              Feature, ProximityRangingTestBase, RangingRoleEnum, RangingTechEnum)
+                              BLTCSSecurityLevelEnum, Feature, ProximityRangingTestBase, RangingRoleEnum, RangingTechEnum)
 
 import matter.clusters as Clusters
 import matter.testing.matter_asserts as matter_asserts
@@ -253,8 +253,16 @@ class TC_PROXR_2_4(MatterTestCommissionedDevice, ProximityRangingTestBase):
             resp_r2 = await self.send_start_ranging(make_r(), node_id=self.reflector_node_id)
             self._assert_session_id(resp_i2.sessionID)
             self._assert_session_id(resp_r2.sessionID)
+            # The plan asks the new SessionID be "higher than the previous ... or a
+            # smaller value due to wrap-around from the limited field size". For a
+            # uint8 that disjunction admits every value except the previous one, so
+            # "differs from the previous" is the strongest falsifiable check the
+            # field allows; a strict > would wrongly fail a conformant wrap. Checked
+            # on both DUTs (previously only DUT_I).
             asserts.assert_not_equal(resp_i2.sessionID, resp_i.sessionID,
-                                     "New DUT_I SessionID must differ from the previous one")
+                                     "New DUT_I SessionID must differ from the previous one (higher, or wrapped)")
+            asserts.assert_not_equal(resp_r2.sessionID, resp_r.sessionID,
+                                     "New DUT_R SessionID must differ from the previous one (higher, or wrapped)")
             await self._collect_and_check_cadence(cb_i, resp_i2.sessionID, validate)
 
             # f: SessionIDList includes both new ids
@@ -345,6 +353,18 @@ class TC_PROXR_2_4(MatterTestCommissionedDevice, ProximityRangingTestBase):
             # below its reported maximum -- an assumption the plan does not state.
             level_i = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel, node_id=self.dut_node_id)
             level_r = await self.read_proxr_attribute(_PROXR.Attributes.BLTCSSecurityLevel, node_id=self.reflector_node_id)
+            # Validate both reported values are known enum members before taking
+            # min(). assert_valid_enum only type-checks, and the SDK coerces any
+            # out-of-range decoded value to kUnknownEnumValue (a valid member), so
+            # the type check alone is vacuous; also reject kUnknownEnumValue so an
+            # out-of-range or unknown level fails here rather than silently
+            # participating in the negotiation below.
+            matter_asserts.assert_valid_enum(level_i, "DUT_I BLTCSSecurityLevel", BLTCSSecurityLevelEnum)
+            matter_asserts.assert_valid_enum(level_r, "DUT_R BLTCSSecurityLevel", BLTCSSecurityLevelEnum)
+            asserts.assert_not_equal(level_i, BLTCSSecurityLevelEnum.kUnknownEnumValue,
+                                     "DUT_I BLTCSSecurityLevel must be a known (in-range) value")
+            asserts.assert_not_equal(level_r, BLTCSSecurityLevelEnum.kUnknownEnumValue,
+                                     "DUT_R BLTCSSecurityLevel must be a known (in-range) value")
             self.blt_level = min(level_i, level_r)
             # BLTCSMode: negotiate a mode supported by BOTH devices (the plan's "a
             # mode supported by both") from their BLTCSModeCapability values.

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -63,6 +63,8 @@ not_automated:
       reason: Code/Test not being used or not shared code for any other tests
     - name: TC_AVSMTestBase.py
       reason: Shared code for TC_AVSM, not a standalone test
+    - name: TC_PROXRTestBase.py
+      reason: Shared code for TC_PROXR, not a standalone test
     - name: TC_BRBINFO_3_1.py
       reason:
           Attribute is not implemented in the bridge app. Same code as


### PR DESCRIPTION
Covers TC-PROXR-2.1 through 2.4 with a server DUT. A shared test base handles the two-device initiator/reflector setup the instant and periodic ranging cases need, and works out the technology, BLTCS mode and security level the two devices have in common rather than assuming any one of them.

The all-devices-app ranging stub now reports a measurement time offset and MaxConcurrentSessions, which the test plan requires every DUT to provide.

### Summary

Add test scripts for Proximity Ranging cluster 2.1 according to the test plan.

### Testing

```
scripts/run_in_python_env.sh out/python_env "python3 ./scripts/tests/run_python_test.py \
  --app out/linux-x64-all-devices-clang/all-devices-app \
  --app-args '--device proximity-ranger:1 --discriminator 1234 --KVS /tmp/kvs_TC_PROXR_2_1 --port 5540' \
  --factory-reset \
  --script src/python_testing/TC_PROXR_2_1.py \
  --script-args '--commissioning-method on-network --discriminator 1234 --passcode 20202021 \
     --PICS src/app/tests/suites/certification/ci-pics-values --endpoint 1 \
     --storage-path /tmp/admin_TC_PROXR_2_1.json'"
```
