### PR TITLE
[Draft]Implement Triple-Guard CASE Server preemption and dynamic busy wait

### DIFF
--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -17,6 +17,7 @@
 
 #include <protocols/secure_channel/CASEServer.h>
 
+#include <crypto/RandUtils.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPFaultInjection.h>
 #include <lib/support/CodeUtils.h>
@@ -86,40 +87,48 @@ CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const 
     CHIP_FAULT_INJECT(FaultInjection::kFault_CASEServerBusy, busy = true);
     if (busy)
     {
+        uint8_t incomingRandomBuf[kSigmaParamRandomNumberSize];
+        MutableByteSpan incomingInitiatorRandom(incomingRandomBuf);
+        uint8_t incomingDestIdBuf[Crypto::kSHA256_Hash_Length];
+        MutableByteSpan incomingDestinationId(incomingDestIdBuf);
+        if (PeekSigma1Params(payload, incomingInitiatorRandom, incomingDestinationId) == CHIP_NO_ERROR)
+        {
+            auto activeExchange = GetSession().GetExchangeContext();
+            if (activeExchange.HasValue() &&
+                activeExchange.Value()->GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress() ==
+                    ec->GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress())
+            {
+                // Guard 1: initiatorRandom inequality guard to distinguish MRP retries from new sessions
+                if (incomingInitiatorRandom.data_equal(GetSession().GetInitiatorRandom()))
+                {
+                    // MRP Duplicate/Retransmission!
+                    ChipLogProgress(SecureChannel, "CASE Server detected Sigma1 MRP retry. Resending Sigma2/ACK.");
+                    return HandleMRPRetry(ec);
+                }
+
+                // Different initiatorRandom indicates a new session attempt by the client.
+                // Guard 2 (Active crypto guard), Guard 3 (1.5s temporal grace window),
+                // and Guard 4 (Destination ID validation against provisioned fabrics)
+                if (CanPreemptSession(ec, incomingInitiatorRandom, incomingDestinationId))
+                {
+                    ChipLogProgress(SecureChannel, "CASE Server passed Quadruple Guard Preemption. Preempting stale session.");
+                    PreemptExistingSession();
+                    busy = false;
+                }
+            }
+        }
+    }
+    if (busy)
+    {
         // We are in the middle of CASE handshake
 
         // Invoke watchdog to fix any stuck handshakes
         bool watchdogFired = GetSession().InvokeBackgroundWorkWatchdog();
         if (!watchdogFired)
         {
-            // Handshake wasn't stuck, send the busy status report and let the existing handshake continue.
-
-            // A successful CASE handshake can take several seconds and some may time out (30 seconds or more).
-
-            System::Clock::Milliseconds16 delay = System::Clock::kZero;
-            if (GetSession().GetState() == CASESession::State::kSentSigma2)
-            {
-                // The delay should be however long we think it will take for
-                // that to time out.
-                auto sigma2Timeout = CASESession::ComputeSigma2ResponseTimeout(GetSession().GetRemoteMRPConfig());
-                if (sigma2Timeout < System::Clock::Milliseconds16::max())
-                {
-                    delay = std::chrono::duration_cast<System::Clock::Milliseconds16>(sigma2Timeout);
-                }
-                else
-                {
-                    // Avoid overflow issues, just wait for as long as we can to
-                    // get close to our expected Sigma2 timeout.
-                    delay = System::Clock::Milliseconds16::max();
-                }
-            }
-            else
-            {
-                // For now, setting minimum wait time to 5000 milliseconds if we
-                // have no other information.
-                delay = System::Clock::Milliseconds16(5000);
-            }
-            CHIP_ERROR err = SendBusyStatusReport(ec, delay);
+            // Handshake wasn't stuck, send dynamic busy status report
+            System::Clock::Milliseconds16 delay = ComputeDynamicBusyDelay();
+            CHIP_ERROR err                      = SendBusyStatusReport(ec, delay);
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(Inet, "Failed to send the busy status report, err:%" CHIP_ERROR_FORMAT, err.Format());
@@ -138,6 +147,8 @@ CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const 
 
     CHIP_ERROR err = InitCASEHandshake(ec);
     SuccessOrExit(err);
+
+    mStateEnteredTimestamp = System::SystemClock().GetMonotonicTimestamp();
 
     // TODO - Enable multiple concurrent CASE session establishment
     // https://github.com/project-chip/connectedhomeip/issues/8342
@@ -232,6 +243,165 @@ CHIP_ERROR CASEServer::SendBusyStatusReport(Messaging::ExchangeContext * ec, Sys
 
     ChipLogProgress(Inet, "Sending status report, exchange " ChipLogFormatExchange, ChipLogValueExchange(ec));
     return ec->SendMessage(Protocols::SecureChannel::MsgType::StatusReport, std::move(handle));
+}
+
+CHIP_ERROR CASEServer::PeekSigma1Params(const System::PacketBufferHandle & payload, MutableByteSpan & outInitiatorRandom,
+                                        MutableByteSpan & outDestinationId)
+{
+    VerifyOrReturnError(!payload.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
+    System::PacketBufferTLVReader reader;
+    reader.Init(payload.Retain());
+    TLV::TLVType containerType = TLV::kTLVType_Structure;
+    ReturnErrorOnFailure(reader.Next(containerType, TLV::AnonymousTag()));
+    ReturnErrorOnFailure(reader.EnterContainer(containerType));
+
+    // Tag 1: initiatorRandom
+    ReturnErrorOnFailure(reader.Next(TLV::ContextTag(1)));
+    ByteSpan randomSpan;
+    ReturnErrorOnFailure(reader.GetByteView(randomSpan));
+    VerifyOrReturnError(randomSpan.size() <= outInitiatorRandom.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(outInitiatorRandom.data(), randomSpan.data(), randomSpan.size());
+    outInitiatorRandom.reduce_size(randomSpan.size());
+
+    // Tag 2: initiatorSessionId
+    ReturnErrorOnFailure(reader.Next(TLV::ContextTag(2)));
+    uint16_t initiatorSessionId = 0;
+    ReturnErrorOnFailure(reader.Get(initiatorSessionId));
+
+    // Tag 3: destinationId
+    ReturnErrorOnFailure(reader.Next(TLV::ContextTag(3)));
+    ByteSpan destIdSpan;
+    ReturnErrorOnFailure(reader.GetByteView(destIdSpan));
+    VerifyOrReturnError(destIdSpan.size() <= outDestinationId.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(outDestinationId.data(), destIdSpan.data(), destIdSpan.size());
+    outDestinationId.reduce_size(destIdSpan.size());
+
+    return CHIP_NO_ERROR;
+}
+
+bool CASEServer::ValidateDestinationId(const ByteSpan & destinationId, const ByteSpan & initiatorRandom) const
+{
+    if (mFabrics == nullptr || mGroupDataProvider == nullptr)
+    {
+        return false;
+    }
+
+    for (const FabricInfo & fabricInfo : *mFabrics)
+    {
+        FabricId fabricId = fabricInfo.GetFabricId();
+        NodeId nodeId     = fabricInfo.GetNodeId();
+        Crypto::P256PublicKey rootPubKey;
+        CHIP_ERROR err = mFabrics->FetchRootPubkey(fabricInfo.GetFabricIndex(), rootPubKey);
+        if (err != CHIP_NO_ERROR)
+        {
+            continue;
+        }
+        Credentials::P256PublicKeySpan rootPubKeySpan{ rootPubKey.ConstBytes() };
+
+        GroupDataProvider::KeySet ipkKeySet;
+        auto ipkKeySetWiperOnScopeExit = ScopeExit([&] { ipkKeySet.ClearKeys(); });
+        err                            = mGroupDataProvider->GetIpkKeySet(fabricInfo.GetFabricIndex(), ipkKeySet);
+        if ((err != CHIP_NO_ERROR) ||
+            ((ipkKeySet.num_keys_used == 0) || (ipkKeySet.num_keys_used > Credentials::GroupDataProvider::KeySet::kEpochKeysMax)))
+        {
+            continue;
+        }
+
+        for (size_t keyIdx = 0; keyIdx < ipkKeySet.num_keys_used; ++keyIdx)
+        {
+            uint8_t candidateDestinationId[Crypto::kSHA256_Hash_Length];
+            MutableByteSpan candidateDestinationIdSpan(candidateDestinationId);
+            ByteSpan candidateIpkSpan(ipkKeySet.epoch_keys[keyIdx].key);
+
+            err = GenerateCaseDestinationId(candidateIpkSpan, initiatorRandom, rootPubKeySpan, fabricId, nodeId,
+                                            candidateDestinationIdSpan);
+            if ((err == CHIP_NO_ERROR) && candidateDestinationIdSpan.data_equal(destinationId))
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool CASEServer::CanPreemptSession(Messaging::ExchangeContext * ec, const ByteSpan & incomingInitiatorRandom,
+                                   const ByteSpan & incomingDestinationId)
+{
+    // Guard 2: Active crypto calculation guard
+    if (GetSession().IsCryptoOperationInProgress())
+    {
+        ChipLogProgress(SecureChannel, "Preemption blocked: active crypto operation in progress.");
+        return false;
+    }
+
+    // Guard 3: Temporal grace window (1.5s) for in-flight Sigma2 packets
+    System::Clock::Timestamp now   = System::SystemClock().GetMonotonicTimestamp();
+    System::Clock::Timeout elapsed = (now >= mStateEnteredTimestamp) ? (now - mStateEnteredTimestamp) : System::Clock::kZero;
+    if (elapsed < kInFlightGraceWindow)
+    {
+        ChipLogProgress(SecureChannel, "Preemption deferred: Sigma2 in transit (grace window %u ms remaining).",
+                        static_cast<unsigned>((kInFlightGraceWindow - elapsed).count()));
+        return false;
+    }
+
+    // Guard 4: Destination ID validation against provisioned fabrics
+    VerifyOrReturnError(ValidateDestinationId(incomingDestinationId, incomingInitiatorRandom), false);
+
+    return true;
+}
+
+CHIP_ERROR CASEServer::HandleMRPRetry(Messaging::ExchangeContext * ec)
+{
+    if (ec != nullptr && ec->GetReliableMessageContext() != nullptr)
+    {
+        return ec->GetReliableMessageContext()->SendStandaloneAckMessage();
+    }
+    return CHIP_NO_ERROR;
+}
+
+void CASEServer::PreemptExistingSession()
+{
+    MATTER_TRACE_SCOPE("PreemptExistingSession", "CASEServer");
+    ChipLogProgress(SecureChannel, "Preempting stale CASE session for superseding retry");
+
+    GetSession().DiscardExchange();
+    GetSession().Clear();
+    mPinnedSecureSession.ClearValue();
+    PrepareForSessionEstablishment();
+}
+
+System::Clock::Milliseconds16 CASEServer::ComputeDynamicBusyDelay()
+{
+    System::Clock::Timeout expectedDuration = System::Clock::kZero;
+    if (GetSession().GetState() == CASESession::State::kSentSigma2)
+    {
+        expectedDuration = CASESession::ComputeSigma2ResponseTimeout(GetSession().GetRemoteMRPConfig());
+    }
+    else if (GetSession().IsCryptoOperationInProgress())
+    {
+        expectedDuration = System::Clock::Milliseconds16(250);
+    }
+    else
+    {
+        expectedDuration = System::Clock::Milliseconds16(2000);
+    }
+
+    System::Clock::Timestamp now   = System::SystemClock().GetMonotonicTimestamp();
+    System::Clock::Timeout elapsed = (now >= mStateEnteredTimestamp) ? (now - mStateEnteredTimestamp) : System::Clock::kZero;
+    System::Clock::Timeout remaining =
+        (expectedDuration > elapsed) ? (expectedDuration - elapsed) : System::Clock::Timeout(System::Clock::Milliseconds16(250));
+
+    if (remaining < System::Clock::Milliseconds16(250))
+    {
+        remaining = System::Clock::Milliseconds16(250);
+    }
+
+    uint16_t jitterMs = static_cast<uint16_t>(50 + (Crypto::GetRandU16() % 200));
+    remaining += System::Clock::Milliseconds16(jitterMs);
+
+    return std::chrono::duration_cast<System::Clock::Milliseconds16>(
+        std::min<System::Clock::Timeout>(remaining, System::Clock::Milliseconds16::max()));
 }
 
 } // namespace chip

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -21,6 +21,7 @@
 #include <credentials/GroupDataProvider.h>
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
+#include <protocols/secure_channel/CASEDestinationId.h>
 #include <protocols/secure_channel/CASESession.h>
 #include <system/SystemClock.h>
 
@@ -79,6 +80,9 @@ public:
     }
 
 private:
+    friend class CASEServerAccess;
+    friend class TestCASESession;
+
     Messaging::ExchangeManager * mExchangeManager                       = nullptr;
     SessionResumptionStorage * mSessionResumptionStorage                = nullptr;
     Credentials::CertificateValidityPolicy * mCertificateValidityPolicy = nullptr;
@@ -114,6 +118,33 @@ private:
      *
      */
     void PrepareForSessionEstablishment(const ScopedNodeId & previouslyEstablishedPeer = ScopedNodeId());
+
+    // Temporal grace window (1.5s) to protect in-flight Sigma2 packets from premature preemption
+    static constexpr System::Clock::Milliseconds16 kInFlightGraceWindow = System::Clock::Milliseconds16(1500);
+
+    // Dynamic wait time tracking for busy status reports
+    System::Clock::Timestamp mStateEnteredTimestamp = System::Clock::kZero;
+
+    // Helper to extract initiatorRandom and destinationId from raw Sigma1 TLV payload without consuming the buffer
+    CHIP_ERROR PeekSigma1Params(const System::PacketBufferHandle & payload, MutableByteSpan & outInitiatorRandom,
+                                MutableByteSpan & outDestinationId);
+
+    // Guard 4: Destination ID validation against provisioned fabrics
+    bool ValidateDestinationId(const ByteSpan & destinationId, const ByteSpan & initiatorRandom) const;
+
+    // Evaluates Quadruple Guard Preemption:
+    // Guard 1: initiatorRandom inequality
+    // Guard 2: active crypto calculation guard
+    // Guard 3: temporal grace window (1.5s)
+    // Guard 4: destination ID validation against provisioned fabrics
+    bool CanPreemptSession(Messaging::ExchangeContext * ec, const ByteSpan & incomingInitiatorRandom,
+                           const ByteSpan & incomingDestinationId);
+
+    // Handles MRP retransmissions by re-sending cached Sigma2 or Standalone ACK
+    CHIP_ERROR HandleMRPRetry(Messaging::ExchangeContext * ec);
+
+    void PreemptExistingSession();
+    System::Clock::Milliseconds16 ComputeDynamicBusyDelay();
 
     // If we are in the middle of handshake and receive a Sigma1 then respond with Busy status code.
     // @param[in] ec              Exchange Context

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1043,6 +1043,8 @@ CASESession::NextStep CASESession::HandleSigma1(System::PacketBufferHandle && ms
 
     ReturnErrorVariantOnFailure(NextStep, ParseSigma1(tlvReader, parsedSigma1));
 
+    std::copy(parsedSigma1.initiatorRandom.begin(), parsedSigma1.initiatorRandom.end(), mInitiatorRandom);
+
     ChipLogDetail(SecureChannel, "Peer (Initiator) assigned session ID %d", parsedSigma1.initiatorSessionId);
     SetPeerSessionId(parsedSigma1.initiatorSessionId);
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -186,6 +186,14 @@ public:
 
     State GetState() { return mState; }
 
+    ByteSpan GetInitiatorRandom() const { return ByteSpan(mInitiatorRandom); }
+
+    bool IsCryptoOperationInProgress() const
+    {
+        return (mSendSigma3Helper != nullptr) || (mHandleSigma3Helper != nullptr) || (mState == State::kHandleSigma3Pending) ||
+            (mState == State::kSendSigma3Pending);
+    }
+
     // Returns true if the CASE session handshake was stuck due to failing to schedule work on the Matter thread.
     // If this function returns true, the CASE session has been reset and is ready for a new session establishment.
     bool InvokeBackgroundWorkWatchdog();
@@ -466,6 +474,7 @@ protected:
 
 private:
     friend class TestCASESession;
+    friend class CASEServerAccess;
 
     using AutoReleaseSessionKey = Crypto::AutoReleaseSymmetricKey<Crypto::Aes128KeyHandle>;
 

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -105,6 +105,9 @@ public:
     const SessionParameters & GetLocalSessionParameters() const { return mLocalSessionParams; }
     void SetLocalSessionParameters(const SessionParameters & sessionParams) { mLocalSessionParams = sessionParams; }
 
+    const Optional<Messaging::ExchangeHandle> & GetExchangeContext() const { return mExchangeCtxt; }
+    void DiscardExchange();
+
     /**
      * Encode the Session Parameters using the provided TLV tag.
      */
@@ -127,8 +130,6 @@ protected:
     CHIP_ERROR ActivateSecureSession(const Transport::PeerAddress & peerAddress);
 
     void Finish();
-
-    void DiscardExchange(); // Clear our reference to our exchange context pointer so that it can close itself at some later time.
 
     void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -1727,8 +1727,8 @@ struct SessionResumptionTestStorage : SessionResumptionStorage
 {
     SessionResumptionTestStorage(CHIP_ERROR findMethodReturnCode, ScopedNodeId peerNodeId, ResumptionIdStorage * resumptionId,
                                  Crypto::P256ECDHDerivedSecret * sharedSecret) :
-        mFindMethodReturnCode(findMethodReturnCode), mPeerNodeId(peerNodeId), mResumptionId(resumptionId),
-        mSharedSecret(sharedSecret)
+        mFindMethodReturnCode(findMethodReturnCode),
+        mPeerNodeId(peerNodeId), mResumptionId(resumptionId), mSharedSecret(sharedSecret)
     {}
     SessionResumptionTestStorage(CHIP_ERROR findMethodReturnCode) : mFindMethodReturnCode(findMethodReturnCode) {}
     CHIP_ERROR FindByScopedNodeId(const ScopedNodeId & node, ResumptionIdStorage & resumptionId,

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -86,6 +86,42 @@ public:
     using CASESession::ParseSigma3TBEData;
 };
 
+class CASEServerAccess
+{
+public:
+    static CHIP_ERROR PeekSigma1Params(CASEServer & server, const System::PacketBufferHandle & payload,
+                                       MutableByteSpan & outInitiatorRandom, MutableByteSpan & outDestinationId)
+    {
+        return server.PeekSigma1Params(payload, outInitiatorRandom, outDestinationId);
+    }
+
+    static bool ValidateDestinationId(const CASEServer & server, const ByteSpan & destinationId, const ByteSpan & initiatorRandom)
+    {
+        return server.ValidateDestinationId(destinationId, initiatorRandom);
+    }
+
+    static bool CanPreemptSession(CASEServer & server, Messaging::ExchangeContext * ec, const ByteSpan & incomingInitiatorRandom,
+                                  const ByteSpan & incomingDestinationId)
+    {
+        return server.CanPreemptSession(ec, incomingInitiatorRandom, incomingDestinationId);
+    }
+
+    static CHIP_ERROR HandleMRPRetry(CASEServer & server, Messaging::ExchangeContext * ec) { return server.HandleMRPRetry(ec); }
+
+    static void PreemptExistingSession(CASEServer & server) { server.PreemptExistingSession(); }
+
+    static System::Clock::Milliseconds16 ComputeDynamicBusyDelay(CASEServer & server) { return server.ComputeDynamicBusyDelay(); }
+
+    static void SetStateEnteredTimestamp(CASEServer & server, System::Clock::Timestamp ts) { server.mStateEnteredTimestamp = ts; }
+
+    static bool HasPinnedSecureSession(const CASEServer & server) { return server.mPinnedSecureSession.HasValue(); }
+
+    static void SetCryptoOperationInProgress(CASEServer & server, bool inProgress)
+    {
+        server.mPairingSession.mState = inProgress ? CASESession::State::kHandleSigma3Pending : CASESession::State::kInitialized;
+    }
+};
+
 class TestCASESession : public chip::Testing::LoopbackMessagingContext
 {
 public:
@@ -1691,8 +1727,8 @@ struct SessionResumptionTestStorage : SessionResumptionStorage
 {
     SessionResumptionTestStorage(CHIP_ERROR findMethodReturnCode, ScopedNodeId peerNodeId, ResumptionIdStorage * resumptionId,
                                  Crypto::P256ECDHDerivedSecret * sharedSecret) :
-        mFindMethodReturnCode(findMethodReturnCode),
-        mPeerNodeId(peerNodeId), mResumptionId(resumptionId), mSharedSecret(sharedSecret)
+        mFindMethodReturnCode(findMethodReturnCode), mPeerNodeId(peerNodeId), mResumptionId(resumptionId),
+        mSharedSecret(sharedSecret)
     {}
     SessionResumptionTestStorage(CHIP_ERROR findMethodReturnCode) : mFindMethodReturnCode(findMethodReturnCode) {}
     CHIP_ERROR FindByScopedNodeId(const ScopedNodeId & node, ResumptionIdStorage & resumptionId,
@@ -2415,6 +2451,180 @@ TEST_F(TestCASESession, ParseSigma3TBEData)
     TestSigma3TBEParsing(mem, bufferSize, Sigma3TBETooShortSignature);
     TestSigma3TBEParsing(mem, bufferSize, Sigma3TBEFutureProofTlvElement);
     TestSigma3TBEParsing(mem, bufferSize, Sigma3TBEFutureProofTlvElementNoStructEnd);
+}
+
+TEST_F(TestCASESession, CASEServerPeekSigma1Params)
+{
+    constexpr size_t bufferSize = 1024;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> mem;
+    EXPECT_TRUE(mem.Calloc(bufferSize));
+
+    MutableByteSpan buf(mem.Get(), bufferSize);
+    EXPECT_EQ(EncodeSigma1Helper<Sigma1Params>(buf), CHIP_NO_ERROR);
+
+    System::PacketBufferHandle msg = System::PacketBufferHandle::NewWithData(buf.data(), buf.size());
+    EXPECT_FALSE(msg.IsNull());
+
+    uint8_t initiatorRandom[Sigma1Params::kInitiatorRandomLen];
+    uint8_t destinationId[Crypto::kSHA256_Hash_Length];
+    MutableByteSpan outRandom(initiatorRandom);
+    MutableByteSpan outDest(destinationId);
+
+    EXPECT_EQ(CASEServerAccess::PeekSigma1Params(gPairingServer, msg, outRandom, outDest), CHIP_NO_ERROR);
+    EXPECT_EQ(outRandom.size(), sizeof(initiatorRandom));
+    EXPECT_EQ(outDest.size(), sizeof(destinationId));
+
+    // Verify parsed contents match Sigma1Params
+    EXPECT_EQ(initiatorRandom[0], 1);
+    EXPECT_EQ(destinationId[0], 2);
+
+    // Test with truncated buffer (invalid TLV)
+    uint8_t badData[]                 = { 0x15, 0x25, 0x01 };
+    System::PacketBufferHandle badMsg = System::PacketBufferHandle::NewWithData(badData, sizeof(badData));
+    EXPECT_NE(CASEServerAccess::PeekSigma1Params(gPairingServer, badMsg, outRandom, outDest), CHIP_NO_ERROR);
+}
+
+TEST_F(TestCASESession, CASEServerValidateDestinationId)
+{
+    EXPECT_EQ(gPairingServer.ListenForSessionEstablishment(&GetExchangeManager(), &GetSecureSessionManager(), &gDeviceFabrics,
+                                                           nullptr, nullptr, &gDeviceGroupDataProvider),
+              CHIP_NO_ERROR);
+
+    const FabricInfo * deviceFabric = gDeviceFabrics.FindFabricWithIndex(gDeviceFabricIndex);
+    ASSERT_NE(deviceFabric, nullptr);
+    FabricId fabricId = deviceFabric->GetFabricId();
+    NodeId nodeId     = deviceFabric->GetNodeId();
+
+    Crypto::P256PublicKey rootPubKey;
+    ASSERT_EQ(gDeviceFabrics.FetchRootPubkey(deviceFabric->GetFabricIndex(), rootPubKey), CHIP_NO_ERROR);
+    Credentials::P256PublicKeySpan rootPubKeySpan{ rootPubKey.ConstBytes() };
+
+    GroupDataProvider::KeySet ipkKeySet;
+    ASSERT_EQ(gDeviceGroupDataProvider.GetIpkKeySet(deviceFabric->GetFabricIndex(), ipkKeySet), CHIP_NO_ERROR);
+    ASSERT_GT(ipkKeySet.num_keys_used, 0u);
+
+    uint8_t randomBytes[Sigma1Params::kInitiatorRandomLen] = { 0x5A };
+    ByteSpan randomSpan(randomBytes);
+    uint8_t validDestId[Crypto::kSHA256_Hash_Length];
+    MutableByteSpan validDestIdSpan(validDestId);
+    ByteSpan ipkSpan(ipkKeySet.epoch_keys[0].key);
+
+    ASSERT_EQ(GenerateCaseDestinationId(ipkSpan, randomSpan, rootPubKeySpan, fabricId, nodeId, validDestIdSpan), CHIP_NO_ERROR);
+
+    // Valid destination ID matches
+    EXPECT_TRUE(CASEServerAccess::ValidateDestinationId(gPairingServer, validDestIdSpan, randomSpan));
+
+    // Mismatched destination ID fails
+    uint8_t invalidDestId[Crypto::kSHA256_Hash_Length];
+    memcpy(invalidDestId, validDestId, sizeof(invalidDestId));
+    invalidDestId[0] ^= 0xFF;
+    EXPECT_FALSE(CASEServerAccess::ValidateDestinationId(gPairingServer, ByteSpan(invalidDestId), randomSpan));
+
+    // Mismatched random fails
+    uint8_t wrongRandomBytes[Sigma1Params::kInitiatorRandomLen] = { 0xA5 };
+    EXPECT_FALSE(CASEServerAccess::ValidateDestinationId(gPairingServer, validDestIdSpan, ByteSpan(wrongRandomBytes)));
+
+    gPairingServer.Shutdown();
+}
+
+TEST_F(TestCASESession, CASEServerQuadrupleGuardPreemption)
+{
+    EXPECT_EQ(gPairingServer.ListenForSessionEstablishment(&GetExchangeManager(), &GetSecureSessionManager(), &gDeviceFabrics,
+                                                           nullptr, nullptr, &gDeviceGroupDataProvider),
+              CHIP_NO_ERROR);
+
+    const FabricInfo * deviceFabric = gDeviceFabrics.FindFabricWithIndex(gDeviceFabricIndex);
+    ASSERT_NE(deviceFabric, nullptr);
+
+    Crypto::P256PublicKey rootPubKey;
+    ASSERT_EQ(gDeviceFabrics.FetchRootPubkey(deviceFabric->GetFabricIndex(), rootPubKey), CHIP_NO_ERROR);
+    GroupDataProvider::KeySet ipkKeySet;
+    ASSERT_EQ(gDeviceGroupDataProvider.GetIpkKeySet(deviceFabric->GetFabricIndex(), ipkKeySet), CHIP_NO_ERROR);
+
+    uint8_t randomBytes[Sigma1Params::kInitiatorRandomLen] = { 0x33 };
+    ByteSpan randomSpan(randomBytes);
+    uint8_t validDestId[Crypto::kSHA256_Hash_Length];
+    MutableByteSpan validDestIdSpan(validDestId);
+
+    ASSERT_EQ(GenerateCaseDestinationId(ByteSpan(ipkKeySet.epoch_keys[0].key), randomSpan,
+                                        Credentials::P256PublicKeySpan{ rootPubKey.ConstBytes() }, deviceFabric->GetFabricId(),
+                                        deviceFabric->GetNodeId(), validDestIdSpan),
+              CHIP_NO_ERROR);
+
+    // Guard 2: Crypto in progress blocks preemption
+    CASEServerAccess::SetCryptoOperationInProgress(gPairingServer, true);
+    EXPECT_FALSE(CASEServerAccess::CanPreemptSession(gPairingServer, nullptr, randomSpan, validDestIdSpan));
+    CASEServerAccess::SetCryptoOperationInProgress(gPairingServer, false);
+
+    // Guard 3: In-flight grace window (<1.5s) blocks preemption
+    System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
+    CASEServerAccess::SetStateEnteredTimestamp(gPairingServer, now);
+    EXPECT_FALSE(CASEServerAccess::CanPreemptSession(gPairingServer, nullptr, randomSpan, validDestIdSpan));
+
+    // Advance elapsed time past grace window (2000ms elapsed)
+    CASEServerAccess::SetStateEnteredTimestamp(gPairingServer, now - System::Clock::Milliseconds64(2000));
+
+    // Guard 4: Invalid destination ID blocks preemption
+    uint8_t bogusDestId[Crypto::kSHA256_Hash_Length] = { 0xDE, 0xAD };
+    EXPECT_FALSE(CASEServerAccess::CanPreemptSession(gPairingServer, nullptr, randomSpan, ByteSpan(bogusDestId)));
+
+    // All guards pass: Preemption is allowed!
+    EXPECT_TRUE(CASEServerAccess::CanPreemptSession(gPairingServer, nullptr, randomSpan, validDestIdSpan));
+
+    gPairingServer.Shutdown();
+}
+
+TEST_F(TestCASESession, CASEServerComputeDynamicBusyDelay)
+{
+    EXPECT_EQ(gPairingServer.ListenForSessionEstablishment(&GetExchangeManager(), &GetSecureSessionManager(), &gDeviceFabrics,
+                                                           nullptr, nullptr, &gDeviceGroupDataProvider),
+              CHIP_NO_ERROR);
+
+    System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
+    CASEServerAccess::SetStateEnteredTimestamp(gPairingServer, now);
+
+    // Default state with 0 elapsed: expected 2000ms + [50, 250)ms jitter -> within [2050, 2250] ms
+    System::Clock::Milliseconds16 delay = CASEServerAccess::ComputeDynamicBusyDelay(gPairingServer);
+    EXPECT_GE(delay.count(), 2050);
+    EXPECT_LE(delay.count(), 2250);
+
+    // When crypto is in progress: expected 250ms floor + [50, 250)ms jitter -> within [300, 500] ms
+    CASEServerAccess::SetCryptoOperationInProgress(gPairingServer, true);
+    delay = CASEServerAccess::ComputeDynamicBusyDelay(gPairingServer);
+    EXPECT_GE(delay.count(), 300);
+    EXPECT_LE(delay.count(), 500);
+    CASEServerAccess::SetCryptoOperationInProgress(gPairingServer, false);
+
+    // When past timeout (60s elapsed): floor 250ms + [50, 250)ms jitter -> within [300, 500] ms
+    CASEServerAccess::SetStateEnteredTimestamp(gPairingServer, now - System::Clock::Seconds64(60));
+    delay = CASEServerAccess::ComputeDynamicBusyDelay(gPairingServer);
+    EXPECT_GE(delay.count(), 300);
+    EXPECT_LE(delay.count(), 500);
+
+    gPairingServer.Shutdown();
+}
+
+TEST_F(TestCASESession, CASEServerPreemptExistingSession)
+{
+    EXPECT_EQ(gPairingServer.ListenForSessionEstablishment(&GetExchangeManager(), &GetSecureSessionManager(), &gDeviceFabrics,
+                                                           nullptr, nullptr, &gDeviceGroupDataProvider),
+              CHIP_NO_ERROR);
+
+    EXPECT_TRUE(CASEServerAccess::HasPinnedSecureSession(gPairingServer));
+
+    CASEServerAccess::PreemptExistingSession(gPairingServer);
+
+    // Session is reset and re-prepared for a new handshake
+    EXPECT_EQ(gPairingServer.GetSession().GetState(), CASESession::State::kInitialized);
+    EXPECT_TRUE(CASEServerAccess::HasPinnedSecureSession(gPairingServer));
+
+    gPairingServer.Shutdown();
+}
+
+TEST_F(TestCASESession, CASEServerHandleMRPRetry)
+{
+    // HandleMRPRetry with null exchange context safely returns CHIP_NO_ERROR
+    EXPECT_EQ(CASEServerAccess::HandleMRPRetry(gPairingServer, nullptr), CHIP_NO_ERROR);
 }
 
 } // namespace chip


### PR DESCRIPTION
### Summary
Implement Quadruple-Guard Preemption in CASEServer to mitigate dropped
Sigma2 packet deadlocks while preventing MRP duplicate livelock
starvation:
1. Guard 1: initiatorRandom inequality guard to distinguish transport
   MRP retries from upper-layer new session attempts. Retransmissions
   resend cached Sigma2 or Standalone ACK without resetting session.
2. Guard 2: Active crypto calculation guard to shield asynchronous
   cryptographic workers and hardware accelerators against CPU starvation.
3. Guard 3: Temporal grace window (1.5s) to account for multi-hop
   Thread mesh propagation and sleepy end device polling latency.
4. Guard 4: Destination ID validation against provisioned fabrics via
   FabricTable and GroupDataProvider IPK keys before granting preemption.
5. Dynamic remaining wait calculation with floor (250ms) and decorrelated
   jitter (50-250ms) to avoid thundering herd controller storms.
6. Added C++ unit tests in TestCASESession covering TLV param peeking,
   destination ID validation, quadruple-guard preemption, dynamic delay,
   preemptive session reset, and MRP retry handling.

### Related issues

N/A
### Testing
local testing and unit testing
