### PR TITLE
TestModeSelectCluster.yaml fixes.

### DIFF
--- a/src/app/tests/suites/TestModeSelectCluster.yaml
+++ b/src/app/tests/suites/TestModeSelectCluster.yaml
@@ -72,7 +72,7 @@ tests:
       command: "readAttribute"
       attribute: "StartUpMode"
       response:
-          value: 0
+          value: null
 
     - label: "Read OnMode"
       command: "readAttribute"
@@ -123,7 +123,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: INVALID_COMMAND
+          error: CONSTRAINT_ERROR
 
     - label: "Change OnMode"
       command: "writeAttribute"
@@ -158,7 +158,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: INVALID_COMMAND
+          error: CONSTRAINT_ERROR
 
     - label: "Change to Supported StartUp Mode"
       command: "writeAttribute"


### PR DESCRIPTION
### Summary

The YAML file is outdated. [This PR removed the walk-around ](https://github.com/project-chip/connectedhomeip/pull/73902/changes)that allowed the test to pass.

### Related issues

https://github.com/project-chip/connectedhomeip/pull/73810
https://github.com/project-chip/connectedhomeip/issues/73795

### Testing

Test ran in Ubuntu Linux 26.
