### PR TITLE
[Python] Build CASE capture unit tests on host platforms only

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -161,7 +161,6 @@ if (chip_build_tests) {
       "${chip_root}/src/app/persistence/tests",
       "${chip_root}/src/app/server-cluster/tests",
       "${chip_root}/src/app/server/tests",
-      "${chip_root}/src/controller/python/matter/case_capture/tests",
       "${chip_root}/src/credentials/tests/jcm",
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/data-model-providers/codedriven/endpoint/tests",
@@ -220,6 +219,15 @@ if (chip_build_tests) {
 
         # keep-sorted: end
       ]
+    }
+
+    # Python controller code, only ever built into the ctypes shared library
+    # on a host. It uses host-only facilities an embedded toolchain need not
+    # provide, notably <mutex>, <condition_variable> and <thread>, which
+    # Zephyr's libstdc++ is built without.
+    if (chip_device_platform == "darwin" || chip_device_platform == "linux") {
+      tests +=
+          [ "${chip_root}/src/controller/python/matter/case_capture/tests" ]
     }
 
     if (current_os != "zephyr") {


### PR DESCRIPTION
#### Summary

`nxp-rw61x-zephyr-unit-test` fails to build. The `case_capture` unit test suite is host-only Python controller code that was being compiled on embedded toolchains.

##### Problem

-   `src/controller/python/matter/case_capture` is the native half of a Python ctypes module. It only ever links into `_ChipDeviceCtrl.so` and has no device-side consumer.
-   Its test suite was listed in the **unconditional** `tests` list in `src/BUILD.gn`, and embedded unit-test builds reach that group directly:

```
config/nxp/chip-gn/BUILD.gn
  └─ group("zephyr")
       └─ ${chip_root}/src:tests
            └─ src/controller/python/matter/case_capture/tests   <-- host-only
```

-   On Zephyr this fails two ways:
    -   **Buffer sizing**: `kCASEHandshakeMetricsPeerAddressMaxLength` is a hardcoded 80, measured on a host. `Transport::PeerAddress::kMaxToStringSize` is platform-dependent because `Inet::InterfaceId::kMaxIfNameLength` is `IF_NAMESIZE` (16) on Linux/macOS but `Z_DEVICE_MAX_NAME_LEN` (48) on Zephyr — 76 against 108, tripping the `static_assert`.
    -   **Missing threading**: Zephyr's libstdc++ is built without gthreads, so `<mutex>`, `<condition_variable>` and `<thread>` are effectively empty headers and `std::mutex` does not resolve.

Failing job: https://github.com/project-chip/connectedhomeip/actions/runs/34523974898/job/103028223930

##### Solution

-   Restrict the suite to host platforms in `src/BUILD.gn`, reusing the `chip_device_platform == "darwin" || chip_device_platform == "linux"` condition already used in that file for host-only suites.
-   The C++ is unchanged. `CompletedCASEHandshakeQueue` hands records from the CHIP event loop to a Python consumer thread, so it needs real threading primitives; making it portable would serve a caller that cannot exist on a device.

##### Caveats

-   No coverage is lost. These suites only ever executed on the Linux/macOS unit-test jobs; the Zephyr job cross-compiled them without running them.

#### Testing

-   `gn path --with-data out/linux-x64-tests-clang //src:tests //src/controller/python/matter/case_capture/tests:tests` — still reachable on a host build.
-   The same query against a build generated with a non-host `chip_device_platform` returns `ERROR Label not found`, confirming the target is absent from the graph on the platforms that were failing.
-   Built and ran both suites on `linux-x64-tests-clang`: `TestCompletedCASEHandshakeQueue` (10 tests) and `TestCASEHandshakeMetricsBackend` (23 tests), all passing.
-   No new tests added: this is a build-configuration change with no runtime behaviour to cover.

#### Related issues
Fixes https://github.com/project-chip/connectedhomeip/issues/74087