### PR TITLE
Darwin: Avoid a data race in test048_MTRDeviceResubscribeOnSubscriptionPool

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6196,14 +6196,19 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         ;
     }];
 
-    // Now we can set up waiting for onSubscriptionPoolWorkComplete from the test
+    // Now we can set up waiting for onSubscriptionPoolWorkComplete from the test.
+    // This has to happen on the delegate queue: _clearSubscriptionPoolWork notifies
+    // delegates asynchronously, so the notification for the initial subscription is
+    // still queued there and would otherwise run the handler we are installing.
     XCTestExpectation * subscriptionPoolWorkCompleteForTriggerTestExpectation = [self expectationWithDescription:@"_triggerResubscribeWithReason work completed"];
     __weak __auto_type weakDelegate = delegate;
-    delegate.onSubscriptionPoolWorkComplete = ^{
-        __strong __auto_type strongDelegate = weakDelegate;
-        strongDelegate.onSubscriptionPoolWorkComplete = nil;
-        [subscriptionPoolWorkCompleteForTriggerTestExpectation fulfill];
-    };
+    dispatch_sync(queue, ^{
+        delegate.onSubscriptionPoolWorkComplete = ^{
+            __strong __auto_type strongDelegate = weakDelegate;
+            strongDelegate.onSubscriptionPoolWorkComplete = nil;
+            [subscriptionPoolWorkCompleteForTriggerTestExpectation fulfill];
+        };
+    });
 
     // Now that subscription is established and live, ReadClient->mIsResubscriptionScheduled should be false, and _handleResubscriptionNeededWithDelayOnDeviceQueue can simulate the code path that leads to ReadClient->TriggerResubscribeIfScheduled() returning false, and exercise the edge case
     [device _handleResubscriptionNeededWithDelayOnDeviceQueue:@(0)];


### PR DESCRIPTION
### Summary

_clearSubscriptionPoolWork notifies delegates with a dispatch_async, and the
test's device queue barrier does not drain the delegate queue, so the
notification from the initial subscription establishment can still be pending
when the main thread installs onSubscriptionPoolWorkComplete. TSan reports the
race on the block's captured XCTestExpectation. Install the handler on the
delegate queue instead, so the pending notification is drained first.

Note that the stale notification could also fulfill the expectation, letting
the test pass without exercising the _triggerResubscribeWithReason path.

### Testing

Fixes an existing test.
