### PR TITLE
OpenSSL: Guard against ECDSA_sign_msg_det producing random signatures

### DIFF
--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -305,7 +305,7 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
     VerifyOrExit(tag_length == CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES, error = CHIP_ERROR_INVALID_ARGUMENT);
 #else
     VerifyOrExit(tag_length == 8 || tag_length == 12 || tag_length == CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES,
-                            error = CHIP_ERROR_INVALID_ARGUMENT);
+                 error = CHIP_ERROR_INVALID_ARGUMENT);
 #endif // CHIP_CRYPTO_BORINGSSL
 
 #if CHIP_CRYPTO_BORINGSSL
@@ -358,7 +358,7 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
     // Encrypt
     VerifyOrExit(CanCastTo<int>(plaintext_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     result = EVP_EncryptUpdate(context, Uint8::to_uchar(ciphertext), &bytesWritten, Uint8::to_const_uchar(plaintext),
-                                          static_cast<int>(plaintext_length));
+                               static_cast<int>(plaintext_length));
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit((ciphertext_was_null && bytesWritten == 0) || (bytesWritten >= 0), error = CHIP_ERROR_INTERNAL);
     ciphertext_length = static_cast<unsigned int>(bytesWritten);
@@ -435,7 +435,7 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     VerifyOrExit(tag_length == CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES, error = CHIP_ERROR_INVALID_ARGUMENT);
 #else
     VerifyOrExit(tag_length == 8 || tag_length == 12 || tag_length == CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES,
-                            error = CHIP_ERROR_INVALID_ARGUMENT);
+                 error = CHIP_ERROR_INVALID_ARGUMENT);
 #endif // CHIP_CRYPTO_BORINGSSL
     VerifyOrExit(nonce != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(nonce_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
@@ -469,7 +469,7 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     // we're writing the tag, not reading.
     VerifyOrExit(CanCastTo<int>(tag_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_TAG, static_cast<int>(tag_length),
-                                            const_cast<void *>(static_cast<const void *>(tag)));
+                                 const_cast<void *>(static_cast<const void *>(tag)));
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in key + nonce
@@ -495,7 +495,7 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     // Pass in ciphertext. We wont get anything if validation fails.
     VerifyOrExit(CanCastTo<int>(ciphertext_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     result = EVP_DecryptUpdate(context, Uint8::to_uchar(plaintext), &bytesOutput, Uint8::to_const_uchar(ciphertext),
-                                          static_cast<int>(ciphertext_length));
+                               static_cast<int>(ciphertext_length));
     if (plaintext_was_null)
     {
         VerifyOrExit(bytesOutput <= static_cast<int>(sizeof(placeholder_plaintext)), error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -54,6 +54,7 @@
 #include <lib/support/SafePointerCast.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#include <stdio.h>
 #include <string.h>
 
 namespace chip {
@@ -72,6 +73,21 @@ using libssl_err_type            = uint32_t;
 #else
 using boringssl_uint_openssl_int = int;
 using libssl_err_type            = unsigned long;
+
+namespace detail {
+void AssertOpenSSLVersion()
+{
+    unsigned long build   = (OPENSSL_VERSION_NUMBER & 0xFFF00000lu); // mask to major / minor only
+    unsigned long runtime = OpenSSL_version_num();
+    if (runtime < build)
+    {
+        // This check runs pre-main(), so logging is probably not set up yet. This is the
+        // spiritual equivalent of a dynamic linker error, just write to stderr directly.
+        fprintf(stderr, "Insufficient OpenSSL runtime version (%lx), binary built for %lx+\n", runtime, build);
+        chipAbort();
+    }
+}
+} // namespace detail
 #endif // CHIP_CRYPTO_BORINGSSL
 
 #define kKeyLengthInBits 256

--- a/src/crypto/CHIPCryptoPALOpenSSL.h
+++ b/src/crypto/CHIPCryptoPALOpenSSL.h
@@ -32,6 +32,29 @@ namespace Crypto {
 using boringssl_size_t_openssl_int = size_t;
 #else
 using boringssl_size_t_openssl_int = int;
+
+namespace detail {
+// Aborts unless we're running against an appropriate version of OpenSSL.
+// All OpenSSL 3.x versions share the same soname, and there are no explicit ABI versioning symbols
+// that would prevent a binary compiled against a newer version from running against an older
+// library version. Especially when OSSL_PARAMs are used, where the library silently ignores
+// unknown parameters, this can result in code silently misbehaving at runtime, even when it was
+// guarded by appropriate OPENSSL_VERSION_NUMBER guards at build time.
+// For example, OpenSSL 3.2 adds support for the OSSL_SIGNATURE_PARAM_NONCE_TYPE parameter to
+// create deterministic ECDSA signatures, but when linked against an OpenSSL 3.0 shared library at
+// runtime that parameter is silently ignored and non-deterministic signatures are produced instead.
+// To prevent such issues, ensure that the runtime version is not older than the version we compiled
+// against (masked to major/minor version only).
+void AssertOpenSSLVersion();
+
+// CHIPCryptoPAL.h has no initialization API that we could hook into. Force a call to
+// AssertOpenSSLVersion() via a static initializer with inline linkage.
+// This ensures the check runs as long as any TU that includes this header is linked.
+inline struct AssertOpenSSLVersionCaller
+{
+    AssertOpenSSLVersionCaller() { AssertOpenSSLVersion(); }
+} gAssertOpenSSLVersion;
+} // namespace detail
 #endif
 
 enum class ECName

--- a/src/crypto/P256KeyPairOpenSSL.cpp
+++ b/src/crypto/P256KeyPairOpenSSL.cpp
@@ -219,6 +219,7 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg_det(const uint8_t * msg, size_t msg_lengt
         // because EVP_PKEY_CTX_set_params() silently ignores parameters it doesn't understand.
         const OSSL_PARAM * settable = EVP_PKEY_CTX_settable_params(pkey_ctx);
         VerifyOrExit(settable != nullptr && OSSL_PARAM_locate_const(settable, OSSL_SIGNATURE_PARAM_NONCE_TYPE) != nullptr,
+                     ChipLogError(Crypto, "OSSL_SIGNATURE_PARAM_NONCE_TYPE not supported by provider context");
                      error = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
         unsigned int nonce_type = 1;
         OSSL_PARAM params[]     = {

--- a/src/crypto/P256KeyPairOpenSSL.cpp
+++ b/src/crypto/P256KeyPairOpenSSL.cpp
@@ -214,6 +214,12 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg_det(const uint8_t * msg, size_t msg_lengt
         VerifyOrExit(EVP_DigestSignInit(md_ctx, &pkey_ctx, EVP_sha256(), nullptr, evp_pkey) == 1, error = CHIP_ERROR_INTERNAL);
 
         // Request deterministic nonce generation (RFC 6979).
+        // Ensure OSSL_SIGNATURE_PARAM_NONCE_TYPE is understood by the signature provider,
+        // otherwise we could end up silently creating a non-deterministic signature,
+        // because EVP_PKEY_CTX_set_params() silently ignores parameters it doesn't understand.
+        const OSSL_PARAM * settable = EVP_PKEY_CTX_settable_params(pkey_ctx);
+        VerifyOrExit(settable != nullptr && OSSL_PARAM_locate_const(settable, OSSL_SIGNATURE_PARAM_NONCE_TYPE) != nullptr,
+                     error = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
         unsigned int nonce_type = 1;
         OSSL_PARAM params[]     = {
             OSSL_PARAM_construct_uint(OSSL_SIGNATURE_PARAM_NONCE_TYPE, &nonce_type),


### PR DESCRIPTION
### Summary

OpenSSL has a sloppy ABI compatibility story; it uses the same soname
for all 3.x releases, so it's fairly easy to accidentally compile
against e.g. 3.5.x on Ubuntu 26.04, and then run against 3.0.x on Ubuntu
24.04. In such a scenario, OSSL_PARAM-based APIs will silently ignore
unknown options at runtime rather than producing a dynamic linker error
at startup (like calling a function that wasn't present in the old
version would).

Guard against this by explicitly checking the version of the OpenSSL
library we're running against at startup, and ensure it isn't older than
the version we built against. (Only major/minor is compared, the
fix/patch component of the version is ignored.)

For the specific case of ECDSA_sign_msg_det(), add an additional runtime
check that OSSL_SIGNATURE_PARAM_NONCE_TYPE is actually understood by the
crypto provider that is in use: It could be a non-default provider that
doesn't support deterministic signatures despite being on the expected
runtime version.

Thanks @ForemanZack-CableLabs for discovering this one :-)

### Testing

Existing CI tests. Error paths tested manually.
