### PR TITLE
ESP32: Track sdkconfig.h in GN dependencies

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -386,6 +386,12 @@ list(APPEND filter_out "-Iconfig")
 idf_build_get_property(config_dir CONFIG_DIR)
 target_compile_options(${COMPONENT_LIB} PRIVATE "-I${config_dir}")
 
+# GN generates dependencies with -MMD. Some ESP-IDF system headers include
+# sdkconfig.h before Matter's platform configuration headers do, which causes
+# GCC to omit sdkconfig.h from the dependency file. Force it to be included
+# first so Kconfig changes rebuild the affected Matter sources.
+target_compile_options(${COMPONENT_LIB} PRIVATE "-include${config_dir}/sdkconfig.h")
+
 if (CONFIG_CHIP_USE_OT_ENDPOINT)
     idf_component_get_property(openthread_dir openthread COMPONENT_DIR)
     target_compile_options(${COMPONENT_LIB} PRIVATE "-I${openthread_dir}/private_include")


### PR DESCRIPTION
### Summary

  ESP32 Matter sources built by GN did not rebuild after `sdkconfig.h` changed.

  GCC first encountered `sdkconfig.h` through an ESP-IDF system-header chain. Because GN
  generates dependency files with `-MMD`, GCC omitted the header from those dependency files.
  Ninja could then reuse Matter objects compiled with stale Kconfig values, causing
  incompatible class layouts and runtime crashes.

  Force-include `sdkconfig.h` through the ESP32 CHIP component compile options. The option
  propagates to GN and makes GCC record the header as a dependency, so Kconfig changes rebuild
  affected Matter sources.

### Related issues

N/A

 ### Testing

  - Regenerated the ESP32 GN arguments and confirmed that the compile flags contain the forced
  `sdkconfig.h` include.
  - Confirmed through `ninja -t deps` that the object now depends on `sdkconfig.h`.