### PR TITLE
[TC-AVANALY] Update TC-AVANALY-2.5, 2.6, and 2.7 for test plan PR #6421

### DIFF
--- a/src/python_testing/TC_AVANALYTestBase.py
+++ b/src/python_testing/TC_AVANALYTestBase.py
@@ -24,6 +24,8 @@ from matter.interaction_model import InteractionModelError, Status
 
 
 class AVANALYTestBase:
+    """Base class providing helper methods and constants for AVANALY tests."""
+
     SPEC_MAX_COUNT_SUPPORTEDAMBIENTCONTEXTS = 50
     SPEC_MAX_COUNT_ANALYSIS_STREAMS = 255
 

--- a/src/python_testing/TC_AVANALYTestBase.py
+++ b/src/python_testing/TC_AVANALYTestBase.py
@@ -175,26 +175,95 @@ class AVANALYTestBase:
         self.has_feature_perzonedetect = (feature_map & cluster.Bitmaps.Feature.kPerZoneContextDetection) != 0
         return feature_map
 
-    async def send_establish_analysis_stream_cmd(self, endpoint, node_id):
-        """Send EstablishAnalysisStream command to the AvAnalysis cluster."""
+    async def send_establish_analysis_stream_cmd(
+        self, endpoint: int, node_id: int, expected_status: Status = Status.Success
+    ) -> Any:
+        """Send EstablishAnalysisStream command to the AvAnalysis cluster and assert expected status."""
         cmd = Clusters.Objects.AvAnalysis.Commands.EstablishAnalysisStream(nodeID=node_id)
-        return await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+        try:
+            resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+            asserts.assert_equal(
+                expected_status,
+                Status.Success,
+                f"Expected status {expected_status} on establishing analysis stream, but command succeeded",
+            )
+            return resp
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                expected_status,
+                f"Unexpected error returned on establishing analysis stream: expected {expected_status}, got {e.status}",
+            )
+            return None
 
-    async def send_activate_analysis_stream_cmd(self, endpoint, analysis_stream_id, webrtc_endpoint_id=None, pushav_endpoint_id=None):
-        """Send ActivateAnalysisStream command to the AvAnalysis cluster."""
+    async def send_activate_analysis_stream_cmd(
+        self,
+        endpoint: int,
+        analysis_stream_id: int,
+        webrtc_endpoint_id=None,
+        pushav_endpoint_id=None,
+        expected_status: Status = Status.Success,
+    ) -> Any:
+        """Send ActivateAnalysisStream command to the AvAnalysis cluster and assert expected status."""
         cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
             analysisStreamID=analysis_stream_id,
             webRTCEndpointID=webrtc_endpoint_id,
-            pushAVEndpointID=pushav_endpoint_id
+            pushAVEndpointID=pushav_endpoint_id,
         )
-        return await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+        try:
+            resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+            asserts.assert_equal(
+                expected_status,
+                Status.Success,
+                f"Expected status {expected_status} on activating analysis stream, but command succeeded",
+            )
+            return resp
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                expected_status,
+                f"Unexpected error returned on activating analysis stream: expected {expected_status}, got {e.status}",
+            )
+            return None
 
-    async def send_deactivate_analysis_stream_cmd(self, endpoint, analysis_stream_id):
-        """Send DeactivateAnalysisStream command to the AvAnalysis cluster."""
+    async def send_deactivate_analysis_stream_cmd(
+        self, endpoint: int, analysis_stream_id: int, expected_status: Status = Status.Success
+    ) -> Any:
+        """Send DeactivateAnalysisStream command to the AvAnalysis cluster and assert expected status."""
         cmd = Clusters.Objects.AvAnalysis.Commands.DeactivateAnalysisStream(analysisStreamID=analysis_stream_id)
-        return await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+        try:
+            resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+            asserts.assert_equal(
+                expected_status,
+                Status.Success,
+                f"Expected status {expected_status} on deactivating analysis stream, but command succeeded",
+            )
+            return resp
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                expected_status,
+                f"Unexpected error returned on deactivating analysis stream: expected {expected_status}, got {e.status}",
+            )
+            return None
 
-    async def send_remove_analysis_stream_cmd(self, endpoint, analysis_stream_id):
-        """Send RemoveAnalysisStream command to the AvAnalysis cluster."""
+    async def send_remove_analysis_stream_cmd(
+        self, endpoint: int, analysis_stream_id: int, expected_status: Status = Status.Success
+    ) -> Any:
+        """Send RemoveAnalysisStream command to the AvAnalysis cluster and assert expected status."""
         cmd = Clusters.Objects.AvAnalysis.Commands.RemoveAnalysisStream(analysisStreamID=analysis_stream_id)
-        return await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+        try:
+            resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+            asserts.assert_equal(
+                expected_status,
+                Status.Success,
+                f"Expected status {expected_status} on removing analysis stream, but command succeeded",
+            )
+            return resp
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                expected_status,
+                f"Unexpected error returned on removing analysis stream: expected {expected_status}, got {e.status}",
+            )
+            return None

--- a/src/python_testing/TC_AVANALY_2_5.py
+++ b/src/python_testing/TC_AVANALY_2_5.py
@@ -43,7 +43,7 @@ from TC_AVANALYTestBase import AVANALYTestBase
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.decorators import has_feature, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
@@ -51,11 +51,14 @@ log = logging.getLogger(__name__)
 
 
 class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
+    """Implementation of test case TC-AVANALY-2.5."""
 
     def desc_TC_AVANALY_2_5(self) -> str:
+        """Returns the description of TC-AVANALY-2.5."""
         return "[TC-AVANALY-2.5] Validate EstablishAnalysisStream functionality with Server as DUT"
 
     def steps_TC_AVANALY_2_5(self) -> list[TestStep]:
+        """Returns the list of test steps for TC-AVANALY-2.5."""
         return [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH reads MaxAnalysisStreamCount attribute. Save as max_streams."),
@@ -135,13 +138,17 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
         ]
 
     def pics_TC_AVANALY_2_5(self) -> list[str]:
+        """Returns the PICS requirements for TC-AVANALY-2.5."""
         return [
             "AVANALY.S",
             "AVANALY.S.F01",
         ]
 
-    @run_if_endpoint_matches(has_cluster(Clusters.AvAnalysis))
+    @run_if_endpoint_matches(
+        has_feature(Clusters.AvAnalysis, Clusters.AvAnalysis.Bitmaps.Feature.kRemoteContextDetection)
+    )
     async def test_TC_AVANALY_2_5(self):
+        """Execute the test steps for TC-AVANALY-2.5."""
         cluster = Clusters.Objects.AvAnalysis
         attributes = cluster.Attributes
         enums = cluster.Enums
@@ -153,12 +160,6 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
         await self.read_avanaly_features(endpoint)
         log.info("Features - LCLCONDETECT: %s, REMCONDETECT: %s, PERZONEDETECT: %s",
                  self.has_feature_lclcondetect, self.has_feature_remcondetect, self.has_feature_perzonedetect)
-
-        if not self.has_feature_remcondetect:
-            log.info("REMCONDETECT not supported, skipping TC-AVANALY-2.5")
-            for s in range(2, 25):
-                self.skip_step(s)
-            return
 
         self.step(2)
         max_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.MaxAnalysisStreamCount)
@@ -206,37 +207,82 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
 
         self.step(9)
         # Activate with unknown stream ID -> expect NOT_FOUND
-        unknown_stream_id = 0xFFEE
+        existing_stream_ids = {s.analysisStreamID for s in analysis_streams}
+        unknown_stream_id = next(i for i in range(0xFFEE, 0xFFFF) if i not in existing_stream_ids)
         await self.send_activate_analysis_stream_cmd(
             endpoint, analysis_stream_id=unknown_stream_id, expected_status=Status.NotFound
         )
 
+        # Discover transport endpoint hosting WebRTCTransportProvider or PushAvStreamTransport
+        parts_list = await self.read_single_attribute_check_success(
+            endpoint=0, cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.PartsList
+        )
+        all_endpoints = [0] + list(parts_list)
+        webrtc_endpoint = None
+        pushav_endpoint = None
+        endpoints_without_transport = []
+
+        for ep in all_endpoints:
+            server_list = await self.read_single_attribute_check_success(
+                endpoint=ep, cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.ServerList
+            )
+            has_webrtc = Clusters.WebRTCTransportProvider.id in server_list
+            has_pushav = Clusters.PushAvStreamTransport.id in server_list
+            if has_webrtc and webrtc_endpoint is None:
+                webrtc_endpoint = ep
+            if has_pushav and pushav_endpoint is None:
+                pushav_endpoint = ep
+            if not has_webrtc and not has_pushav:
+                endpoints_without_transport.append(ep)
+
+        # Fallback to endpoint if no transport cluster was found on the device
+        if webrtc_endpoint is None and pushav_endpoint is None:
+            webrtc_endpoint = endpoint
+
+        # Find an endpoint that does not host WebRTC or PushAV transport clusters
+        invalid_endpoint = endpoints_without_transport[0] if endpoints_without_transport else 0xFFFF
+
         self.step(10)
         # Activate with invalid endpoint ID -> expect NOT_FOUND per test plan
-        cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
-            analysisStreamID=stream_id,
-            webRTCEndpointID=0xFFFF,
-        )
-        try:
-            await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
-            log.warning("DUT did not return NOT_FOUND for invalid endpoint in ActivateAnalysisStream (returned Success)")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Expected NOT_FOUND for invalid endpoint, got {e.status}")
+        if not self.is_ci:
+            await self.send_activate_analysis_stream_cmd(
+                endpoint,
+                analysis_stream_id=stream_id,
+                webrtc_endpoint_id=invalid_endpoint if webrtc_endpoint is not None else None,
+                pushav_endpoint_id=invalid_endpoint if webrtc_endpoint is None else None,
+                expected_status=Status.NotFound,
+            )
+        else:
+            cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
+                analysisStreamID=stream_id,
+                webRTCEndpointID=invalid_endpoint if webrtc_endpoint is not None else None,
+                pushAVEndpointID=invalid_endpoint if webrtc_endpoint is None else None,
+            )
+            try:
+                await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+                log.warning(
+                    "CI reference app does not yet validate transport endpoint ID; returned Success instead of NOT_FOUND"
+                )
+                # Deactivate stream back to PendingInitiation so step 11 can activate it
+                await self.send_deactivate_analysis_stream_cmd(
+                    endpoint, analysis_stream_id=stream_id, expected_status=Status.Success
+                )
+            except InteractionModelError as e:
+                asserts.assert_equal(
+                    e.status,
+                    Status.NotFound,
+                    f"Expected NOT_FOUND for invalid transport endpoint ID, got {e.status}",
+                )
 
         self.step(11)
         # Activate with valid endpoint ID -> expect SUCCESS
-        cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
-            analysisStreamID=stream_id,
-            webRTCEndpointID=endpoint,
+        await self.send_activate_analysis_stream_cmd(
+            endpoint,
+            analysis_stream_id=stream_id,
+            webrtc_endpoint_id=webrtc_endpoint,
+            pushav_endpoint_id=pushav_endpoint,
+            expected_status=Status.Success,
         )
-        try:
-            await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
-        except InteractionModelError as e:
-            if e.status == Status.InvalidInState:
-                log.warning("ActivateAnalysisStream returned InvalidInState, stream was already activated in Step 10")
-            else:
-                asserts.fail(f"Unexpected status on ActivateAnalysisStream: {e.status}")
 
         self.step(12)
         analysis_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.AnalysisStreams)
@@ -245,25 +291,49 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
         valid_active_states = [enums.AnalysisStreamStateEnum.kWebRTCActive, enums.AnalysisStreamStateEnum.kPushAVActive]
         asserts.assert_in(matching_streams[0].analysisStreamState, valid_active_states,
                           f"Expected stream state to be WebRTCActive or PushAVActive, got {matching_streams[0].analysisStreamState}")
-        if matching_streams[0].webRTCEndpointID not in [NullValue, None]:
-            log.info("Transport endpoint ID is populated: %s", matching_streams[0].webRTCEndpointID)
+        if not self.is_ci:
+            if webrtc_endpoint is not None:
+                asserts.assert_equal(
+                    matching_streams[0].webRTCEndpointID,
+                    webrtc_endpoint,
+                    f"Expected webRTCEndpointID {webrtc_endpoint}, got {matching_streams[0].webRTCEndpointID}",
+                )
+            elif pushav_endpoint is not None:
+                asserts.assert_equal(
+                    matching_streams[0].pushAVEndpointID,
+                    pushav_endpoint,
+                    f"Expected pushAVEndpointID {pushav_endpoint}, got {matching_streams[0].pushAVEndpointID}",
+                )
         else:
-            log.warning("Transport endpoint ID was not populated by DUT in AnalysisStreams")
+            if matching_streams[0].webRTCEndpointID not in [NullValue, None]:
+                log.info("Transport endpoint ID is populated: %s", matching_streams[0].webRTCEndpointID)
+            else:
+                log.warning("Transport endpoint ID was not populated by DUT in AnalysisStreams")
 
         self.step(13)
         # TH sends ActivateAnalysisStream command again for the already active analysis_stream_id.
         # Spec 11.9.8.5.2 & Test Plan Step 13 expect SUCCESS. Some implementations return INVALID_IN_STATE.
-        cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
-            analysisStreamID=stream_id,
-            webRTCEndpointID=endpoint,
-        )
-        try:
-            await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
-        except InteractionModelError as e:
-            if e.status == Status.InvalidInState:
-                log.warning("DUT returned InvalidInState instead of Success for already active stream")
-            else:
-                asserts.fail(f"Expected SUCCESS or InvalidInState on reactivating active stream, got {e.status}")
+        if not self.is_ci:
+            await self.send_activate_analysis_stream_cmd(
+                endpoint,
+                analysis_stream_id=stream_id,
+                webrtc_endpoint_id=webrtc_endpoint,
+                pushav_endpoint_id=pushav_endpoint,
+                expected_status=Status.Success,
+            )
+        else:
+            cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
+                analysisStreamID=stream_id,
+                webRTCEndpointID=webrtc_endpoint,
+                pushAVEndpointID=pushav_endpoint,
+            )
+            try:
+                await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+            except InteractionModelError as e:
+                if e.status == Status.InvalidInState:
+                    log.warning("DUT returned InvalidInState instead of Success for already active stream")
+                else:
+                    asserts.fail(f"Expected SUCCESS or InvalidInState on reactivating active stream, got {e.status}")
 
         self.step(14)
         # Remove while active -> expect INVALID_IN_STATE

--- a/src/python_testing/TC_AVANALY_2_5.py
+++ b/src/python_testing/TC_AVANALY_2_5.py
@@ -41,6 +41,8 @@ from mobly import asserts
 from TC_AVANALYTestBase import AVANALYTestBase
 
 import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
@@ -58,15 +60,78 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH reads MaxAnalysisStreamCount attribute. Save as max_streams."),
             TestStep(3, "TH reads CurrentAnalysisStreamCount attribute. Save as current_streams."),
-            TestStep(4, "TH sends EstablishAnalysisStream command with a valid NodeID. Verify EstablishAnalysisStreamResponse with AnalysisStreamID."),
-            TestStep(5, "TH reads CurrentAnalysisStreamCount attribute. Value is current_streams + 1."),
-            TestStep(6, "TH reads AnalysisStreams attribute. Verify new entry exists with state PendingInitiation."),
-            TestStep(7, "TH sends ActivateAnalysisStream command for the new stream. Verify success response."),
-            TestStep(8, "TH reads AnalysisStreams attribute. Verify state is WebRTCActive or PushAVActive."),
-            TestStep(9, "TH sends DeactivateAnalysisStream command. Verify success response."),
-            TestStep(10, "TH reads AnalysisStreams attribute. Verify state returns to PendingInitiation."),
-            TestStep(11, "TH sends RemoveAnalysisStream command. Verify success response."),
-            TestStep(12, "TH reads CurrentAnalysisStreamCount attribute. Value is current_streams."),
+            TestStep(
+                4,
+                "TH sends EstablishAnalysisStream command with an invalid NodeID that does not support camera streaming services. Verify NOT_FOUND error.",
+            ),
+            TestStep(
+                5,
+                "TH sends EstablishAnalysisStream command with a valid NodeID. Verify EstablishAnalysisStreamResponse with AnalysisStreamID. Save as analysis_stream_id.",
+            ),
+            TestStep(6, "TH reads CurrentAnalysisStreamCount attribute. Value is current_streams + 1."),
+            TestStep(
+                7,
+                "TH reads AnalysisStreams attribute. Verify entry exists with AnalysisStreamID matching analysis_stream_id, and AnalysisStreamState set to PendingInitiation.",
+            ),
+            TestStep(
+                8,
+                "TH sends DeactivateAnalysisStream command with AnalysisStreamID set to analysis_stream_id. Verify INVALID_IN_STATE error.",
+            ),
+            TestStep(
+                9,
+                "TH sends ActivateAnalysisStream command with an AnalysisStreamID that does not match a known analysis stream. Verify NOT_FOUND error.",
+            ),
+            TestStep(
+                10,
+                "TH sends ActivateAnalysisStream command with AnalysisStreamID set to analysis_stream_id and an invalid endpoint ID that does not host WebRTC or PushAV transport clusters. Verify NOT_FOUND error.",
+            ),
+            TestStep(
+                11,
+                "TH sends ActivateAnalysisStream command with AnalysisStreamID set to analysis_stream_id and a valid WebRTCEndpointID or PushAVEndpointID. Verify success response.",
+            ),
+            TestStep(
+                12,
+                "TH reads AnalysisStreams attribute. Verify that for analysis_stream_id, AnalysisStreamState is set to WebRTCActive or PushAVActive, and the corresponding endpoint ID is populated.",
+            ),
+            TestStep(
+                13,
+                "TH sends ActivateAnalysisStream command again for the already active analysis_stream_id. Verify success response.",
+            ),
+            TestStep(
+                14,
+                "TH sends RemoveAnalysisStream command with AnalysisStreamID set to analysis_stream_id. Verify INVALID_IN_STATE error.",
+            ),
+            TestStep(
+                15,
+                "TH sends DeactivateAnalysisStream command with an AnalysisStreamID that does not match a known analysis stream. Verify NOT_FOUND error.",
+            ),
+            TestStep(
+                16,
+                "TH sends DeactivateAnalysisStream command with AnalysisStreamID set to analysis_stream_id. Verify success response.",
+            ),
+            TestStep(
+                17,
+                "TH reads AnalysisStreams attribute. Verify that for analysis_stream_id, AnalysisStreamState returns to PendingInitiation, and the transport endpoint ID is reset to null.",
+            ),
+            TestStep(
+                18,
+                "TH sends RemoveAnalysisStream command with an AnalysisStreamID that does not match a known analysis stream. Verify NOT_FOUND error.",
+            ),
+            TestStep(
+                19,
+                "TH sends RemoveAnalysisStream command with AnalysisStreamID set to analysis_stream_id. Verify success response.",
+            ),
+            TestStep(20, "TH reads CurrentAnalysisStreamCount attribute. Value is current_streams."),
+            TestStep(21, "TH reads AnalysisStreams attribute. Verify that analysis_stream_id is no longer present in the list."),
+            TestStep(
+                22,
+                "If current_streams < max_streams, TH establishes streams using EstablishAnalysisStream command until CurrentAnalysisStreamCount == MaxAnalysisStreamCount. Verify success response.",
+            ),
+            TestStep(23, "TH sends EstablishAnalysisStream command with a valid NodeID. Verify RESOURCE_EXHAUSTED error."),
+            TestStep(
+                24,
+                "TH removes any streams established in step 22 by sending RemoveAnalysisStream commands. TH reads CurrentAnalysisStreamCount to verify it returns to current_streams.",
+            ),
         ]
 
     def pics_TC_AVANALY_2_5(self) -> list[str]:
@@ -81,6 +146,7 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
         attributes = cluster.Attributes
         enums = cluster.Enums
         endpoint = self.get_endpoint()
+        self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
 
         self.step(1)  # Already done, immediately go to step 2
 
@@ -90,17 +156,8 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
 
         if not self.has_feature_remcondetect:
             log.info("REMCONDETECT not supported, skipping TC-AVANALY-2.5")
-            self.skip_step(2)
-            self.skip_step(3)
-            self.skip_step(4)
-            self.skip_step(5)
-            self.skip_step(6)
-            self.skip_step(7)
-            self.skip_step(8)
-            self.skip_step(9)
-            self.skip_step(10)
-            self.skip_step(11)
-            self.skip_step(12)
+            for s in range(2, 25):
+                self.skip_step(s)
             return
 
         self.step(2)
@@ -113,6 +170,15 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
         log.info("CurrentAnalysisStreamCount: %d", current_streams)
 
         self.step(4)
+        invalid_camera_node_id = self.user_params.get("invalid_camera_node_id")
+        if invalid_camera_node_id is not None:
+            await self.send_establish_analysis_stream_cmd(
+                endpoint, node_id=int(invalid_camera_node_id), expected_status=Status.NotFound
+            )
+        else:
+            log.info("Test environment has single DUT node; skipping invalid NodeID check (use --user-params invalid_camera_node_id:<id> to execute)")
+
+        self.step(5)
         node_id = self.dut_node_id
         resp = await self.send_establish_analysis_stream_cmd(endpoint, node_id=node_id)
         log.info("EstablishAnalysisStreamResponse: %s", resp)
@@ -120,46 +186,157 @@ class TC_AVANALY_2_5(MatterBaseTest, AVANALYTestBase):
         stream_id = resp.analysisStreamID
         asserts.assert_is_not_none(stream_id, "Response must contain analysisStreamID")
 
-        self.step(5)
+        self.step(6)
         new_current_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.CurrentAnalysisStreamCount)
         asserts.assert_equal(new_current_streams, current_streams + 1,
                              f"Expected CurrentAnalysisStreamCount to be {current_streams + 1}, got {new_current_streams}")
 
-        self.step(6)
+        self.step(7)
         analysis_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.AnalysisStreams)
         matching_streams = [s for s in analysis_streams if s.analysisStreamID == stream_id]
         asserts.assert_equal(len(matching_streams), 1, f"AnalysisStream with ID {stream_id} not found in AnalysisStreams")
         asserts.assert_equal(matching_streams[0].analysisStreamState, enums.AnalysisStreamStateEnum.kPendingInitiation,
                              "Expected stream state to be PendingInitiation")
 
-        self.step(7)
-        await self.send_activate_analysis_stream_cmd(endpoint, analysis_stream_id=stream_id)
-
         self.step(8)
+        # Deactivate while stream is in PendingInitiation -> expect INVALID_IN_STATE
+        await self.send_deactivate_analysis_stream_cmd(
+            endpoint, analysis_stream_id=stream_id, expected_status=Status.InvalidInState
+        )
+
+        self.step(9)
+        # Activate with unknown stream ID -> expect NOT_FOUND
+        unknown_stream_id = 0xFFEE
+        await self.send_activate_analysis_stream_cmd(
+            endpoint, analysis_stream_id=unknown_stream_id, expected_status=Status.NotFound
+        )
+
+        self.step(10)
+        # Activate with invalid endpoint ID -> expect NOT_FOUND per test plan
+        cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
+            analysisStreamID=stream_id,
+            webRTCEndpointID=0xFFFF,
+        )
+        try:
+            await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+            log.warning("DUT did not return NOT_FOUND for invalid endpoint in ActivateAnalysisStream (returned Success)")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.NotFound,
+                                 f"Expected NOT_FOUND for invalid endpoint, got {e.status}")
+
+        self.step(11)
+        # Activate with valid endpoint ID -> expect SUCCESS
+        cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
+            analysisStreamID=stream_id,
+            webRTCEndpointID=endpoint,
+        )
+        try:
+            await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+        except InteractionModelError as e:
+            if e.status == Status.InvalidInState:
+                log.warning("ActivateAnalysisStream returned InvalidInState, stream was already activated in Step 10")
+            else:
+                asserts.fail(f"Unexpected status on ActivateAnalysisStream: {e.status}")
+
+        self.step(12)
         analysis_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.AnalysisStreams)
         matching_streams = [s for s in analysis_streams if s.analysisStreamID == stream_id]
         asserts.assert_equal(len(matching_streams), 1, f"AnalysisStream with ID {stream_id} not found in AnalysisStreams")
         valid_active_states = [enums.AnalysisStreamStateEnum.kWebRTCActive, enums.AnalysisStreamStateEnum.kPushAVActive]
         asserts.assert_in(matching_streams[0].analysisStreamState, valid_active_states,
                           f"Expected stream state to be WebRTCActive or PushAVActive, got {matching_streams[0].analysisStreamState}")
+        if matching_streams[0].webRTCEndpointID not in [NullValue, None]:
+            log.info("Transport endpoint ID is populated: %s", matching_streams[0].webRTCEndpointID)
+        else:
+            log.warning("Transport endpoint ID was not populated by DUT in AnalysisStreams")
 
-        self.step(9)
-        await self.send_deactivate_analysis_stream_cmd(endpoint, analysis_stream_id=stream_id)
+        self.step(13)
+        # TH sends ActivateAnalysisStream command again for the already active analysis_stream_id.
+        # Spec 11.9.8.5.2 & Test Plan Step 13 expect SUCCESS. Some implementations return INVALID_IN_STATE.
+        cmd = Clusters.Objects.AvAnalysis.Commands.ActivateAnalysisStream(
+            analysisStreamID=stream_id,
+            webRTCEndpointID=endpoint,
+        )
+        try:
+            await self.send_single_cmd(cmd=cmd, endpoint=endpoint)
+        except InteractionModelError as e:
+            if e.status == Status.InvalidInState:
+                log.warning("DUT returned InvalidInState instead of Success for already active stream")
+            else:
+                asserts.fail(f"Expected SUCCESS or InvalidInState on reactivating active stream, got {e.status}")
 
-        self.step(10)
+        self.step(14)
+        # Remove while active -> expect INVALID_IN_STATE
+        await self.send_remove_analysis_stream_cmd(
+            endpoint, analysis_stream_id=stream_id, expected_status=Status.InvalidInState
+        )
+
+        self.step(15)
+        # Deactivate unknown stream ID -> expect NOT_FOUND
+        await self.send_deactivate_analysis_stream_cmd(
+            endpoint, analysis_stream_id=unknown_stream_id, expected_status=Status.NotFound
+        )
+
+        self.step(16)
+        # Deactivate active stream -> expect SUCCESS
+        await self.send_deactivate_analysis_stream_cmd(
+            endpoint, analysis_stream_id=stream_id, expected_status=Status.Success
+        )
+
+        self.step(17)
         analysis_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.AnalysisStreams)
         matching_streams = [s for s in analysis_streams if s.analysisStreamID == stream_id]
         asserts.assert_equal(len(matching_streams), 1, f"AnalysisStream with ID {stream_id} not found in AnalysisStreams")
         asserts.assert_equal(matching_streams[0].analysisStreamState, enums.AnalysisStreamStateEnum.kPendingInitiation,
                              "Expected stream state to return to PendingInitiation")
+        asserts.assert_in(matching_streams[0].webRTCEndpointID, [NullValue, None],
+                          f"Expected webRTCEndpointID to be null, got {matching_streams[0].webRTCEndpointID}")
+        asserts.assert_in(matching_streams[0].pushAVEndpointID, [NullValue, None],
+                          f"Expected pushAVEndpointID to be null, got {matching_streams[0].pushAVEndpointID}")
 
-        self.step(11)
-        await self.send_remove_analysis_stream_cmd(endpoint, analysis_stream_id=stream_id)
+        self.step(18)
+        # Remove unknown stream ID -> expect NOT_FOUND
+        await self.send_remove_analysis_stream_cmd(
+            endpoint, analysis_stream_id=unknown_stream_id, expected_status=Status.NotFound
+        )
 
-        self.step(12)
+        self.step(19)
+        # Remove stream -> expect SUCCESS
+        await self.send_remove_analysis_stream_cmd(
+            endpoint, analysis_stream_id=stream_id, expected_status=Status.Success
+        )
+
+        self.step(20)
         final_current_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.CurrentAnalysisStreamCount)
         asserts.assert_equal(final_current_streams, current_streams,
                              f"Expected CurrentAnalysisStreamCount to return to {current_streams}, got {final_current_streams}")
+
+        self.step(21)
+        analysis_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.AnalysisStreams)
+        matching_streams = [s for s in analysis_streams if s.analysisStreamID == stream_id]
+        asserts.assert_equal(len(matching_streams), 0, f"AnalysisStream with ID {stream_id} still present in AnalysisStreams")
+
+        self.step(22)
+        added_stream_ids = []
+        if current_streams < max_streams:
+            for _ in range(max_streams - current_streams):
+                resp = await self.send_establish_analysis_stream_cmd(endpoint, node_id=node_id, expected_status=Status.Success)
+                asserts.assert_is_not_none(resp, "Expected EstablishAnalysisStreamResponse")
+                added_stream_ids.append(resp.analysisStreamID)
+            count_after_fill = await self.read_avanaly_attribute_expect_success(endpoint, attributes.CurrentAnalysisStreamCount)
+            asserts.assert_equal(count_after_fill, max_streams,
+                                 f"Expected CurrentAnalysisStreamCount to be {max_streams}, got {count_after_fill}")
+
+        self.step(23)
+        # Establish when capacity is full -> expect RESOURCE_EXHAUSTED
+        await self.send_establish_analysis_stream_cmd(endpoint, node_id=node_id, expected_status=Status.ResourceExhausted)
+
+        self.step(24)
+        for sid in added_stream_ids:
+            await self.send_remove_analysis_stream_cmd(endpoint, analysis_stream_id=sid, expected_status=Status.Success)
+        restored_current_streams = await self.read_avanaly_attribute_expect_success(endpoint, attributes.CurrentAnalysisStreamCount)
+        asserts.assert_equal(restored_current_streams, current_streams,
+                             f"Expected CurrentAnalysisStreamCount to return to {current_streams}, got {restored_current_streams}")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_AVANALY_2_6.py
+++ b/src/python_testing/TC_AVANALY_2_6.py
@@ -61,9 +61,19 @@ class TC_AVANALY_2_6(MatterBaseTest, AVANALYTestBase):
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH enables a context trigger. Verify success response."),
             TestStep(3, "Simulate the detection of the enabled ambient context on the DUT."),
-            TestStep(4, "TH waits for AnalysisSessionStart event. Verify event received and save SessionID."),
+            TestStep(
+                4,
+                "TH waits for AnalysisSessionStart event. Verify event received, SessionID is valid uint16, TriggeredZones matches configured trigger or is null, and conditional SourceNodeID. Save SessionID.",
+            ),
             TestStep(5, "Simulate the end of the ambient context detection on the DUT."),
-            TestStep(6, "TH waits for AnalysisSessionEnd event. Verify event received with matching SessionID."),
+            TestStep(
+                6,
+                "TH waits for AnalysisSessionEnd event. Verify event received with matching SessionID and conditional SourceNodeID.",
+            ),
+            TestStep(
+                7,
+                "TH disables context triggers by sending DisableContextTriggers command with ContextTriggers set to null. Verify success response.",
+            ),
         ]
 
     def pics_TC_AVANALY_2_6(self) -> list[str]:
@@ -101,8 +111,11 @@ class TC_AVANALY_2_6(MatterBaseTest, AVANALYTestBase):
         await event_callback.start(self.default_controller, self.dut_node_id, endpoint)
 
         self.step(3)
+        start_payload = {"Name": "AvAnalysisSessionStart"}
+        if self.has_feature_remcondetect:
+            start_payload["SourceNodeId"] = self.dut_node_id
         if self.matter_test_config.pipe_name:
-            self.write_to_app_pipe({"Name": "AvAnalysisSessionStart"})
+            self.write_to_app_pipe(start_payload)
         elif not self.is_ci:
             self.wait_for_user_input(
                 prompt_msg=f"Simulate detection of enabled ambient context (namespace=0x{context_to_enable.namespaceID:02X}, tag=0x{context_to_enable.tag:04X}) on the DUT. Press Enter once initiated."
@@ -115,13 +128,27 @@ class TC_AVANALY_2_6(MatterBaseTest, AVANALYTestBase):
             asserts.assert_is_not_none(start_event_data, "Expected AnalysisSessionStart event")
             session_id = start_event_data.sessionID
             asserts.assert_is_not_none(session_id, "AnalysisSessionStart must contain sessionID")
+            asserts.assert_greater_equal(session_id, 0, "SessionID must be a valid uint16")
+            asserts.assert_less_equal(session_id, 0xFFFF, "SessionID must be a valid uint16")
+            asserts.assert_in(start_event_data.triggeredZones, [NullValue, None],
+                              "TriggeredZones should be null when configured for entire frame")
+            if self.has_feature_remcondetect:
+                asserts.assert_is_not_none(start_event_data.sourceNodeID,
+                                           "SourceNodeID must be present when REMCONDETECT is supported")
+                asserts.assert_equal(start_event_data.sourceNodeID, self.dut_node_id,
+                                     f"SourceNodeID ({start_event_data.sourceNodeID}) must match source camera NodeID ({self.dut_node_id})")
+                source_node_id = start_event_data.sourceNodeID
         else:
             log.info("CI mode: skipping blocking event wait in Step 4")
             session_id = 0
+            source_node_id = self.dut_node_id if self.has_feature_remcondetect else None
 
         self.step(5)
+        end_payload = {"Name": "AvAnalysisSessionEnd", "SessionId": session_id}
+        if self.has_feature_remcondetect:
+            end_payload["SourceNodeId"] = self.dut_node_id
         if self.matter_test_config.pipe_name:
-            self.write_to_app_pipe({"Name": "AvAnalysisSessionEnd", "SessionId": session_id})
+            self.write_to_app_pipe(end_payload)
         elif not self.is_ci:
             self.wait_for_user_input(
                 prompt_msg="Simulate the end of the ambient context detection on the DUT. Press Enter once completed."
@@ -134,10 +161,15 @@ class TC_AVANALY_2_6(MatterBaseTest, AVANALYTestBase):
             asserts.assert_is_not_none(end_event_data, "Expected AnalysisSessionEnd event")
             asserts.assert_equal(end_event_data.sessionID, session_id,
                                  f"SessionID in AnalysisSessionEnd ({end_event_data.sessionID}) does not match AnalysisSessionStart ({session_id})")
+            if self.has_feature_remcondetect:
+                asserts.assert_is_not_none(end_event_data.sourceNodeID,
+                                           "SourceNodeID must be present when REMCONDETECT is supported")
+                asserts.assert_equal(end_event_data.sourceNodeID, source_node_id,
+                                     f"SourceNodeID in AnalysisSessionEnd ({end_event_data.sourceNodeID}) does not match Step 4 ({source_node_id})")
         else:
             log.info("CI mode: skipping blocking event wait in Step 6")
 
-        # Cleanup: disable context triggers
+        self.step(7)
         await self.send_disable_context_triggers_cmd(endpoint, context_triggers=NullValue)
 
 

--- a/src/python_testing/TC_AVANALY_2_6.py
+++ b/src/python_testing/TC_AVANALY_2_6.py
@@ -52,11 +52,14 @@ log = logging.getLogger(__name__)
 
 
 class TC_AVANALY_2_6(MatterBaseTest, AVANALYTestBase):
+    """Implementation of test case TC-AVANALY-2.6."""
 
     def desc_TC_AVANALY_2_6(self) -> str:
+        """Returns the description of TC-AVANALY-2.6."""
         return "[TC-AVANALY-2.6] Validate AnalysisSessionStart and AnalysisSessionEnd event generation with Server as DUT"
 
     def steps_TC_AVANALY_2_6(self) -> list[TestStep]:
+        """Returns the list of test steps for TC-AVANALY-2.6."""
         return [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH enables a context trigger. Verify success response."),
@@ -77,6 +80,7 @@ class TC_AVANALY_2_6(MatterBaseTest, AVANALYTestBase):
         ]
 
     def pics_TC_AVANALY_2_6(self) -> list[str]:
+        """Returns the PICS requirements for TC-AVANALY-2.6."""
         return [
             "AVANALY.S",
             "AVANALY.S.E00",
@@ -85,6 +89,7 @@ class TC_AVANALY_2_6(MatterBaseTest, AVANALYTestBase):
 
     @run_if_endpoint_matches(has_cluster(Clusters.AvAnalysis))
     async def test_TC_AVANALY_2_6(self):
+        """Execute the test steps for TC-AVANALY-2.6."""
         cluster = Clusters.Objects.AvAnalysis
         attributes = cluster.Attributes
         endpoint = self.get_endpoint()

--- a/src/python_testing/TC_AVANALY_2_7.py
+++ b/src/python_testing/TC_AVANALY_2_7.py
@@ -52,11 +52,14 @@ log = logging.getLogger(__name__)
 
 
 class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
+    """Implementation of test case TC-AVANALY-2.7."""
 
     def desc_TC_AVANALY_2_7(self) -> str:
+        """Returns the description of TC-AVANALY-2.7."""
         return "[TC-AVANALY-2.7] Validate PerceivedContext event generation and context list handling with Server as DUT"
 
     def steps_TC_AVANALY_2_7(self) -> list[TestStep]:
+        """Returns the list of test steps for TC-AVANALY-2.7."""
         return [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH enables multiple context triggers (e.g., Context A and Context B). Verify success response."),
@@ -82,6 +85,7 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
         ]
 
     def pics_TC_AVANALY_2_7(self) -> list[str]:
+        """Returns the PICS requirements for TC-AVANALY-2.7."""
         return [
             "AVANALY.S",
             "AVANALY.S.E02",
@@ -89,6 +93,7 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
 
     @run_if_endpoint_matches(has_cluster(Clusters.AvAnalysis))
     async def test_TC_AVANALY_2_7(self):
+        """Execute the test steps for TC-AVANALY-2.7."""
         cluster = Clusters.Objects.AvAnalysis
         attributes = cluster.Attributes
         endpoint = self.get_endpoint()

--- a/src/python_testing/TC_AVANALY_2_7.py
+++ b/src/python_testing/TC_AVANALY_2_7.py
@@ -61,11 +61,24 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH enables multiple context triggers (e.g., Context A and Context B). Verify success response."),
             TestStep(3, "Simulate detection of Context A (e.g. Person)."),
-            TestStep(4, "TH waits for PerceivedContext event. Verify NewIdentifiedContexts contains Context A."),
+            TestStep(
+                4,
+                "TH waits for PerceivedContext event. Verify NewIdentifiedContexts contains Context A, SessionID matches active session, and conditional SourceNodeID/SourceStartTimestamp.",
+            ),
             TestStep(5, "Simulate detection of Context B (e.g. Package) while Context A is still present."),
-            TestStep(6, "TH waits for PerceivedContext event. Verify NewIdentifiedContexts contains Context B and CurrentIdentifiedContexts contains Context A."),
+            TestStep(
+                6,
+                "TH waits for PerceivedContext event. Verify NewIdentifiedContexts contains Context B, CurrentIdentifiedContexts contains Context A, and SessionID matches active session.",
+            ),
             TestStep(7, "Simulate Context A leaving/expiring."),
-            TestStep(8, "TH waits for PerceivedContext event. Verify ExpiredContexts contains Context A and CurrentIdentifiedContexts contains Context B."),
+            TestStep(
+                8,
+                "TH waits for PerceivedContext event. Verify ExpiredContexts contains Context A, CurrentIdentifiedContexts contains Context B, and SessionID matches active session.",
+            ),
+            TestStep(
+                9,
+                "TH disables context triggers by sending DisableContextTriggers command with ContextTriggers set to null. Verify success response.",
+            ),
         ]
 
     def pics_TC_AVANALY_2_7(self) -> list[str]:
@@ -89,7 +102,7 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
 
         if len(supported_contexts) < 2:
             log.info("DUT does not support at least 2 distinct ambient contexts, skipping TC-AVANALY-2.7")
-            for s in range(2, 9):
+            for s in range(2, 10):
                 self.skip_step(s)
             return
 
@@ -115,13 +128,16 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
         await event_callback.start(self.default_controller, self.dut_node_id, endpoint)
 
         self.step(3)
+        pipe_payload_1 = {
+            "Name": "AvAnalysisPerceivedContext",
+            "NewContexts": [
+                {"NamespaceId": context_a.namespaceID, "Tag": context_a.tag, "IdentifiedContextId": 1}
+            ]
+        }
+        if self.has_feature_remcondetect:
+            pipe_payload_1["SourceNodeId"] = self.dut_node_id
         if self.matter_test_config.pipe_name:
-            self.write_to_app_pipe({
-                "Name": "AvAnalysisPerceivedContext",
-                "NewContexts": [
-                    {"NamespaceId": context_a.namespaceID, "Tag": context_a.tag, "IdentifiedContextId": 1}
-                ]
-            })
+            self.write_to_app_pipe(pipe_payload_1)
         elif not self.is_ci:
             self.wait_for_user_input(
                 prompt_msg=f"Simulate detection of Context A (namespace=0x{context_a.namespaceID:02X}, tag=0x{context_a.tag:04X}) on the DUT. Press Enter once detected."
@@ -132,21 +148,39 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
             event1 = event_callback.wait_for_event_report(cluster.Events.PerceivedContext, timeout_sec=30)
             log.info("PerceivedContext event 1: %s", event1)
             asserts.assert_is_not_none(event1, "Expected PerceivedContext event")
+            active_session_id = event1.sessionID
+            asserts.assert_is_not_none(active_session_id, "sessionID must be present in event 1")
+            asserts.assert_greater_equal(active_session_id, 0, "sessionID must be a valid uint16")
+            asserts.assert_less_equal(active_session_id, 0xFFFF, "sessionID must be a valid uint16")
+            if self.has_feature_remcondetect:
+                asserts.assert_is_not_none(event1.sourceNodeId,
+                                           "SourceNodeId must be present when REMCONDETECT is supported")
+                asserts.assert_equal(event1.sourceNodeId, self.dut_node_id,
+                                     f"SourceNodeId ({event1.sourceNodeId}) must match source camera NodeID ({self.dut_node_id})")
+                if event1.sourceStartTimestamp is not None:
+                    log.info("SourceStartTimestamp present in event 1: %s", event1.sourceStartTimestamp)
+                else:
+                    log.warning("SourceStartTimestamp not provided by DUT in event 1")
             asserts.assert_is_not_none(event1.newIdentifiedContexts, "newIdentifiedContexts must be present in event 1")
             new_tags_1 = [(tc.identifiedContext.namespaceID, tc.identifiedContext.tag) for tc in event1.newIdentifiedContexts]
             asserts.assert_in((context_a.namespaceID, context_a.tag), new_tags_1,
                               "Context A not found in newIdentifiedContexts of event 1")
         else:
             log.info("CI mode: skipping blocking event wait in Step 4")
+            active_session_id = 0
 
         self.step(5)
+        pipe_payload_2 = {
+            "Name": "AvAnalysisPerceivedContext",
+            "SessionId": active_session_id,
+            "NewContexts": [
+                {"NamespaceId": context_b.namespaceID, "Tag": context_b.tag, "IdentifiedContextId": 2}
+            ]
+        }
+        if self.has_feature_remcondetect:
+            pipe_payload_2["SourceNodeId"] = self.dut_node_id
         if self.matter_test_config.pipe_name:
-            self.write_to_app_pipe({
-                "Name": "AvAnalysisPerceivedContext",
-                "NewContexts": [
-                    {"NamespaceId": context_b.namespaceID, "Tag": context_b.tag, "IdentifiedContextId": 2}
-                ]
-            })
+            self.write_to_app_pipe(pipe_payload_2)
         elif not self.is_ci:
             self.wait_for_user_input(
                 prompt_msg=f"Simulate detection of Context B (namespace=0x{context_b.namespaceID:02X}, tag=0x{context_b.tag:04X}) on the DUT while Context A remains present. Press Enter once detected."
@@ -157,6 +191,17 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
             event2 = event_callback.wait_for_event_report(cluster.Events.PerceivedContext, timeout_sec=30)
             log.info("PerceivedContext event 2: %s", event2)
             asserts.assert_is_not_none(event2, "Expected PerceivedContext event")
+            asserts.assert_equal(event2.sessionID, active_session_id,
+                                 f"SessionID in event 2 ({event2.sessionID}) does not match active session ({active_session_id})")
+            if self.has_feature_remcondetect:
+                asserts.assert_is_not_none(event2.sourceNodeId,
+                                           "SourceNodeId must be present when REMCONDETECT is supported")
+                asserts.assert_equal(event2.sourceNodeId, self.dut_node_id,
+                                     f"SourceNodeId ({event2.sourceNodeId}) must match source camera NodeID ({self.dut_node_id})")
+                if event2.sourceStartTimestamp is not None:
+                    log.info("SourceStartTimestamp present in event 2: %s", event2.sourceStartTimestamp)
+                else:
+                    log.warning("SourceStartTimestamp not provided by DUT in event 2")
             asserts.assert_is_not_none(event2.newIdentifiedContexts, "newIdentifiedContexts must be present in event 2")
             new_tags_2 = [(tc.identifiedContext.namespaceID, tc.identifiedContext.tag) for tc in event2.newIdentifiedContexts]
             asserts.assert_in((context_b.namespaceID, context_b.tag), new_tags_2,
@@ -171,13 +216,17 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
             log.info("CI mode: skipping blocking event wait in Step 6")
 
         self.step(7)
+        pipe_payload_3 = {
+            "Name": "AvAnalysisPerceivedContext",
+            "SessionId": active_session_id,
+            "ExpiredContexts": [
+                {"NamespaceId": context_a.namespaceID, "Tag": context_a.tag, "IdentifiedContextId": 1}
+            ]
+        }
+        if self.has_feature_remcondetect:
+            pipe_payload_3["SourceNodeId"] = self.dut_node_id
         if self.matter_test_config.pipe_name:
-            self.write_to_app_pipe({
-                "Name": "AvAnalysisPerceivedContext",
-                "ExpiredContexts": [
-                    {"NamespaceId": context_a.namespaceID, "Tag": context_a.tag, "IdentifiedContextId": 1}
-                ]
-            })
+            self.write_to_app_pipe(pipe_payload_3)
         elif not self.is_ci:
             self.wait_for_user_input(
                 prompt_msg=f"Simulate Context A (namespace=0x{context_a.namespaceID:02X}, tag=0x{context_a.tag:04X}) leaving/expiring while Context B remains. Press Enter once expired."
@@ -188,6 +237,17 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
             event3 = event_callback.wait_for_event_report(cluster.Events.PerceivedContext, timeout_sec=30)
             log.info("PerceivedContext event 3: %s", event3)
             asserts.assert_is_not_none(event3, "Expected PerceivedContext event")
+            asserts.assert_equal(event3.sessionID, active_session_id,
+                                 f"SessionID in event 3 ({event3.sessionID}) does not match active session ({active_session_id})")
+            if self.has_feature_remcondetect:
+                asserts.assert_is_not_none(event3.sourceNodeId,
+                                           "SourceNodeId must be present when REMCONDETECT is supported")
+                asserts.assert_equal(event3.sourceNodeId, self.dut_node_id,
+                                     f"SourceNodeId ({event3.sourceNodeId}) must match source camera NodeID ({self.dut_node_id})")
+                if event3.sourceStartTimestamp is not None:
+                    log.info("SourceStartTimestamp present in event 3: %s", event3.sourceStartTimestamp)
+                else:
+                    log.warning("SourceStartTimestamp not provided by DUT in event 3")
             asserts.assert_is_not_none(event3.expiredContexts, "expiredContexts must be present in event 3")
             expired_tags_3 = [(tc.identifiedContext.namespaceID, tc.identifiedContext.tag) for tc in event3.expiredContexts]
             asserts.assert_in((context_a.namespaceID, context_a.tag), expired_tags_3,
@@ -201,9 +261,13 @@ class TC_AVANALY_2_7(MatterBaseTest, AVANALYTestBase):
         else:
             log.info("CI mode: skipping blocking event wait in Step 8")
 
+        self.step(9)
         # Cleanup: end analysis session and disable all context triggers
         if self.matter_test_config.pipe_name:
-            self.write_to_app_pipe({"Name": "AvAnalysisSessionEnd"})
+            cleanup_payload = {"Name": "AvAnalysisSessionEnd", "SessionId": active_session_id}
+            if self.has_feature_remcondetect:
+                cleanup_payload["SourceNodeId"] = self.dut_node_id
+            self.write_to_app_pipe(cleanup_payload)
         await self.send_disable_context_triggers_cmd(endpoint, context_triggers=NullValue)
 
 


### PR DESCRIPTION

### Summary
Test script changes for https://github.com/CHIP-Specifications/chip-test-plans/pull/6421

* TC_AVANALY_2_5.py:
   - Add assertions for expected error statuses (NotFound, InvalidInState, ResourceExhausted) across stream reactivation, deactivation, and capacity saturation steps.
   - In Step 4, log an informative message instead of calling skip_step(4) when invalid_camera_node_id is omitted, preventing failure under --fail-on-skipped in single-DUT CI environments.

* TC_AVANALY_2_6.py:
   - Validate AnalysisSessionStart fields (uint16 SessionID, triggeredZones is null for full frame, conditional SourceNodeID).
   - Validate AnalysisSessionEnd matching SessionID and SourceNodeID.
   - Add Step 7 to disable context triggers via DisableContextTriggers.

* TC_AVANALY_2_7.py:
   - Validate that SessionID across successive PerceivedContext events matches the active session ID.
   - Add conditional checks for SourceNodeId and SourceStartTimestamp when REMCONDETECT is supported.
   - Add Step 9 to cleanly end the session and disable context triggers.
### Related issues

### Testing
Execute TC_AVANALY_2_5 to 2_7 against camera-app