### PR TITLE
Ambient Context Sensing Cluster Test Script PR (Rebased PR43197)

### DIFF
--- a/TC_ACS_2_1.py
+++ b/TC_ACS_2_1.py
@@ -1,0 +1,353 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device ambient-context-sensor --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/acs_fifo
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --endpoint 1
+#       --app-pipe /tmp/acs_fifo
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+min_value_uint8 = 0
+max_value_uint8 = 255
+min_value_uint16 = 0
+max_value_uint16 = 65535
+min_value_uint32 = 0
+max_value_uint32 = 4294967295
+
+HUMAN_ACTIVITY_NAMESPACE_ID = 0x4B
+OBJECT_IDENTIFICATION_NAMESPACE_ID = 0x49
+SOUND_IDENTIFICATION_NAMESPACE_ID = 0x4A
+
+HUMAN_ACTIVITY_MAXTAGNUMBER = 0X09
+OBJECT_IDENTIFICATION_MAXTAGNUMBER = 0X0C
+SOUND_IDENTIFICATION_MAXTAGNUMBER = 0X15
+
+# Script Function Call Example
+# python3 ./scripts/tests/run_python_test.py --app out/linux-x64-all-devices-clang/all-devices-app --factory-reset
+# --app-args "--device ambient-context-sensor --KVS kvs1 --discriminator 1234 --app-pipe /tmp/acs_fifo"
+# --script src/python_testing/TC_ACS_2_1.py --script-args "--storage-path admin_storage1.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network --endpoint 1"
+
+
+class TC_ACS_2_1(MatterBaseTest):
+
+    # @pics('ACS.S')
+    # @run_if_endpoint_matches(has_cluster(Clusters.AmbientContextSensing))
+    def pics_TC_ACS_2_1(self):
+        return ['ACS.S']
+
+    def setup_test(self):
+        super().setup_test()
+        self.is_ci = self.matter_test_config.global_test_params.get('simulate_ambientsensing', True)
+
+    @async_test_body
+    async def test_TC_ACS_2_1(self):
+        endpoint = self.get_endpoint()
+        cluster = Clusters.AmbientContextSensing
+        attr = Clusters.AmbientContextSensing.Attributes
+
+        """[TC-ACS-2.1] Cluster endpoint"""
+        self.step("1", "Commissioning, already done", is_commissioning=True)
+        # Commission DUT - already done
+        # Implicit step to get the feature map to ensure attribute operations are performed on supported features
+        aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap)
+        log.info("Rx'd FeatureMap: %s", {aFeatureMap})
+        self.HumanActivitySupported = ((aFeatureMap & cluster.Bitmaps.Feature.kHumanActivity) != 0)
+        log.info("Rx'd HumanActivitySupported: %s", {self.HumanActivitySupported})
+        self.ObjectCountingSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kObjectCounting) != 0)
+        log.info("Rx'd ObjectCountingSupported: %s", {self.ObjectCountingSupported})
+        self.ObjectIdentificationSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kObjectIdentification) != 0)
+        log.info("Rx'd ObjectIdentificationSupported: %s", {self.ObjectIdentificationSupported})
+        self.SoundIdentificationSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kSoundIdentification) != 0)
+        log.info("Rx'd SoundIdentificationSupported: %s", {self.SoundIdentificationSupported})
+        self.PredictedActivitySupported = ((aFeatureMap & cluster.Bitmaps.Feature.kPredictedActivity) != 0)
+        log.info("Rx'd PredictedActivitySupported: %s", {self.PredictedActivitySupported})
+
+        if self.HumanActivitySupported:
+            self.step("2", "If DUT supports HumanActivity feature, TH reads the HumanActivityDetected attribute. TH reads the HumanActivityDetected attribute containing Boolean True or False.")
+            humanActivityDetected = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.HumanActivityDetected
+            )
+            asserts.assert_true((type(humanActivityDetected) is bool),
+                                "Expected True or False Boolean value.")
+        else:
+            self.skip_step("2")
+
+        if self.ObjectIdentificationSupported:
+            self.step("3", "If DUT supports ObjectIdentification feature, TH reads the ObjectIdentified attribute. TH reads the ObjectIdentified attribute containing Boolean True or False.")
+            objectIdentified = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.ObjectIdentified
+            )
+            asserts.assert_true((type(objectIdentified) is bool),
+                                "Expected True or False Boolean value.")
+        else:
+            log.info("ObjectIdentification Feature not supported. Test steps skipped")
+            self.skip_step("3")
+
+        if self.SoundIdentificationSupported:
+            self.step("4", "If DUT supports SoundIdentification feature, TH reads the AudioContextDetected attribute. TH reads the AudioContextDetected attribute containing Boolean True or False.")
+            audioContextDetected = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.AudioContextDetected
+            )
+            asserts.assert_true((type(audioContextDetected) is bool),
+                                "Expected True or False Boolean value.")
+        else:
+            log.info("SoundIdentification Feature not supported. Test steps skipped")
+            self.skip_step("4")
+
+        if self.HumanActivitySupported or self.ObjectIdentificationSupported or self.SoundIdentificationSupported:
+
+            self.step("5", "If DUT supports HumanActivity or ObjectIdentification or SoundIdentification, TH reads the AmbientContextTypeSupported attribute. Verify that the DUT response contains SemanticTag struct data field including namespace ID and tag ID from IdentifiedObject or IdentifiedHumanActivity or IdentifiedSound namespaces. Verify that the list size is less than equal to 50.")
+            ambientContextTypeSupported = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.AmbientContextTypeSupported)
+            if ambientContextTypeSupported:
+
+                log.info("Rx'd AmbientContextTypeSupported: %s", {ambientContextTypeSupported})
+                asserts.assert_less_equal(len(ambientContextTypeSupported), 50,
+                                          "AmbientContextTypeSupported should be less than equalt to 50.")
+
+                for acts in ambientContextTypeSupported:
+                    nsID = acts.namespaceID
+                    tagID = acts.tag
+
+                    if nsID == HUMAN_ACTIVITY_NAMESPACE_ID:
+                        asserts.assert_less_equal(tagID, HUMAN_ACTIVITY_MAXTAGNUMBER,
+                                                  "Tag number doesn't exit in IdentifiedHumanActivity namesapce.")
+                    elif nsID == OBJECT_IDENTIFICATION_NAMESPACE_ID:
+                        asserts.assert_less_equal(tagID, OBJECT_IDENTIFICATION_MAXTAGNUMBER,
+                                                  "Tag number doesn't exit in IdentifiedObject namesapce.")
+                    elif nsID == SOUND_IDENTIFICATION_NAMESPACE_ID:
+                        asserts.assert_less_equal(tagID, SOUND_IDENTIFICATION_MAXTAGNUMBER,
+                                                  "Tag number doesn't exit in IdentifiedSound namesapce.")
+
+            self.step("6", "If DUT supports HumanActivity or ObjectIdentification or SoundIdentification, TH reads the AmbientContextType attribute. Verify that DUT response contains the list size is less than SimultaneousDetectionLimit. Verify that DUT response contains the list of namespace ID and tag ID scoped within the AmbientContextTypeSupported attribute.")
+            ambientContextType = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.AmbientContextType)
+            if ambientContextType:
+
+                log.info("Rx'd AmbientContextType: %s", {ambientContextType})
+                simultaneousDetectionLimit = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.SimultaneousDetectionLimit)
+                asserts.assert_less_equal(len(ambientContextType), simultaneousDetectionLimit,
+                                          "AmbientContextTypeSupported should be less than equalt to SimultaneousDetectLimit.")
+
+                for context in ambientContextType:
+                    nsID = context.ambientContextSensed[0].namespaceID
+                    tagID = context.ambientContextSensed[0].tag
+
+                    if nsID == HUMAN_ACTIVITY_NAMESPACE_ID:
+                        asserts.assert_less_equal(tagID, HUMAN_ACTIVITY_MAXTAGNUMBER,
+                                                  "Tag number doesn't exit in IdentifiedHumanActivity namesapce.")
+                    elif nsID == OBJECT_IDENTIFICATION_NAMESPACE_ID:
+                        asserts.assert_less_equal(tagID, OBJECT_IDENTIFICATION_MAXTAGNUMBER,
+                                                  "Tag number doesn't exit in IdentifiedObject namesapce.")
+                    elif nsID == SOUND_IDENTIFICATION_NAMESPACE_ID:
+                        asserts.assert_less_equal(tagID, SOUND_IDENTIFICATION_MAXTAGNUMBER,
+                                                  "Tag number doesn't exit in IdentifiedSound namesapce.")
+
+                    # check if each AmbientContexType attribute is scoped within AmbientContextTypeSupported list
+                    num_support = 0
+                    for acts in ambientContextTypeSupported:
+                        nsID_support = acts.namespaceID
+                        tagID_support = acts.tag
+
+                        if (nsID == nsID_support) and (tagID == tagID_support):
+                            num_support = num_support + 1
+
+                    asserts.assert_greater(num_support, 0, "Ambient Context is not scoped within AmbientContextSupport list.")
+
+        else:
+            log.info("HumanActivity, ObjectIdentification, SoundIdentification Feature not supported. Test steps skipped")
+            self.skip_step("5")
+            self.skip_step("6")
+
+        if self.ObjectCountingSupported and self.ObjectIdentificationSupported:
+            self.step("7", "If DUT supports ObjectCounting and ObjectIdentification feature, then TH reads the ObjectCountThresholdReached attribute. TH reads the ObjectCountThresholdReached containing Boolean True or False.")
+            objectCountThresholdReached = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.ObjectCountThresholdReached
+            )
+            log.info("Rx'd ObjectCountThresholdReached: %s", {objectCountThresholdReached})
+            asserts.assert_true(objectCountThresholdReached in [True, False],
+                                "Expected True or False Boolean value.")
+
+            self.step("8", "If DUT supports ObjectCounting and ObjectIdentification feature, then TH reads the ObjectCountConfig attribute. Verify that DUT response contains the list of ObjectCountDataStruct entries and its CountingObject field is SemanticTagStruct data type containing namespace ID and tag ID from IdentifiedObject. Verify that the ObjectCountThreshold value is greater than equal to 1.")
+            objectCountConfig = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.ObjectCountConfig
+            )
+            nsID = objectCountConfig.countingObject.namespaceID
+            tagID = objectCountConfig.countingObject.tag
+
+            # object should come from Identified Object namespace
+            asserts.assert_equal(nsID, OBJECT_IDENTIFICATION_NAMESPACE_ID, "Not Identified Object Namespace ID")
+            asserts.assert_less_equal(tagID, OBJECT_IDENTIFICATION_MAXTAGNUMBER, "Tag number doesn't exit.")
+
+            # ObjectCountThreshold should be greater than equal to 1
+            asserts.assert_less_equal(1, objectCountConfig.objectCountThreshold,
+                                      "Threshold value should be greater than equalt to 1.")
+
+            self.step("9", "If DUT supports ObjectCount attribute, TH reads the ObjectCount attribute. Verity that DUT reads uint16 value.")
+            # ObjectCount should be uint16 (optional)
+            attribute_list = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.AttributeList)
+            if attr.ObjectCount.attribute_id in attribute_list:
+                objectCount = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.ObjectCount)
+                asserts.assert_true((type(objectCount) is int), "ObjectCount value should be uint16 data.")
+                asserts.assert_less_equal(1, objectCount,
+                                          "ObjectCount value should be greater than equal to 1.")
+
+        else:
+            log.info("Object Counting & Object Identification are not supported. Test steps skipped")
+            self.skip_step("7")
+            self.skip_step("8")
+            self.skip_step("9")
+
+        self.step("10", "TH reads the SimultaneousDetectionLimit attribute. Verify that the DUT response contains a value greater than equal to 1 and less than equal to 10.")
+        # simultaneousDetectionLimit from the step 6
+
+        simultaneousDetectionLimit = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.SimultaneousDetectionLimit)
+        asserts.assert_less_equal(1, simultaneousDetectionLimit, "SimultaneousDetectionLimit is not within 1 and 10.")
+        asserts.assert_less_equal(simultaneousDetectionLimit, 10, "SimultaneousDetectionLimit is not within 1 and 10.")
+
+        self.step("11", "TH reads the HoldTime attribute. Verify that DUT response contains an uint16 value ranging between HoldTimeLimits.HoldTimeMin and HoldTimeLimits.HoldTimeMax")
+        holdTime = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.HoldTime)
+        holdTimeLimits = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.HoldTimeLimits)
+        log.info("Rx'd HoldTime: %s", {holdTime})
+        asserts.assert_less_equal(holdTimeLimits.holdTimeMin, holdTime, "Expected to be between HoldTimeMin and HoldTimeMax.")
+        asserts.assert_less_equal(holdTime, holdTimeLimits.holdTimeMax, "Expected to be between HoldTimeMin and HoldTimeMax.")
+
+        self.step("12", "TH reads the HoldTimeLimits attribute. Verify that DUT response contains HoldTimeMin (>=1), HolTimeMax (min maxOf(HoldTimeMin, 10)) and HoldTimeDefault (between HoldTimeMin and HoldTimeMax)")
+        # log.info(f"Rx'd HoldTimeLimits: {holdTimeLimits}")
+        asserts.assert_greater_equal(holdTimeLimits.holdTimeMin, 1,
+                                     "Expected HoldTimeMin to be greater than equal to 1.")
+
+        minformax = max(holdTimeLimits.holdTimeMin, 10)
+        asserts.assert_greater_equal(holdTimeLimits.holdTimeMax, minformax,
+                                     "Expected HoldTimeMax to be greater than equal to max(holdTimeLimits.holdTimeMin, 10).")
+
+        asserts.assert_less_equal(holdTimeLimits.holdTimeMin, holdTimeLimits.holdTimeDefault,
+                                  "Expected to be between HoldTimeMin and HoldTimeMax.")
+        asserts.assert_less_equal(holdTimeLimits.holdTimeDefault, holdTimeLimits.holdTimeMax,
+                                  "Expected to be between HoldTimeMin and HoldTimeMax.")
+
+        if self.PredictedActivitySupported:
+
+            predictedActivityList = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.PredictedActivity
+            )
+            # log.info(f"Rx'd PredictedActivity: {predictedActivityList}")
+
+            if predictedActivityList:
+                self.step("13a", "If DUT supports PredictedActivity feature, then TH reads the PredictedActivity attribute. Verify that DUT response contains StartTimestamp epoch-s data less than equal to EndTimestamp-1 and EndTimestamp epoch-s data greater than equal to StartTimestamp-1 and Verify that DUT response contains Confidence field that is a percentage data between 0 and 100. If DUT supports HumanActivity or ObjectIdentification or SoundIdentification, then TH reads a list of SemanticTagStruct data that includes namespace ID and tag ID from IdentifiedObject or IdentifiedHumanActivity or IdentifiedSound namespaces.")
+
+                # less than 20
+                asserts.assert_less_equal(len(predictedActivityList), 20, "PredictedActivity should be less than 20.")
+
+                for predictedActivity in predictedActivityList:
+
+                    startTime = predictedActivity.startTimestamp
+                    endTime = predictedActivity.endTimestamp
+
+                    # StartTimestamp should be epoch-s (uint32)
+                    asserts.assert_less_equal(startTime, endTime-1, "StartTimestamp must be less than EndTimestamp.")
+
+                    # EndTimestamp should be epoch-s (uint32)
+                    asserts.assert_greater_equal(endTime, startTime+1, "EndTimestamp must be greater than StartTimestamp.")
+
+                    # Confidence
+                    asserts.assert_greater(predictedActivity.confidence, 0,
+                                           "Expected the percentage greater than 0 and less than equat to 100.")
+                    asserts.assert_less_equal(predictedActivity.confidence, 100,
+                                              "Expected the percentage greater than 0 and less than equat to 100.")
+
+                    if predictedActivity.ambientContextType:
+                        # AmbientContextType
+                        asserts.assert_less_equal(len(predictedActivity.ambientContextType), 100,
+                                                  "AmbientContextType should be less than 100.")
+
+                        if self.HumanActivitySupported or self.ObjectIdentificationSupported or self.SoundIdentificationSupported:
+
+                            for acts in predictedActivity.ambientContextType:
+                                nsID = acts.namespaceID
+                                tagID = acts.tag
+
+                                if nsID == HUMAN_ACTIVITY_NAMESPACE_ID:
+                                    asserts.assert_less_equal(tagID, HUMAN_ACTIVITY_MAXTAGNUMBER,
+                                                              "Tag number doesn't exit in IdentifiedHumanActivity namesapce.")
+                                elif nsID == OBJECT_IDENTIFICATION_NAMESPACE_ID:
+                                    asserts.assert_less_equal(tagID, OBJECT_IDENTIFICATION_MAXTAGNUMBER,
+                                                              "Tag number doesn't exit in IdentifiedObject namesapce.")
+                                elif nsID == SOUND_IDENTIFICATION_NAMESPACE_ID:
+                                    asserts.assert_less_equal(tagID, SOUND_IDENTIFICATION_MAXTAGNUMBER,
+                                                              "Tag number doesn't exit in IdentifiedSound namesapce.")
+                                else:
+                                    asserts.fail("Namespace is not matching to the features.")
+
+                if self.ObjectCountingSupported and predictedActivity:
+                    self.step("13b", "If DUT supports PredictedActivity feature, then TH reads the PredictedActivity attribute. Verify that DUT response contains StartTimestamp epoch-s data less than equal to EndTimestamp-1 and EndTimestamp epoch-s data greater than equal to StartTimestamp-1 and Verify that DUT response contains Confidence field that is a percentage data between 0 and 100. If DUT supports HumanActivity or ObjectIdentification or SoundIdentification, then TH reads a list of SemanticTagStruct data that includes namespace ID and tag ID from IdentifiedObject or IdentifiedHumanActivity or IdentifiedSound namespaces.")
+
+                    for predictedActivity in predictedActivityList:
+                        # CrowdDetected
+                        asserts.assert_true(predictedActivity.crowdDetected in [True, False],
+                                            "Expected True or False Boolean value.")
+                        log.info("Rx'd CrowdDetected: %s", {predictedActivity.crowdDetected})
+
+                        # CrowdCount
+                        if predictedActivity.crowdCount != NullValue:
+                            # log.info(f"Rx'd CrowdCount: {predictedActivity.crowdCount}")
+                            asserts.assert_less_equal(1, predictedActivity.crowdCount,
+                                                      "CrowdCount is expected to be between 1 and 254.")
+                            asserts.assert_less_equal(predictedActivity.crowdCount, 254,
+                                                      "CrowdCount is expected to be between 1 and 254.")
+                else:
+                    self.skip_step("13b")
+
+            else:
+                log.info("predictedActivity is empty")
+                self.skip_step("13a")
+                self.skip_step("13b")
+
+        else:
+            log.info("PredictedActivity Feature not supported. Test steps skipped")
+            self.skip_step("13a")
+            self.skip_step("13b")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/TC_ACS_3_1.py
+++ b/TC_ACS_3_1.py
@@ -1,0 +1,518 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device ambient-context-sensor --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/acs_fifo_3_1
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#       --app-pipe /tmp/acs_fifo_3_1
+#       --string-arg PIXIT.ACS.Event1_NSID:0x4B --string-arg PIXIT.ACS.Event1_TAGID:0x03
+#       --string-arg PIXIT.ACS.Event2_NSID:0x49 --string-arg PIXIT.ACS.Event2_TAGID:0x04
+#       --string-arg PIXIT.ACS.Event3_NSID:0x4A --string-arg PIXIT.ACS.Event3_TAGID:0x03
+#       --float-arg PIXIT.ACS.Holdtime:30
+#       --bool-arg simulate_ambientsensing:True
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import ast
+import asyncio
+import logging
+import time
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler, EventSubscriptionHandler
+from matter.testing.matter_testing import AttributeValue, MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+# Namespace in integer
+HUMAN_ACTIVITY_NAMESPACE_ID = 75  # 0x4B
+OBJECT_IDENTIFICATION_NAMESPACE_ID = 73  # 0x49
+SOUND_IDENTIFICATION_NAMESPACE_ID = 74  # 0x4A
+
+# Script Function Call Example
+# python3 ./scripts/tests/run_python_test.py --app out/linux-x64-all-devices-clang/all-devices-app --factory-reset
+# --app-args "--device ambient-context-sensor --KVS kvs1 --discriminator 1234 --app-pipe /tmp/acs_fifo_3_1"
+# --script src/python_testing/TC_ACS_3_1.py --script-args "--storage-path admin_storage1.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network --endpoint 1
+# --string-arg PIXIT.ACS.Event1_NSID:0x4B --string-arg PIXIT.ACS.Event1_TAGID:0x03
+# --string-arg PIXIT.ACS.Event2_NSID:0x49 --string-arg PIXIT.ACS.Event2_TAGID:0x04
+# --string-arg PIXIT.ACS.Event3_NSID:0x4A --string-arg PIXIT.ACS.Event3_TAGID:0x03 --float-arg PIXIT.ACS.Holdtime:30"
+
+
+class TC_ACS_3_1(MatterBaseTest):
+
+    def pics_TC_ACS_3_1(self):
+        return ['ACS.S']
+
+    def setup_test(self):
+        super().setup_test()
+        self.is_ci = self.matter_test_config.global_test_params.get('simulate_ambientsensing', False)
+
+    # Sends and out-of-band command to the all-clusters-app
+    def write_to_app_pipe(self, command):
+        # CI app pipe id creation
+        # self.app_pipe = "/tmp/acs_fifo"
+        if self.is_ci:
+            # app_pid = self.matter_test_config.app_pid
+            # if app_pid == 0:
+            #     asserts.fail("The --app-pid flag must be set when using named pipe")
+            # self.app_pipe = self.app_pipe + str(app_pid)
+            self.app_pipe = "/tmp/acs_fifo_3_1"
+
+        with open(self.app_pipe, "w") as app_pipe:
+            app_pipe.write(command + "\n")
+        # Delay for pipe command to be processed (otherwise tests are flaky)
+        time.sleep(0.001)
+
+    @async_test_body
+    async def test_TC_ACS_3_1(self):
+        """[TC-ACS-3.1] Cluster endpoint"""
+
+        node_id = self.dut_node_id
+        endpoint = self.get_endpoint()
+        cluster = Clusters.AmbientContextSensing
+        attr = Clusters.AmbientContextSensing.Attributes
+        dev_ctrl = self.default_controller
+
+        self.step("1", "Commissioning, already done", is_commissioning=True)
+        # Commission DUT - already done
+        # Implicit step to get the feature map to ensure attribute operations are performed on supported features
+        aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap)
+        log.info("Rx'd FeatureMap: %s", {aFeatureMap})
+        self.HumanActivitySupported = ((aFeatureMap & cluster.Bitmaps.Feature.kHumanActivity) != 0)
+        log.info("Rx'd HumanActivitySupported: %s", {self.HumanActivitySupported})
+        self.ObjectCountingSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kObjectCounting) != 0)
+        log.info("Rx'd ObjectCountingSupported: %s", {self.ObjectCountingSupported})
+        self.ObjectIdentificationSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kObjectIdentification) != 0)
+        log.info("Rx'd ObjectIdentificationSupported: %s", {self.ObjectIdentificationSupported})
+        self.SoundIdentificationSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kSoundIdentification) != 0)
+        log.info("Rx'd SoundIdentificationSupported: %s", {self.SoundIdentificationSupported})
+        self.PredictedActivitySupported = ((aFeatureMap & cluster.Bitmaps.Feature.kPredictedActivity) != 0)
+        log.info("Rx'd PredictedActivitySupported: %s", {self.PredictedActivitySupported})
+
+        self.step("2", "TH reads the SimultaneousDetectionLimit attribute. If 1 is read, skip this test case. Otherwise proceed the following.")
+        simultaneousDetectionLimit = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.SimultaneousDetectionLimit
+        )
+        log.info("Rx'd SimultaneousDetectionLimit: %s", {simultaneousDetectionLimit})
+
+        # check if multi detection is supported
+        if simultaneousDetectionLimit < 2:
+            log.info("Multiple Detection Feature not supported. This test case skipped")
+            self.skip_step("3")
+            self.skip_step("4")
+            self.skip_step("5a")
+            self.skip_step("5b")
+            self.skip_step("5c")
+            self.skip_step("6a")
+            self.skip_step("6b")
+            self.skip_step("6c")
+            self.skip_step("7")
+            return
+
+        self.step("3", "TH establishes a wildcard subscription to all attributes on Ambient Context Sensing Cluster on the endpoint under test with minIntervalFloor set to 0, MaxIntervalCeiling set to 30 and KeepSubscriptions set to false.")
+        # subscription setup
+        attrib_listener = AttributeSubscriptionHandler(expected_cluster=cluster)
+        await attrib_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30, keepSubscriptions=False)
+
+        # start event listener
+        event_listener = EventSubscriptionHandler(expected_cluster=cluster)
+        await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
+
+        self.step("4", "TH writes DUT HoldTime attribute to enable proper testing completion using PIXIT.ACS.Holdtime input. Verify that its value is ranged between HoldTimeLimits.HoldTimeMin and HoldTimeLimits.HoldTimeMax.")
+        # PIXIT input
+        holdTime_input = self.user_params.get("PIXIT.ACS.Holdtime", 30)
+        # holdTime_input = 30  # 30 seconds
+        holdTimeLimits = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.HoldTimeLimits)
+        asserts.assert_less_equal(holdTimeLimits.holdTimeMin, holdTime_input, "Expected to be between HoldTimeMin and HoldTimeMax.")
+        asserts.assert_less_equal(holdTime_input, holdTimeLimits.holdTimeMax, "Expected to be between HoldTimeMin and HoldTimeMax.")
+        await self.write_single_attribute(attr.HoldTime(holdTime_input))
+
+        # Add AmbientContextSupported elements based on DUT capability
+        # Human activity walking, Object identification person, Audio identification barking are default
+        if self.is_ci:
+            self.write_to_app_pipe(
+                # '{"Name":"SetAmbientContextSupport","EndpointId":1,"AmbientContextType":[{"TypeId":73, "TagId":3},{"TypeId":74, "TagId":4},{"TypeId":75,"TagId":3}]}')
+                f'{{"Name":"SetAmbientContextSupport", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":73, "TagId":4}},{{"TypeId":74, "TagId":3}},{{"TypeId":75,"TagId":3}}]}}')
+            await asyncio.sleep(1)
+
+        # check the SimultaneousDetectLimit
+        simultaneousDetectionLimit = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.SimultaneousDetectionLimit)
+
+        # DUT only supports 2 SimultaneousDetectLimit
+        if simultaneousDetectionLimit == 2:
+            self.step("5a", "This step is for the DUT capable of supporting only 2 simultaneous detection. If supports more, skip to 6a. An operator actuates DUT to generate the first ambient sensing event, and then removes its sensing stimulus. And within HoldTime duration, an operator actuates DUT to generate the second ambient sensing event, and then removes its sensing stimulus.")
+
+            # First PIXIT input
+            pixit1_nsid = self.user_params.get("PIXIT.ACS.Event1_NSID", "0x4B")
+            pixit1_tagid = self.user_params.get("PIXIT.ACS.Event1_TAGID", "0x03")
+            log.info("pixit1_nsid: %s", pixit1_nsid)
+            log.info("pixit1_tagid: %s", pixit1_tagid)
+            # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+            list_dec = ast.literal_eval(pixit1_nsid)
+            namespaceID1 = list_dec
+            list_dec = ast.literal_eval(pixit1_tagid)  # same as the above
+            tag1 = list_dec
+            log.info("PIXIT input: %s %s", {namespaceID1}, {tag1})
+
+            # CI for the first ambient sensing event => Human activity walking
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":75, "TagId":3}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID1}, "TagId":{tag1}}}]}}')
+                # Add 1 second delay to make sure it's done
+                await asyncio.sleep(1)
+            else:
+                # Trigger the ambient sensor with PIXIT.ACS.Event1_NSID & PIXIT.ACS.Event1_TAGID
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after the first ambient sensing event representing PIXIT.ACS.Event1_NSID & PIXIT.ACS.Event1_TAGID is triggered.")
+
+            # 1st event timer start
+            start_time = time.perf_counter()
+
+            # Second PIXIT input
+            pixit2_nsid = self.user_params.get("PIXIT.ACS.Event2_NSID", "0x49")
+            pixit2_tagid = self.user_params.get("PIXIT.ACS.Event2_TAGID", "0x03")
+            log.info("pixit1_nsid: %s", pixit2_nsid)
+            log.info("pixit1_tagid: %s", pixit2_tagid)
+            # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+            list_dec = ast.literal_eval(pixit2_nsid)
+            namespaceID2 = list_dec
+            list_dec = ast.literal_eval(pixit2_tagid)  # same as the above
+            tag2 = list_dec
+            log.info("PIXIT input: %s %s", {namespaceID2}, {tag2})
+
+            # CI for the second ambient sensing event => Object Identification person
+            # namespaceID2 = OBJECT_IDENTIFICATION_NAMESPACE_ID  # 73 and tag2 = 3  # person
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":73, "TagId":4}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID2}, "TagId":{tag2}}}]}}')
+                # Add 1 second delay to make sure it's done
+                await asyncio.sleep(1)
+            else:
+                # Trigger the ambient sensor with PIXIT.ACS.Event2_NSID & PIXIT.ACS.Event2_TAGID
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after the second ambient sensing event representing PIXIT.ACS.Event2_NSID & PIXIT.ACS.Event2_TAGID is triggered.")
+
+            self.step("5b", "TH verifies the AmbientContextType attribute change. Verify that DUT response contains the AmbientContextSensed struct data list size of up to 2. Verify that DUT response contains the AmbientContextSensed struct data including the namespace ID and its tag ID that match both ambient sensing events from the step 5a.")
+            ambientContextType = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.AmbientContextType)
+            # log.info(f"Rx'd AmbientContextType: {ambientContextType}")
+
+            # Simultaneous Detection = 2
+            asserts.assert_equal(len(ambientContextType), 2, "AmbientContextType list must hold both detections from step 5a.")
+
+            # check the subscription of AmbientContextType attribute
+            subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][-1].value
+            humanActivityDetected = False
+            objectIdentified = False
+            audioContextDetected = False
+
+            # latest namespace id == namespaceID2
+            namespaceid_test = subscription_expected[0].ambientContextSensed[0].namespaceID
+            asserts.assert_true(namespaceid_test == namespaceID2,
+                                f"Unexpected namespaceID, {namespaceid_test}, exp {namespaceID2}")
+            asserts.assert_true(subscription_expected[0].ambientContextSensed[0].tag == tag2,
+                                f"Unexpected tag, {subscription_expected[0].ambientContextSensed[0].tag}, exp {tag2}")
+
+            # early namespace id == namespaceID1
+            namespaceid_test1 = subscription_expected[1].ambientContextSensed[0].namespaceID
+            asserts.assert_true(namespaceid_test1 == namespaceID1,
+                                f"Unexpected namespaceID, {namespaceid_test1}, exp {namespaceID1}")
+            asserts.assert_true(subscription_expected[1].ambientContextSensed[0].tag == tag1,
+                                f"Unexpected tag, {subscription_expected[1].ambientContextSensed[0].tag}, exp {tag1}")
+
+            # AmbientContextType attribute subscription check for the latest event boolean attribute
+            if (namespaceid_test == HUMAN_ACTIVITY_NAMESPACE_ID) and self.HumanActivitySupported:
+                subscription_bool_expected = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+                humanActivityDetected = subscription_bool_expected[0].value
+                asserts.assert_true(humanActivityDetected, "Failed to get HumanActivityDetected being True.")
+            elif (namespaceid_test == OBJECT_IDENTIFICATION_NAMESPACE_ID) and self.ObjectIdentificationSupported:
+                subscription_bool_expected = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+                objectIdentified = subscription_bool_expected[0].value
+                asserts.assert_true(objectIdentified, "Failed to get ObjectIdentified being True.")
+            elif (namespaceid_test == SOUND_IDENTIFICATION_NAMESPACE_ID) and self.SoundIdentificationSupported:
+                subscription_bool_expected = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+                audioContextDetected = subscription_bool_expected[0].value
+                asserts.assert_true(audioContextDetected, "Failed to get audioContextDetected being True.")
+
+            # AmbientContextType attribute subscription check for the early boolean attribute
+            if (namespaceid_test1 == HUMAN_ACTIVITY_NAMESPACE_ID) and self.HumanActivitySupported:
+                subscription_bool_expected1 = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+                humanActivityDetected = subscription_bool_expected1[0].value
+                asserts.assert_true(humanActivityDetected, "Failed to get HumanActivityDetected being True.")
+            elif (namespaceid_test1 == OBJECT_IDENTIFICATION_NAMESPACE_ID) and self.ObjectIdentificationSupported:
+                subscription_bool_expected1 = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+                objectIdentified = subscription_bool_expected1[0].value
+                asserts.assert_true(objectIdentified, "Failed to get ObjectIdentified being True.")
+            elif (namespaceid_test1 == SOUND_IDENTIFICATION_NAMESPACE_ID) and self.SoundIdentificationSupported:
+                subscription_bool_expected1 = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+                audioContextDetected = subscription_bool_expected1[0].value
+                asserts.assert_true(audioContextDetected, "Failed to get audioContextDetected being True.")
+
+            attrib_listener.reset()
+
+            self.step("5c", "An operator waits until the HoldTime duration expires since the step 5a execution. Check if AmbientContextDetectEnded is received for the second ambient sensing event.")
+            # timer ends
+            end_time = time.perf_counter()
+            elapsed_time = end_time - start_time
+            if elapsed_time > holdTime_input:
+                log.info("Two events weren't completed within HoldTime input.")
+            else:
+                log.info("Waiting for the HoldTime input to expire.")
+                await asyncio.sleep(holdTime_input - elapsed_time + 1)
+
+            # The last end event
+            event = event_listener.get_last_event()
+            # event = event_listener.wait_for_event_report(cluster.Events.AmbientContextDetectEnded, timeout_sec=30.0)
+            asserts.assert_equal(event.Header.EventId, cluster.Events.AmbientContextDetectEnded.event_id,
+                                 f"Wrong event, {event.Header.EventId}, {cluster.Events.AmbientContextDetectStarted.event_id}")
+
+            self.skip_step("6a")
+            self.skip_step("6b")
+            self.skip_step("6c")
+
+        else:
+            self.skip_step("5a")
+            self.skip_step("5b")
+            self.skip_step("5c")
+
+            self.step("6a", "This step is for DUT capable of supporting 3 or more simultaneous detection. An operator actuates DUT to generate the first ambient sensing event, and then removes its sensing stimulus. And within HoldTime duration, an operator actuates DUT to generate the second ambient sensing event, and then removes its sensing stimulus. And within HoldTime duration, an operator actuates DUT to generate the third ambient sensing event, and then removes its sensing stimulus.")
+
+            # First PIXIT input
+            pixit1_nsid = self.user_params.get("PIXIT.ACS.Event1_NSID", "0x4B")
+            pixit1_tagid = self.user_params.get("PIXIT.ACS.Event1_TAGID", "0x03")
+            log.info("pixit1_nsid: %s", pixit1_nsid)
+            log.info("pixit1_nsid: %s", pixit1_tagid)
+            # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+            list_dec = ast.literal_eval(pixit1_nsid)
+            namespaceID1 = list_dec
+            list_dec = ast.literal_eval(pixit1_tagid)  # same as the above
+            tag1 = list_dec
+            log.info("PIXIT input: %s %s", {namespaceID1}, {tag1})
+
+            # CI for the first ambient sensing event => Human activity walking
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":75, "TagId":3}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID1}, "TagId":{tag1}}}]}}')
+                # Add 1 second delay to make sure it's done
+                await asyncio.sleep(1)
+            else:
+                # Trigger the ambient sensor with PIXIT.ACS.Event1_NSID & PIXIT.ACS.Event1_TAGID
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after the first ambient sensing event representing PIXIT.ACS.Event1_NSID & PIXIT.ACS.Event1_TAGID is triggered.")
+
+            # 1st event timer start
+            start_time = time.perf_counter()
+
+            # Second PIXIT input
+            pixit2_nsid = self.user_params.get("PIXIT.ACS.Event2_NSID", "0x49")
+            pixit2_tagid = self.user_params.get("PIXIT.ACS.Event2_TAGID", "0x04")
+            log.info("pixit2_nsid: %s", pixit2_nsid)
+            log.info("pixit2_nsid: %s", pixit2_tagid)
+            # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+            list_dec = ast.literal_eval(pixit2_nsid)
+            namespaceID2 = list_dec
+            list_dec = ast.literal_eval(pixit2_tagid)  # same as the above
+            tag2 = list_dec
+            log.info("PIXIT input: %s %s", {namespaceID2}, {tag2})
+
+            # CI for the second ambient sensing event => Object Identification person
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":73, "TagId":4}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID2}, "TagId":{tag2}}}]}}')
+                # Add 1 second delay to make sure it's done
+                await asyncio.sleep(1)
+            else:
+                # Trigger the ambient sensor with PIXIT.ACS.Event2_NSID & PIXIT.ACS.Event2_TAGID
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after the second ambient sensing event representing PIXIT.ACS.Event2_NSID & PIXIT.ACS.Event2_TAGID is triggered.")
+
+            # Third PIXIT input
+            pixit3_nsid = self.user_params.get("PIXIT.ACS.Event3_NSID", "0x4A")
+            pixit3_tagid = self.user_params.get("PIXIT.ACS.Event3_TAGID", "0x03")
+            log.info("pixit3_nsid: %s", pixit3_nsid)
+            log.info("pixit3_tagid: %s", pixit3_tagid)
+            # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+            list_dec = ast.literal_eval(pixit3_nsid)
+            namespaceID3 = list_dec
+            list_dec = ast.literal_eval(pixit3_tagid)  # same as the above
+            tag3 = list_dec
+            log.info("PIXIT input: %s %s", {namespaceID3}, {tag3})
+
+            # CI for the third ambient sensing event => Sound context barking
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":74, "TagId":3}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID3}, "TagId":{tag3}}}]}}')
+                # Add 1 second delay to make sure it's done
+                await asyncio.sleep(1)
+            else:
+                # Trigger the ambient sensor with PIXIT.ACS.Event3_NSID & PIXIT.ACS.Event3_TAGID
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after the third ambient sensing event representing PIXIT.ACS.Event3_NSID & PIXIT.ACS.Event3_TAGID is triggered.")
+
+            self.step("6b", "TH verifies the AmbientContextType attribute change. Verify that DUT response contains the AmbientContextSensed struct data list size of up to 3. Verify that DUT response contains the AmbientContextSensed struct data including the namespace ID and its tag ID that match both ambient sensing events from the step 6a.")
+            ambientContextType = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.AmbientContextType)
+            # log.info(f"Rx'd AmbientContextType: {ambientContextType}")
+
+            # Simultaneous Detection = 3
+            asserts.assert_equal(len(ambientContextType), 3, "AmbientContextType list needs to be the size of 3.")
+
+            # check the subscription of AmbientContextType attribute
+            subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][-1].value
+            # log.info(f"Rx'd subscription_expected: {subscription_expected}")
+
+            humanActivityDetected = False
+            objectIdentified = False
+            audioContextDetected = False
+
+            # latest namespace id == namespaceID3
+            namespaceid_test = subscription_expected[0].ambientContextSensed[0].namespaceID
+            asserts.assert_true(namespaceid_test == namespaceID3,
+                                f"Unexpected namespaceID, {namespaceid_test}, exp {namespaceID3}")
+            asserts.assert_true(subscription_expected[0].ambientContextSensed[0].tag == tag3,
+                                f"Unexpected tag, {subscription_expected[0].ambientContextSensed[0].tag}, exp {tag3}")
+
+            # early namespace id == namespaceID2
+            namespaceid_test1 = subscription_expected[1].ambientContextSensed[0].namespaceID
+            asserts.assert_true(namespaceid_test1 == namespaceID2,
+                                f"Unexpected namespaceID, {namespaceid_test1}, exp {namespaceID2}")
+            asserts.assert_true(subscription_expected[1].ambientContextSensed[0].tag == tag2,
+                                f"Unexpected tag, {subscription_expected[1].ambientContextSensed[0].tag}, exp {tag2}")
+
+            # earliest namespace id == namespaceID1
+            namespaceid_test2 = subscription_expected[2].ambientContextSensed[0].namespaceID
+            asserts.assert_true(namespaceid_test2 == namespaceID1,
+                                f"Unexpected namespaceID, {namespaceid_test2}, exp {namespaceID1}")
+            asserts.assert_true(subscription_expected[2].ambientContextSensed[0].tag == tag1,
+                                f"Unexpected tag, {subscription_expected[2].ambientContextSensed[0].tag}, exp {tag1}")
+
+            # AmbientContextType attribute subscription check for the latest event boolean attribute
+            if (namespaceid_test == HUMAN_ACTIVITY_NAMESPACE_ID) and self.HumanActivitySupported:
+                subscription_bool_expected = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+                humanActivityDetected = subscription_bool_expected[0].value
+                asserts.assert_true(humanActivityDetected, "Failed to get HumanActivityDetected being True.")
+            elif (namespaceid_test == OBJECT_IDENTIFICATION_NAMESPACE_ID) and self.ObjectIdentificationSupported:
+                subscription_bool_expected = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+                objectIdentified = subscription_bool_expected[0].value
+                asserts.assert_true(objectIdentified, "Failed to get ObjectIdentified being True.")
+            elif (namespaceid_test == SOUND_IDENTIFICATION_NAMESPACE_ID) and self.SoundIdentificationSupported:
+                subscription_bool_expected = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+                audioContextDetected = subscription_bool_expected[0].value
+                asserts.assert_true(audioContextDetected, "Failed to get audioContextDetected being True.")
+
+            # AmbientContextType attribute subscription check for the early boolean attribute
+            if (namespaceid_test1 == HUMAN_ACTIVITY_NAMESPACE_ID) and self.HumanActivitySupported:
+                subscription_bool_expected1 = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+                humanActivityDetected = subscription_bool_expected1[0].value
+                asserts.assert_true(humanActivityDetected, "Failed to get HumanActivityDetected being True.")
+            elif (namespaceid_test1 == OBJECT_IDENTIFICATION_NAMESPACE_ID) and self.ObjectIdentificationSupported:
+                subscription_bool_expected1 = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+                objectIdentified = subscription_bool_expected1[0].value
+                asserts.assert_true(objectIdentified, "Failed to get ObjectIdentified being True.")
+            elif (namespaceid_test1 == SOUND_IDENTIFICATION_NAMESPACE_ID) and self.SoundIdentificationSupported:
+                subscription_bool_expected1 = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+                audioContextDetected = subscription_bool_expected1[0].value
+                asserts.assert_true(audioContextDetected, "Failed to get audioContextDetected being True.")
+
+            # AmbientContextType attribute subscription check for the earliest boolean attribute
+            if (namespaceid_test2 == HUMAN_ACTIVITY_NAMESPACE_ID) and self.HumanActivitySupported:
+                subscription_bool_expected2 = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+                humanActivityDetected = subscription_bool_expected2[0].value
+                asserts.assert_true(humanActivityDetected, "Failed to get HumanActivityDetected being True.")
+            elif (namespaceid_test2 == OBJECT_IDENTIFICATION_NAMESPACE_ID) and self.ObjectIdentificationSupported:
+                subscription_bool_expected2 = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+                objectIdentified = subscription_bool_expected2[0].value
+                asserts.assert_true(objectIdentified, "Failed to get ObjectIdentified being True.")
+            elif (namespaceid_test2 == SOUND_IDENTIFICATION_NAMESPACE_ID) and self.SoundIdentificationSupported:
+                subscription_bool_expected2 = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+                audioContextDetected = subscription_bool_expected2[0].value
+                asserts.assert_true(audioContextDetected, "Failed to get audioContextDetected being True.")
+
+            attrib_listener.reset()
+
+            self.step("6c", "An operator waits until the HoldTime duration expires since the step 6a execution. Check if AmbientContextDetectEnded is received for the last ambient sensing event.")
+
+            # timer ends
+            end_time = time.perf_counter()
+            elapsed_time = end_time - start_time
+            if elapsed_time > holdTime_input:
+                log.info("Three events weren't completed within HoldTime input.")
+            else:
+                log.info("Waiting for the HoldTime input to expire.")
+                await asyncio.sleep(holdTime_input - elapsed_time + 3)
+
+            # The last end event
+            event = event_listener.get_last_event()
+            # event = event_listener.wait_for_event_report(cluster.Events.AmbientContextDetectEnded, timeout_sec=30.0)
+            asserts.assert_equal(event.Header.EventId, cluster.Events.AmbientContextDetectEnded.event_id,
+                                 f"Wrong event, {event.Header.EventId}, {cluster.Events.AmbientContextDetectStarted.event_id}")
+
+        self.step("7", "TH reads the AmbientContextType attribute. Verify that the AmbientContextType attribute contains an empty list and the Boolean attributes related the step 5a or 6a are False.")
+        # Check the boolean attributes are set to False
+        if humanActivityDetected and self.HumanActivitySupported:
+            # subscription_bool_expected = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+            # humanActivityDetected = subscription_bool_expected[-1].value
+            # asserts.assert_true(not humanActivityDetected, "Failed to get HumanActivityDetected being False.")
+            attrib_listener.await_all_final_values_reported(expected_final_values=[AttributeValue(
+                endpoint_id=self.get_endpoint(), attribute=cluster.Attributes.HumanActivityDetected, value=False)], timeout_sec=10)
+            log.info("Received HumanActivityDetected False.")
+
+        if objectIdentified and self.ObjectIdentificationSupported:
+            attrib_listener.await_all_final_values_reported(expected_final_values=[AttributeValue(
+                endpoint_id=self.get_endpoint(), attribute=cluster.Attributes.ObjectIdentified, value=False)], timeout_sec=10)
+            log.info("Received ObjectIdentified False.")
+
+        if audioContextDetected and self.SoundIdentificationSupported:
+            attrib_listener.await_all_final_values_reported(expected_final_values=[AttributeValue(
+                endpoint_id=self.get_endpoint(), attribute=cluster.Attributes.AudioContextDetected, value=False)], timeout_sec=10)
+            log.info("Received AudioContextDetected False.")
+
+        # check the subscription of AmbientContextType attribute (to be empty list)
+        # subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][-1].value
+        # asserts.assert_true(len(subscription_expected) == 0, "AmbientContext attribute is not empty.")
+        attrib_listener.await_all_final_values_reported(expected_final_values=[AttributeValue(
+            endpoint_id=self.get_endpoint(), attribute=cluster.Attributes.AmbientContextType, value=[])], timeout_sec=10)
+        log.info("Received AmbientContextType empty.")
+
+        attrib_listener.reset()
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/TC_ACS_3_2.py
+++ b/TC_ACS_3_2.py
@@ -1,0 +1,290 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device ambient-context-sensor --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/acs_fifo_3_2
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#       --app-pipe /tmp/acs_fifo_3_2
+#       --string-arg PIXIT.ACS.Event1_NSID:0x4B
+#       --string-arg PIXIT.ACS.Event1_TAGID:0x03
+#       --float-arg PIXIT.ACS.Holdtime:30
+#       --bool-arg simulate_ambientsensing:True
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import ast
+import asyncio
+import logging
+import time
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+# Namespace in integer (not hex)
+HUMAN_ACTIVITY_NAMESPACE_ID = 75  # 0x4B
+OBJECT_IDENTIFICATION_NAMESPACE_ID = 73  # 0x49
+SOUND_IDENTIFICATION_NAMESPACE_ID = 74  # 0x4A
+
+# Script Function Call Example
+# python3 ./scripts/tests/run_python_test.py --app out/linux-x64-all-devices-clang/all-devices-app --factory-reset
+# --app-args "--device ambient-context-sensor --KVS kvs1 --discriminator 1234 --app-pipe /tmp/acs_fifo_3_2"
+# --script src/python_testing/TC_ACS_3_2.py --script-args "--storage-path admin_storage1.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network --endpoint 1
+# --string-arg PIXIT.ACS.Event1_NSID:0x4B --string-arg PIXIT.ACS.Event1_TAGID:0x03 --float-arg PIXIT.ACS.Holdtime:30"
+
+
+class TC_ACS_3_2(MatterBaseTest):
+
+    def pics_TC_ACS_3_2(self):
+        return ['ACS.S']
+
+    def setup_test(self):
+        super().setup_test()
+        self.is_ci = self.matter_test_config.global_test_params.get('simulate_ambientsensing', False)
+
+    # Sends and out-of-band command to the all-clusters-app
+    def write_to_app_pipe(self, command):
+
+        if self.is_ci:
+            self.app_pipe = "/tmp/acs_fifo_3_2"
+
+        with open(self.app_pipe, "w") as app_pipe:
+            app_pipe.write(command + "\n")
+        # Delay for pipe command to be processed (otherwise tests are flaky)
+        time.sleep(0.001)
+
+    @async_test_body
+    async def test_TC_ACS_3_2(self):
+        """[TC-ACS-3.2] Cluster endpoint"""
+
+        node_id = self.dut_node_id
+        endpoint = self.get_endpoint()
+        cluster = Clusters.AmbientContextSensing
+        attr = Clusters.AmbientContextSensing.Attributes
+        dev_ctrl = self.default_controller
+
+        self.step("1", "Commissioning, already done", is_commissioning=True)
+        # Commission DUT - already done
+        # Implicit step to get the feature map to ensure attribute operations
+        # are performed on supported features
+        aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap)
+        log.info("Rx'd FeatureMap: %s", {aFeatureMap})
+        self.HumanActivitySupported = ((aFeatureMap & cluster.Bitmaps.Feature.kHumanActivity) != 0)
+        log.info("Rx'd HumanActivitySupported: %s", {self.HumanActivitySupported})
+        self.ObjectCountingSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kObjectCounting) != 0)
+        log.info("Rx'd ObjectCountingSupported: %s", {self.ObjectCountingSupported})
+        self.ObjectIdentificationSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kObjectIdentification) != 0)
+        log.info("Rx'd ObjectIdentificationSupported: %s", {self.ObjectIdentificationSupported})
+        self.SoundIdentificationSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kSoundIdentification) != 0)
+        log.info("Rx'd SoundIdentificationSupported: %s", {self.SoundIdentificationSupported})
+        self.PredictedActivitySupported = ((aFeatureMap & cluster.Bitmaps.Feature.kPredictedActivity) != 0)
+        log.info("Rx'd PredictedActivitySupported: %s", {self.PredictedActivitySupported})
+
+        self.step("2", "TH establishes a wildcard subscription to all attributes on Ambient Context Sensing Cluster on the endpoint under test with minIntervalFloor set to 0, MaxIntervalCeiling set to 30 and KeepSubscriptions set to false")
+        # Add AmbientContextSupported elements based on DUT capability for ci
+        # Human activity walking, Object identification person, Audio identification barking
+        if self.is_ci:
+            self.write_to_app_pipe(
+                # '{"Name":"SetAmbientContextSupport","EndpointId":1,"AmbientContextType":[{"TypeId":73, "TagId":3},{"TypeId":74, "TagId":4},{"TypeId":75,"TagId":3}]}')
+                f'{{"Name":"SetAmbientContextSupport", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":73, "TagId":3}},{{"TypeId":74, "TagId":4}},{{"TypeId":75,"TagId":3}}]}}')
+            await asyncio.sleep(1)
+
+        # subscription setup for the following trigger testing
+        attrib_listener = AttributeSubscriptionHandler(expected_cluster=cluster)
+        await attrib_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30, keepSubscriptions=False)
+        attrib_listener.reset()
+
+        self.step("3", "TH writes DUT HoldTime attribute to enable proper testing completion using PIXIT.ACS.Holdtime input")
+
+        # PIXIT input
+        holdTime_input = self.user_params.get("PIXIT.ACS.Holdtime", 30)
+        # holdTime_input = 30  # 30 seconds
+        holdTimeLimits = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.HoldTimeLimits)
+        asserts.assert_less_equal(holdTimeLimits.holdTimeMin, holdTime_input, "Expected to be between HoldTimeMin and HoldTimeMax.")
+        asserts.assert_less_equal(holdTime_input, holdTimeLimits.holdTimeMax, "Expected to be between HoldTimeMin and HoldTimeMax.")
+        await self.write_single_attribute(attr.HoldTime(holdTime_input))
+
+        self.step("4", "Trigger one of DUT supporting ambient sensing feature representing PIXIT.ACS.Event1_NSID and PIXIT.ACS.Event1_TAGID")
+        log.info("\n\n First trigger. \n\n")
+
+        # PIXIT input
+        pixit1_nsid = self.user_params.get("PIXIT.ACS.Event1_NSID", "0x4B")
+        pixit1_tagid = self.user_params.get("PIXIT.ACS.Event1_TAGID", "0x03")
+        log.info("pixit1_nsid: %s", pixit1_nsid)
+        log.info("pixit1_tagid: %s", pixit1_tagid)
+        list_dec = ast.literal_eval(pixit1_nsid)  # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+        namespaceID1 = list_dec
+        list_dec = ast.literal_eval(pixit1_tagid)  # same as the above
+        tag1 = list_dec
+        log.info("PIXIT input: %s %s", {namespaceID1}, {tag1})
+
+        # CI call to trigger on
+        if self.is_ci:
+            # Human activity walking for ci
+            self.write_to_app_pipe(
+                # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":75, "TagId":3}]}')
+                f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID1}, "TagId":{tag1}}}]}}')
+            # Add 1 second delay to make sure the name piped functional latency
+            await asyncio.sleep(1)
+        else:
+            self.wait_for_user_input(
+                prompt_msg="Type any letter and press ENTER after the first ambient sensing event is triggered.")
+
+        # 1st event timer start
+        start_time = time.perf_counter()
+
+        self.step("5", "TH reads the AmbientContextType attribute. Verify that DUT response contains the AmbientContextSensed struct data including the namespace ID and its tag ID of test step 4")
+        # Check the boolean attribute subscription
+        if namespaceID1 == HUMAN_ACTIVITY_NAMESPACE_ID:
+            subscription_expected1 = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+            humanActivityDetected = subscription_expected1[0].value
+            asserts.assert_true(humanActivityDetected, "Failed to get HumanActivityDetected being True.")
+
+        elif namespaceID1 == OBJECT_IDENTIFICATION_NAMESPACE_ID:
+            subscription_expected2 = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+            objectIdentified = subscription_expected2[0].value
+            asserts.assert_true(objectIdentified, "Failed to get ObjectIdentified being True.")
+
+        elif namespaceID1 == SOUND_IDENTIFICATION_NAMESPACE_ID:
+            subscription_expected3 = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+            audioContextDetected = subscription_expected3[0].value
+            asserts.assert_true(audioContextDetected, "Failed to get audioContextDetected being True.")
+
+        # Read AmbientContextType attribute
+        ambientContextType = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AmbientContextType)
+        # log.info(f"Rx'd AmbientContextType_read: {ambientContextType_read}")
+
+        # check attribute read for future use, just in case
+        # nsID_1_read = ambientContextType_read[0].ambientContextSensed[0].namespaceID
+        # tagID_1_read = ambientContextType_read[0].ambientContextSensed[0].tag
+        # asserts.assert_equal(nsID_1_read, namespaceID1, "Namespace ID and Tag ID must match.")
+        # asserts.assert_equal(tagID_1_read, tag1, "Namespace ID and Tag ID must match.")
+
+        # check the subscription of AmbientContextType attribute
+        subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][0].value
+        asserts.assert_true(subscription_expected[0].ambientContextSensed[0].namespaceID == namespaceID1,
+                            f"Unexpected namespaceID, {subscription_expected[0].ambientContextSensed[0].namespaceID}, exp {namespaceID1}")
+        asserts.assert_true(subscription_expected[0].ambientContextSensed[0].tag == tag1,
+                            f"Unexpected tag, {subscription_expected[0].ambientContextSensed[0].tag}, exp {tag1}")
+
+        self.step("6", "Within HoldTime duration of the step 4, trigger the DUT with the same ambient sensing feature.")
+        # Trigger the sensor with same ambient context within HoldTime duration
+        # Human activity walking for ci
+        log.info("\n\n Re-triggering another same type ambient sensing event \n\n")
+
+        # CI call to trigger on
+        if self.is_ci:
+            self.write_to_app_pipe(
+                # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":75, "TagId":3}]}')
+                f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID1}, "TagId":{tag1}}}]}}')
+            # Add 1 second delay to make sure it's done
+            await asyncio.sleep(1)
+        else:
+            self.wait_for_user_input(
+                prompt_msg="Type any letter and press ENTER after the same type ambient sensing event is re-triggered.")
+
+        self.step("7", "TH reads the AmbientContextType attribute. Verify that DUT response contains the AmbientContextSensed struct data including the namespace ID and its tag ID from the step 6. Verify that DUT response contains the size of AmbientContextType list is 1.")
+        ambientContextType = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AmbientContextType)
+        # log.info(f"Rx'd AmbientContextType_read: {ambientContextType}")
+
+        # Same trigger shouldn't add to the list, so check to be 1.
+        asserts.assert_equal(len(ambientContextType), 1, "AmbientContextType needs to be the size of 1.")
+
+        # Check the boolean attribute subscription
+        if namespaceID1 == HUMAN_ACTIVITY_NAMESPACE_ID:
+            subscription_expected1 = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+            humanActivityDetected = subscription_expected1[0].value
+            asserts.assert_true(humanActivityDetected, "Failed to get HumanActivityDetected being True.")
+
+        elif namespaceID1 == OBJECT_IDENTIFICATION_NAMESPACE_ID:
+            subscription_expected2 = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+            objectIdentified = subscription_expected2[0].value
+            asserts.assert_true(objectIdentified, "Failed to get ObjectIdentified being True.")
+
+        elif namespaceID1 == SOUND_IDENTIFICATION_NAMESPACE_ID:
+            subscription_expected3 = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+            audioContextDetected = subscription_expected3[0].value
+            asserts.assert_true(audioContextDetected, "Failed to get audioContextDetected being True.")
+
+        # check the subscription of AmbientContextType attribute
+        subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][-1].value
+        asserts.assert_true(subscription_expected[0].ambientContextSensed[0].namespaceID == namespaceID1,
+                            f"Unexpected namespaceID, {subscription_expected[0].ambientContextSensed[0].namespaceID}, exp {namespaceID1}")
+        asserts.assert_true(subscription_expected[0].ambientContextSensed[0].tag == tag1,
+                            f"Unexpected tag, {subscription_expected[0].ambientContextSensed[0].tag}, exp {tag1}")
+
+        attrib_listener.reset()
+
+        self.step("8", "Wait until HoldTime seconds are passed from the step 4 execution.")
+        # timer ends
+        end_time = time.perf_counter()
+        elapsed_time = end_time - start_time
+        if elapsed_time > holdTime_input:
+            log.info("HoldTime already elapsed since the step 4 trigger; no additional wait needed.")
+        else:
+            log.info("Waiting for the HoldTime input to expire.")
+            await asyncio.sleep(holdTime_input - elapsed_time + 1)
+
+        self.step("9", "TH reads the AmbientContextType attribute and check a Boolean attribute related to the step 6. Verify that DUT response contains the Boolean attribute (HumanActivityDetected, ObjectIdentified, AudioContextDetected) is read False.")
+        # check the subscription of AmbientContextType attribute (to be empty list)
+        subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][0].value
+        asserts.assert_true(len(subscription_expected) == 0, "AmbientContext attribute is not empty.")
+
+        # check boolean attributes
+        if namespaceID1 == HUMAN_ACTIVITY_NAMESPACE_ID and self.HumanActivitySupported:
+            # subscription check
+            subscription_expected1 = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+            humanActivityDetected = subscription_expected1[0].value
+            asserts.assert_true(humanActivityDetected is False, "Failed to get HumanActivityDetected being False.")
+        elif namespaceID1 == OBJECT_IDENTIFICATION_NAMESPACE_ID and self.ObjectIdentificationSupported:
+            # subscription check
+            subscription_expected2 = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+            objectIdentified = subscription_expected2[0].value
+            asserts.assert_true(objectIdentified is False, "Failed to get ObjectIdentified being False.")
+        elif namespaceID1 == SOUND_IDENTIFICATION_NAMESPACE_ID and self.SoundIdentificationSupported:
+            # subscription check
+            subscription_expected3 = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+            audioContextDetected = subscription_expected3[0].value
+            asserts.assert_true(not audioContextDetected, "Failed to get audioContextDetected being False.")
+
+        attrib_listener.reset()
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/TC_ACS_3_3.py
+++ b/TC_ACS_3_3.py
@@ -1,0 +1,586 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --device ambient-context-sensor --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/acs_fifo_3_3
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#       --app-pipe /tmp/acs_fifo_3_3
+#       --string-arg PIXIT.ACS.Event1_NSID:0x4B --string-arg PIXIT.ACS.Event1_TAGID:0x03
+#       --string-arg PIXIT.ACS.Event2_NSID:0x49 --string-arg PIXIT.ACS.Event2_TAGID:0x04
+#       --string-arg PIXIT.ACS.Event3_NSID:0x4A --string-arg PIXIT.ACS.Event3_TAGID:0x03
+#       --float-arg PIXIT.ACS.Holdtime:10
+#       --bool-arg simulate_ambientsensing:True
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import ast
+import asyncio
+import logging
+import time
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters import Globals
+from matter.clusters.Types import NullValue
+from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler, EventSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+min_value_uint8 = 0
+max_value_uint8 = 255
+min_value_uint16 = 0
+max_value_uint16 = 65535
+min_value_uint32 = 0
+max_value_uint32 = 4294967295
+
+# Namespace in integer (not hex)
+HUMAN_ACTIVITY_NAMESPACE_ID = 75  # 0x4B
+OBJECT_IDENTIFICATION_NAMESPACE_ID = 73  # 0x49
+SOUND_IDENTIFICATION_NAMESPACE_ID = 74  # 0x4A
+
+# Script Function Call Example
+# python3 ./scripts/tests/run_python_test.py --app out/linux-x64-all-devices-clang/all-devices-app --factory-reset
+# --app-args "--device ambient-context-sensor --KVS kvs1 --discriminator 1234 --app-pipe /tmp/acs_fifo_3_3"
+# --script src/python_testing/TC_ACS_3_3.py --script-args "--storage-path admin_storage1.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network --endpoint 1
+# --string-arg PIXIT.ACS.Event1_NSID:0x4B --string-arg PIXIT.ACS.Event1_TAGID:0x03
+# --string-arg PIXIT.ACS.Event2_NSID:0x49 --string-arg PIXIT.ACS.Event2_TAGID:0x04
+# --string-arg PIXIT.ACS.Event3_NSID:0x4A --string-arg PIXIT.ACS.Event3_TAGID:0x03
+# --float-arg PIXIT.ACS.Holdtime:10"
+
+
+class TC_ACS_3_3(MatterBaseTest):
+
+    def pics_TC_ACS_3_3(self):
+        return ['ACS.S']
+
+    def setup_test(self):
+        super().setup_test()
+        self.is_ci = self.matter_test_config.global_test_params.get('simulate_ambientsensing', False)
+
+    def write_to_app_pipe(self, command):
+        if self.is_ci:
+            self.app_pipe = "/tmp/acs_fifo_3_3"
+
+        with open(self.app_pipe, "w") as app_pipe:
+            app_pipe.write(command + "\n")
+        # Delay for pipe command to be processed (otherwise tests are flaky)
+        time.sleep(0.001)
+
+    @async_test_body
+    async def test_TC_ACS_3_3(self):
+        """[TC-ACS-3.3] Cluster endpoint"""
+
+        node_id = self.dut_node_id
+        endpoint = self.get_endpoint()
+        cluster = Clusters.AmbientContextSensing
+        attr = Clusters.AmbientContextSensing.Attributes
+        dev_ctrl = self.default_controller
+
+        # PIXIT1 input => This is meant for Human Activity Ambient Sensing Event Testing
+        pixit1_nsid = self.user_params.get("PIXIT.ACS.Event1_NSID", None)
+        if pixit1_nsid is None:
+            namespaceID1 = None
+            tag1 = None
+        else:
+            pixit1_tagid = self.user_params.get("PIXIT.ACS.Event1_TAGID", None)
+            asserts.assert_not_equal(pixit1_tagid, None, "Missing PIXIT Tag ID for the namespace!")
+            log.info("nsid %s tagid %s", {pixit1_nsid}, {pixit1_tagid})
+            # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+            namespaceID1 = ast.literal_eval(pixit1_nsid)
+            tag1 = ast.literal_eval(pixit1_tagid)  # same as the above
+            log.info("PIXIT input1: %s %s", {namespaceID1}, {tag1})
+
+        # PIXIT2 input => This is meant for Object Identification Ambient Sensing Event Testing
+        pixit2_nsid = self.user_params.get("PIXIT.ACS.Event2_NSID", None)
+        if pixit2_nsid is None:
+            namespaceID2 = None
+            tag2 = None
+        else:
+            pixit2_tagid = self.user_params.get("PIXIT.ACS.Event2_TAGID", None)
+            asserts.assert_not_equal(pixit2_tagid, None, "Missing PIXIT Tag ID for the namespace!")
+            log.info("nsid %s tagid %s", {pixit2_nsid}, {pixit2_tagid})
+            # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+            namespaceID2 = ast.literal_eval(pixit2_nsid)
+            tag2 = ast.literal_eval(pixit2_tagid)  # same as the above
+            log.info("PIXIT input2: %s %s", {namespaceID2}, {tag2})
+
+        # PIXIT3 input => This is meant for Object Identification Ambient Sensing Event Testing
+        pixit3_nsid = self.user_params.get("PIXIT.ACS.Event3_NSID", None)
+        if pixit3_nsid is None:
+            namespaceID3 = None
+            tag3 = None
+        else:
+            pixit3_tagid = self.user_params.get("PIXIT.ACS.Event3_TAGID", None)
+            asserts.assert_not_equal(pixit3_tagid, None, "Missing PIXIT Tag ID for the namespace!")
+            log.info("nsid %s tagid %s", {pixit3_nsid}, {pixit3_tagid})
+            # expecting PIXIT to be like "0x4B" hex string and convert string hex to decimal
+            namespaceID3 = ast.literal_eval(pixit3_nsid)
+            tag3 = ast.literal_eval(pixit3_tagid)  # same as the above
+            log.info("PIXIT input3: %s %s", {namespaceID3}, {tag3})
+
+        # PIXIT HoldTime input
+        holdTime_input = self.user_params.get("PIXIT.ACS.Holdtime", 30)
+        # holdTime_input = 30  # 30 seconds
+        holdTimeLimits = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.HoldTimeLimits)
+        asserts.assert_less_equal(holdTimeLimits.holdTimeMin, holdTime_input, "Expected to be between HoldTimeMin and HoldTimeMax.")
+        asserts.assert_less_equal(holdTime_input, holdTimeLimits.holdTimeMax, "Expected to be between HoldTimeMin and HoldTimeMax.")
+        await self.write_single_attribute(attr.HoldTime(holdTime_input))
+
+        post_prompt_settle_delay_seconds = 10  # seconds
+        # ---------------------------------------------------------------
+
+        self.step("1", "Commissioning, already done", is_commissioning=True)
+        # Commission DUT - already done
+
+        # Implicit step to get the feature map to ensure attribute operations are performed on supported features
+        aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap)
+        log.info("Rx'd FeatureMap: %s", {aFeatureMap})
+        self.HumanActivitySupported = ((aFeatureMap & cluster.Bitmaps.Feature.kHumanActivity) != 0)
+        log.info("Rx'd HumanActivitySupported: %s", {self.HumanActivitySupported})
+        self.ObjectCountingSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kObjectCounting) != 0)
+        log.info("Rx'd ObjectCountingSupported: %s", {self.ObjectCountingSupported})
+        self.ObjectIdentificationSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kObjectIdentification) != 0)
+        log.info("Rx'd ObjectIdentificationSupported: %s", {self.ObjectIdentificationSupported})
+        self.SoundIdentificationSupported = ((aFeatureMap & cluster.Bitmaps.Feature.kSoundIdentification) != 0)
+        log.info("Rx'd SoundIdentificationSupported: %s", {self.SoundIdentificationSupported})
+        self.PredictedActivitySupported = ((aFeatureMap & cluster.Bitmaps.Feature.kPredictedActivity) != 0)
+        log.info("Rx'd PredictedActivitySupported: %s", {self.PredictedActivitySupported})
+
+        # Add AmbientContextSupported elements based on DUT capability for ci
+        # Human activity walking, Object identification person, Audio identification barking <= HARD CODE ADDED FOR CI CALL
+        if self.is_ci:
+            self.write_to_app_pipe(
+                # '{"Name":"SetAmbientContextSupport","EndpointId":1,"AmbientContextType":[{"TypeId":75, "TagId":3},{"TypeId":74, "TagId":3},{"TypeId":73,"TagId":4}]}')
+                # f'{{"Name":"SetAmbientContextSupport", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":73, "TagId":4}},{{"TypeId":74, "TagId":3}},{{"TypeId":75, "TagId":3}}]}}')
+                f'{{"Name":"SetAmbientContextSupport", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID1}, "TagId":{tag1}}},{{"TypeId":{namespaceID2}, "TagId":{tag2}}},{{"TypeId":{namespaceID3}, "TagId":{tag3}}}]}}')
+            await asyncio.sleep(1)
+
+        self.step("2", "TH establishes a wildcard subscription to all attributes on Ambient Context Sensing Cluster on the endpoint under test. Subscription min interval = 0 and max interval = 30 seconds.")
+        attribute_list = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AttributeList)
+
+        # Set up wildcard subscription for attributes and events
+        # MinIntervalFloor = 0, MaxIntervalCeiling = 30, KeepSubscriptions = false (EventSubscriptionHandler has True hardcoded and can't be changed)
+        attrib_listener = AttributeSubscriptionHandler(expected_cluster=cluster)
+        await attrib_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30, keepSubscriptions=False)
+
+        # start event listener
+        event_listener = EventSubscriptionHandler(expected_cluster=cluster)
+        await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
+
+        # Wait user to input capabilities
+        if not self.is_ci:
+            self.wait_for_user_input(
+                prompt_msg="Type any letter and press ENTER after DUT is clear of any detection state.")
+
+        # Human Activity Feature Supported =======================================================================
+        if (namespaceID1 == HUMAN_ACTIVITY_NAMESPACE_ID) and self.HumanActivitySupported:
+
+            self.step("3a", "If DUT supports HumanActivity feature, check if DUT is under the undetected HumanActivityDetect attribute state.")
+            humanActivityDetected = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.HumanActivityDetected
+            )
+            asserts.assert_true(not humanActivityDetected, "Expected False Boolean value.")
+
+            self.step("3b", "DUT is triggered with a human activity ambient sensing event represented by PIXIT.ACS.Event1_NSID and PIXIT.ACS.Event1_TAGID.")
+            # Human activity walking for ci
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":75, "TagId":3}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID1}, "TagId":{tag1}}}]}}')
+                # Add 1 second delay to make sure it's done
+                await asyncio.sleep(1)
+            else:
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after a human activity ambient sensing event is triggered.")
+
+            # event timer start
+            start_time = time.perf_counter()
+
+            self.step("3c", "TH awaits a ReportDataMessage containing an attribute report for HumanActivityDetected attribute and AmbientContextType attribute. Verify that the value of HumanActivityDetected attribute is True. Verify that the AmbientContextSensed field of AmbientContextType attribute contains the namespace ID ant tag ID of the step 3b triggering event.")
+            # subscription check - boolean attribute
+            subscription_expected1 = attrib_listener.attribute_reports[cluster.Attributes.HumanActivityDetected]
+            humanActivityDetected = subscription_expected1[0].value
+            asserts.assert_true(humanActivityDetected, "Failed to get HumanActivityDetected being True.")
+            log.info("Received attribute report for HumanActivityDetected = True.")
+
+            # check the subscription of AmbientContextType attribute
+            subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][0].value
+            asserts.assert_true(subscription_expected[0].ambientContextSensed[0].namespaceID == namespaceID1,
+                                f"Unexpected namespaceID, {subscription_expected[0].ambientContextSensed[0].namespaceID}, exp {namespaceID1}")
+            asserts.assert_true(subscription_expected[0].ambientContextSensed[0].tag == tag1,
+                                f"Unexpected tag, {subscription_expected[0].ambientContextSensed[0].tag}, exp {tag1}")
+            attrib_listener.reset()
+            log.info("Received attribute report for AmbientContextType.")
+
+            self.step("3d", "TH receives AmbientContextDetectStarted event and reads AmbientContextDetected field. Verify that the AmbientContextSensed struct data of AmbientContextDetected field contains the namespace ID and tag ID of the step 3b triggering event. Store the event time generated by this AmbientContextDetectStarted event.")
+            # Check if AmbientContextDetectStarted event is detected
+            event = event_listener.get_last_event()
+            # log.info(f"eventheader: {event}")
+            asserts.assert_equal(event.Header.EventId, cluster.Events.AmbientContextDetectStarted.event_id,
+                                 f"Wrong event, {event.Header.EventId}, {cluster.Events.AmbientContextDetectStarted.event_id}")
+            # check event field is sent correctly.
+            asserts.assert_equal(
+                event.Data.ambientContextDetected.ambientContextSensed[0].namespaceID, namespaceID1, "Wrong NamespaceID")
+            asserts.assert_equal(event.Data.ambientContextDetected.ambientContextSensed[0].tag, tag1, "Wrong Tag")
+            # save the event start time.
+            event_start_time = event.Header.Timestamp
+            log.info("event time from AmbientContextDetectStarted : %s", {event_start_time})
+
+            self.step("3e", "Wait until HoldTime seconds represented by PIXIT.ACS.Holdtime expires from the step 3b.")
+            # timer ends
+            end_time = time.perf_counter()
+            elapsed_time = end_time - start_time
+            if elapsed_time > holdTime_input:
+                log.info("The event testing wasn't completed within HoldTime input.")
+            else:
+                log.info("Waiting for the HoldTime input to expire for %s seconds.", holdTime_input-elapsed_time+1)
+                await asyncio.sleep(holdTime_input - elapsed_time + 1)
+
+            self.step("3f", "TH receives AmbientContextDetectEnded event and reads EventStartTimePos or EventStartTimeSys event field. Verify that the EventStartTimePos or EventStartTimeSys field contains the event start time stored from the step 3d.")
+            # check AmbientContextDetectEnded event
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AmbientContextDetectEnded, timeout_sec=(post_prompt_settle_delay_seconds+holdTime_input))
+            if event.eventStartTimePos is not None:
+                asserts.assert_true(abs(event.eventStartTimePos - event_start_time) < 2000, "Not matching EventStartTimePos")
+                log.info("event time from AmbientContextDetectEnded field data: %s", {event.eventStartTimePos})
+            else:
+                asserts.assert_true(abs(event.eventStartTimeSys - event_start_time) < 2000, "Not matching EventStartTimeSys")
+                log.info("event time from AmbientContextDetectEnded field data: %s", {event.eventStartTimeSys})
+
+        else:
+            log.info("HumanActivity Feature not supported. Test steps skipped")
+            self.skip_step("3a")
+            self.skip_step("3b")
+            self.skip_step("3c")
+            self.skip_step("3d")
+            self.skip_step("3e")
+            self.skip_step("3f")
+
+        # Clear accumulated reports and restart accumulating
+        attrib_listener.reset()
+        event_listener.reset()
+        await asyncio.sleep(0.1)
+        log.info("Cleared accumulated reports. Restarting accumulation.")
+
+        # Object Identification Feature Supported =======================================================================
+        if (namespaceID2 == OBJECT_IDENTIFICATION_NAMESPACE_ID) and self.ObjectIdentificationSupported:
+            self.step("4a", "If DUT supports Object Identification feature, check if DUT is under the undetected ObjectIdentified attribute state.")
+            objectIdentified = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.ObjectIdentified
+            )
+            asserts.assert_true(not objectIdentified, "Expected False Boolean value.")
+
+            self.step("4b", "DUT is triggered with object identification sensing event represented by PIXIT.ACS.Event2_NSID and PIXIT.ACS.Event2_TAGID.")
+            # Object Identification person for ci
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":73, "TagId":3}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID2}, "TagId":{tag2}}}]}}')
+                await asyncio.sleep(1)
+            else:
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after an object identification ambient sensing event is triggered.")
+            # event timer start
+            start_time = time.perf_counter()
+
+            self.step("4c", "TH awaits a ReportDataMessage containing an attribute report for ObjectIdentified attribute and AmbientContextType attribute. Verify that the value of ObjectIdentified  attribute is True. Verify that the AmbientContextSensed field of AmbientContextType attribute contains the namespace ID ant tag ID of the step 4b triggering event.")
+            # subscription check - boolean attribute
+            subscription_expected1 = attrib_listener.attribute_reports[cluster.Attributes.ObjectIdentified]
+            objectIdentified = subscription_expected1[0].value
+            asserts.assert_true(objectIdentified, "Failed to get ObjectIdentified being True.")
+            log.info("Received attribute report for ObjectIdentified = True.")
+
+            # check the subscription of AmbientContextType attribute
+            subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][0].value
+            asserts.assert_true(subscription_expected[0].ambientContextSensed[0].namespaceID == namespaceID2,
+                                f"Unexpected namespaceID, {subscription_expected[0].ambientContextSensed[0].namespaceID}, exp {namespaceID2}")
+            asserts.assert_true(subscription_expected[0].ambientContextSensed[0].tag == tag2,
+                                f"Unexpected tag, {subscription_expected[0].ambientContextSensed[0].tag}, exp {tag2}")
+            log.info("Received attribute report for AmbientContextType.")
+
+            self.step("4d", "TH receives AmbientContextDetectStarted event and reads AmbientContextDetected field. Verify that the AmbientContextSensed struct data of AmbientContextDetected field contains the namespace ID and tag ID of the step 3b triggering event. Store the event time generated by this AmbientContextDetectStarted event.")
+            # Check if AmbientContextDetectStarted event is detected
+            event = event_listener.get_last_event()
+            # log.info(f"eventheader: {event}")
+            asserts.assert_equal(event.Header.EventId, cluster.Events.AmbientContextDetectStarted.event_id,
+                                 f"Wrong event, {event.Header.EventId}, {cluster.Events.AmbientContextDetectStarted.event_id}")
+            # check event field is sent correctly.
+            asserts.assert_equal(
+                event.Data.ambientContextDetected.ambientContextSensed[0].namespaceID, namespaceID2, "Wrong NamespaceID")
+            asserts.assert_equal(event.Data.ambientContextDetected.ambientContextSensed[0].tag, tag2, "Wrong Tag")
+            # save the event start time.
+            event_start_time = event.Header.Timestamp
+            log.info("event time from AmbientContextDetectStarted : %s", {event_start_time})
+            # log.info(f"Rx'd AmbientContextType_read: {ambientContextType_read}")
+
+            self.step("4e", "Wait until HoldTime seconds represented by PIXIT.ACS.Holdtime expires from the step 4b.")
+            # timer ends
+            end_time = time.perf_counter()
+            elapsed_time = end_time - start_time
+            if elapsed_time > holdTime_input:
+                log.info("The event testing wasn't completed within HoldTime input.")
+            else:
+                log.info("Waiting for the HoldTime input to expire for %s seconds.", holdTime_input-elapsed_time+1)
+                await asyncio.sleep(holdTime_input - elapsed_time + 1)
+
+            self.step("4f", "TH receives AmbientContextDetectEnded event and reads EventStartTimePos or EventStartTimeSys event field. Verify that the EventStartTimePos or EventStartTimeSys field contains the event start time stored from the step 4d.")
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AmbientContextDetectEnded, timeout_sec=(post_prompt_settle_delay_seconds+holdTime_input))
+            # asserts.assert_true((event.eventStartTime//1000) == event_start_time, "Not matching EventStartTime")
+            if event.eventStartTimePos is not None:
+                asserts.assert_true(abs(event.eventStartTimePos - event_start_time) < 2000, "Not matching EventStartTimePos")
+                # log.info(f"event time from AmbientContextDetectEnded field data: {event.eventStartTimePos}")
+            else:
+                asserts.assert_true(abs(event.eventStartTimeSys - event_start_time) < 2000, "Not matching EventStartTimeSys")
+                # log.info(f"event time from AmbientContextDetectEnded field data: {event.eventStartTimeSys}")
+        else:
+            log.info("ObjectIdentification Feature not supported. Test steps skipped")
+            self.skip_step("4a")
+            self.skip_step("4b")
+            self.skip_step("4c")
+            self.skip_step("4d")
+            self.skip_step("4e")
+            self.skip_step("4f")
+
+        # Clear accumulated reports and restart accumulating
+        attrib_listener.reset()
+        event_listener.reset()
+        await asyncio.sleep(0.1)
+        log.info("Cleared accumulated reports. Restarting accumulation.")
+
+        # Sound Identification Feature Supported =======================================================================
+        if (namespaceID3 == SOUND_IDENTIFICATION_NAMESPACE_ID) and self.SoundIdentificationSupported:
+            self.step("5a", "If DUT supports Sound Identification feature, check if DUT is under the undetected AudioContextDetected attribute state.")
+            # initial
+            audioContextDetected = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.AudioContextDetected
+            )
+            asserts.assert_true(not audioContextDetected, "Expected False Boolean value.")
+
+            self.step("5b", "DUT is triggered with audio context sensing event represented by PIXIT.ACS.Event3_NSID and PIXIT.ACS.Event3_TAGID.")
+            # Sound Identification barking for ci
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":74, "TagId":4}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID3}, "TagId":{tag3}}}]}}')
+                # Add 1 second delay to make sure it's done
+                await asyncio.sleep(1)
+            else:
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after an audio ambient sensing event is triggered.")
+            # event timer start
+            start_time = time.perf_counter()
+
+            self.step("5c", "TH awaits a ReportDataMessage containing an attribute report for AudioContextDetected attribute and AmbientContextType attribute. Verify that the value of AudioContextDetected attribute is True. Verify that the AmbientContextSensed field of AmbientContextType attribute contains the namespace ID ant tag ID of the step 5b triggering event.")
+            # subscription check - boolean attribute
+            subscription_expected3 = attrib_listener.attribute_reports[cluster.Attributes.AudioContextDetected]
+            audioContextDetected = subscription_expected3[0].value
+            asserts.assert_true(audioContextDetected, "Failed to get AudioContextDetected being True.")
+            log.info("Received attribute report for AudioContextDetected = True.")
+
+            # check the subscription of AmbientContextType attribute
+            subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.AmbientContextType][0].value
+            asserts.assert_true(subscription_expected[0].ambientContextSensed[0].namespaceID == namespaceID3,
+                                f"Unexpected namespaceID, {subscription_expected[0].ambientContextSensed[0].namespaceID}, exp {namespaceID3}")
+            asserts.assert_true(subscription_expected[0].ambientContextSensed[0].tag == tag3,
+                                f"Unexpected tag, {subscription_expected[0].ambientContextSensed[0].tag}, exp {tag3}")
+            log.info("Received attribute report for AmbientContextType.")
+
+            self.step("5d", "TH receives AmbientContextDetectStarted event and reads AmbientContextDetected field. Verify that the AmbientContextSensed struct data of AmbientContextDetected field contains the namespace ID and tag ID of the step 5b triggering event. Store the event time generated by this AmbientContextDetectStarted event.")
+            # Check if AmbientContextDetectStarted event is detected
+            event = event_listener.get_last_event()
+            # log.info(f"eventheader: {event}")
+            asserts.assert_equal(event.Header.EventId, cluster.Events.AmbientContextDetectStarted.event_id,
+                                 f"Wrong event, {event.Header.EventId}, {cluster.Events.AmbientContextDetectStarted.event_id}")
+            # check event field is sent correctly.
+            asserts.assert_equal(
+                event.Data.ambientContextDetected.ambientContextSensed[0].namespaceID, namespaceID3, "Wrong NamespaceID")
+            asserts.assert_equal(event.Data.ambientContextDetected.ambientContextSensed[0].tag, tag3, "Wrong Tag")
+            # save the event start time.
+            event_start_time = event.Header.Timestamp
+            log.info("event time from AmbientContextDetectStarted : %s", {event_start_time})
+            # log.info(f"Rx'd AmbientContextType_read: {ambientContextType_read}")
+
+            self.step("5e", "Wait until HoldTime seconds represented by PIXIT.ACS.Holdtime expires from the step 5b.")
+            # timer ends
+            end_time = time.perf_counter()
+            elapsed_time = end_time - start_time
+            if elapsed_time > holdTime_input:
+                log.info("The event testing wasn't completed within HoldTime input.")
+            else:
+                log.info("Waiting for the HoldTime input to expire for %s seconds.", holdTime_input-elapsed_time+1)
+                await asyncio.sleep(holdTime_input - elapsed_time + 1)
+                # time.sleep(int(holdTime_input - elapsed_time + 1))
+
+            self.step("5f", "TH receives AmbientContextDetectEnded event and reads EventStartTimePos or EventStartTimeSys event field. Verify that the EventStartTimePos or EventStartTimeSys field contains the event start time stored from the step 5d.")
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AmbientContextDetectEnded, timeout_sec=(post_prompt_settle_delay_seconds+holdTime_input))
+            if event.eventStartTimePos is not None:
+                asserts.assert_true(abs(event.eventStartTimePos - event_start_time) < 2000, "Not matching EventStartTimePos")
+                # log.info(f"event time from AmbientContextDetectEnded field data: {event.eventStartTimePos}")
+            else:
+                asserts.assert_true(abs(event.eventStartTimeSys - event_start_time) < 2000, "Not matching EventStartTimeSys")
+                # log.info(f"event time from AmbientContextDetectEnded field data: {event.eventStartTimeSys}")
+        else:
+            log.info("SoundIdentification Feature not supported. Test steps skipped")
+            self.skip_step("5a")
+            self.skip_step("5b")
+            self.skip_step("5c")
+            self.skip_step("5d")
+            self.skip_step("5e")
+            self.skip_step("5f")
+
+        # Clear accumulated reports and restart accumulating
+        attrib_listener.reset()
+        event_listener.reset()
+        await asyncio.sleep(0.1)
+        log.info("Cleared accumulated reports. Restarting accumulation.")
+
+        # Object Counting Feature Supported =======================================================================
+        if (namespaceID2 == OBJECT_IDENTIFICATION_NAMESPACE_ID) and self.ObjectCountingSupported and self.ObjectIdentificationSupported:
+            objectcount_input = 2
+            self.step("6a", "If DUT supports ObjectCounting and Object Identification feature, prepare DUT with an undetected ObjectCountThresholdReached attribute state.")
+
+            # check the boolean state is cleared as False
+            objectCountThresholdReached = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.ObjectCountThresholdReached
+            )
+            asserts.assert_true(objectCountThresholdReached is False, "Expected False Boolean value.")
+
+            self.step("6b", "Change DUT ObjectCountThreshold with 2 and the DUT supporting counting object type represented by PIXIT.ACS.Event2_NSID and PIXIT.ACS.Event2_TAGID.")
+            # setting up object counting configuration parameters
+            objectcountthreshold_input = 2
+            semantic_tag = Globals.Structs.SemanticTagStruct(mfgCode=NullValue, namespaceID=namespaceID2, tag=tag2, label=None)
+            objectCountConfig_input = Clusters.AmbientContextSensing.Structs.ObjectCountConfigStruct(
+                countingObject=semantic_tag, objectCountThreshold=objectcountthreshold_input)
+            await self.write_single_attribute(attr.ObjectCountConfig(objectCountConfig_input))
+            await asyncio.sleep(1)
+
+            self.step("6c", "TH awaits a ReportDataMessage containing an attribute report for ObjectCountConfig attribute. Verify that the CountingObject field of ObjectCountConfig attribute contains the namespace ID ant tag ID entered in the step 6b and the ObjectCountThreshold field contains 2")
+            # subscription check for ObjectCountConfig
+            subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.ObjectCountConfig][0].value
+            asserts.assert_true(subscription_expected.countingObject.namespaceID == namespaceID2,
+                                f"Unexpected namespaceID, {subscription_expected.countingObject.namespaceID}, exp {namespaceID2}")
+            asserts.assert_true(subscription_expected.countingObject.tag == tag2,
+                                f"Unexpected tag, {subscription_expected.countingObject.tag}, exp {tag2}")
+            asserts.assert_true(subscription_expected.objectCountThreshold == objectcountthreshold_input,
+                                f"Unexpected tag, {subscription_expected.objectCountThreshold}, exp {objectcountthreshold_input}")
+            log.info("Received attribute report for ObjectCountConfig.")
+
+            self.step("6d", "DUT is triggered with object counting event with the number of the object greater than equal to 2.")
+            # trigger the counting sensing event
+            if self.is_ci:
+                self.write_to_app_pipe(
+                    # '{"Name":"AddAmbientContextDetect", "EndpointId":1, "AmbientContextType":[{"TypeId":73, "TagId":3}]}')
+                    f'{{"Name":"AddAmbientContextDetect", "EndpointId":{endpoint}, "AmbientContextType":[{{"TypeId":{namespaceID2}, "TagId":{tag2}}}]}}')
+                # await asyncio.sleep(1)
+                self.write_to_app_pipe(
+                    f'{{"Name":"SetObjCount","EndpointId":{endpoint},"ObjectCount":2}}')
+                # await asyncio.sleep(1)
+            else:
+                self.wait_for_user_input(
+                    prompt_msg="Type any letter and press ENTER after an object counting ambient sensing event is triggered.")
+
+            # event timer start
+            start_time = time.perf_counter()
+
+            self.step("6e", "TH awaits a ReportDataMessage containing an attribute report for ObjectCountThresholdReached attribute. Verify that the value of ObjectCountThresholdReached attribute is True. Verify that if DUT supports ObjectCount attribute, ObjectCount is greater than equal to 2.")
+            # subscription check - boolean attribute
+            subscription_expected4 = attrib_listener.attribute_reports[cluster.Attributes.ObjectCountThresholdReached]
+            objectCountThresholdReached = subscription_expected4[0].value
+            asserts.assert_true(objectCountThresholdReached, "Failed  to get ObjectCountThresholdReached being True.")
+            log.info("Received attribute report for ObjectCountThresholdReached = True.")
+
+            # check if ObjectCount optional attribute is supported
+            if attr.ObjectCount.attribute_id in attribute_list:
+                subscription_expected = attrib_listener.attribute_reports[cluster.Attributes.ObjectCount]
+                objectCount = subscription_expected[0].value
+                asserts.assert_true(objectCount > 1, "Failed to have ObjectCount value greater than 1")
+                log.info("Received attribute report for ObjectCountReached.")
+
+            self.step("6f", "TH receives AmbientContextDetectStarted event. Verify that the AmbientContextDetected field contains the namespace ID and tag ID of the step 6d, and if DUT supports ObjectCount, ObjectCount event field is greater than equal to 2. Store the event time generated by this AmbientContextDetectStarted event.")
+            event = event_listener.get_last_event()
+            asserts.assert_equal(event.Header.EventId, cluster.Events.AmbientContextDetectStarted.event_id,
+                                 f"Wrong event, {event.Header.EventId}, {cluster.Events.AmbientContextDetectStarted.event_id}")
+            asserts.assert_equal(event.Data.objectCountThresholdReached, True, "Wrong objectCountReached")
+            asserts.assert_equal(
+                event.Data.ambientContextDetected.ambientContextSensed[0].namespaceID, namespaceID2, "Wrong NamespaceID")
+            asserts.assert_equal(event.Data.ambientContextDetected.ambientContextSensed[0].tag, tag2, "Wrong Tag")
+            if event.Data.objectCount != NullValue:
+                asserts.assert_equal(event.Data.objectCount, objectcount_input, "Wrong ObjectCount")
+            # event start time
+            event_start_time = event.Header.Timestamp
+
+            self.step("6g", "Wait until HoldTime seconds represented by PIXIT.ACS.Holdtime are passed since step 6d.")
+            # timer ends
+            end_time = time.perf_counter()
+            elapsed_time = end_time - start_time
+            if elapsed_time > holdTime_input:
+                log.info("The event testing wasn't completed within HoldTime input.")
+            else:
+                log.info("Waiting for the HoldTime input to expire for %s seconds.", holdTime_input-elapsed_time+1)
+                await asyncio.sleep(int(holdTime_input - elapsed_time + 1))
+                # time.sleep(int(holdTime_input - elapsed_time + 1))
+
+            self.step("6h", "TH receives AmbientContextDetectEnded event and reads EventStartTimePos or EventStartTimeSys field. Verify that the EventStartTimePos or EventStartTimeSys field contains the event time stored from the step 6f.")
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AmbientContextDetectEnded, timeout_sec=(post_prompt_settle_delay_seconds+holdTime_input))
+            if event.eventStartTimePos is not None:
+                asserts.assert_true(abs(event.eventStartTimePos - event_start_time) < 2000, "Not matching EventStartTimePos")
+                log.info("event time from AmbientContextDetectEnded field data: %s", {event.eventStartTimePos})
+            else:
+                asserts.assert_true(abs(event.eventStartTimeSys - event_start_time) < 2000, "Not matching EventStartTimeSys")
+                log.info("event time from AmbientContextDetectEnded field data: %s", {event.eventStartTimeSys})
+
+        else:
+            log.info("Object Counting & Object Identification Feature not supported. Test steps skipped")
+            self.skip_step("6a")
+            self.skip_step("6b")
+            self.skip_step("6c")
+            self.skip_step("6d")
+            self.skip_step("6e")
+            self.skip_step("6f")
+            self.skip_step("6g")
+            self.skip_step("6h")
+
+        # Clear accumulated reports and restart accumulating
+        attrib_listener.reset()
+        event_listener.reset()
+        log.info("Cleared accumulated reports. Restarting accumulation.")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
Recreate a new PR as a continuation of  PR43197 (https://github.com/project-chip/connectedhomeip/pull/43197) to resolve the rebase problem. Test script files are same as PR43197.

### Summary

4 Python test scripts are uploaded to test plan PR (https://github.com/CHIP-Specifications/chip-test-plans/pull/5874).
TC_ACS_2_1 - Attributes
TC_ACS_3_1 - Multiple Detection Functionality & Simultaneous Detection Limit Check
TC_ACS_3_2 - Same Continuous Detection and HoldTimeMax Functionality
TC_ACS_3_3 - Attribute Subscription and Event Functionality

### Related issues

Fixes the issue https://github.com/project-chip/connectedhomeip/issues/41939

### Testing

The script was validated based on the current application SDK PR (https://github.com/project-chip/connectedhomeip/pull/43327)
The example test script commands are as follows:

tc-acs-2.1
python3 ./scripts/tests/run_python_test.py --app out/linux-x64-all-devices-clang/all-devices-app --factory-reset --app-args "--device ambient-context-sensor --KVS kvs1 --discriminator 1234 --app-pipe /tmp/acs_fifo" --script src/python_testing/TC_ACS_2_1.py --script-args "--storage-path admin_storage1.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network --endpoint 1"

tc-acs-3.1
python3 ./scripts/tests/run_python_test.py --app out/linux-x64-all-devices-clang/all-devices-app --factory-reset --app-args "--device ambient-context-sensor --KVS kvs1 --discriminator 1234 --app-pipe /tmp/acs_fifo_3_1" --script src/python_testing/TC_ACS_3_1.py --script-args "--storage-path admin_storage1.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network --endpoint 1 --string-arg PIXIT.ACS.Event1_NSID:0x4B --string-arg PIXIT.ACS.Event1_TAGID:0x03 --string-arg PIXIT.ACS.Event2_NSID:0x49 --string-arg PIXIT.ACS.Event2_TAGID:0x04 --string-arg PIXIT.ACS.Event3_NSID:0x4A --string-arg PIXIT.ACS.Event3_TAGID:0x03 --float-arg PIXIT.ACS.Holdtime:30"

tc-acs-3.2
python3 ./scripts/tests/run_python_test.py --app out/linux-x64-all-devices-clang/all-devices-app --factory-reset --app-args "--device ambient-context-sensor --KVS kvs1 --discriminator 1234 --app-pipe /tmp/acs_fifo_3_2" --script src/python_testing/TC_ACS_3_2.py --script-args "--storage-path admin_storage1.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network --endpoint 1 --string-arg PIXIT.ACS.Event1_NSID:0x4B --string-arg PIXIT.ACS.Event1_TAGID:0x03 --float-arg PIXIT.ACS.Holdtime:30"

tc-acs-3.3
python3 ./scripts/tests/run_python_test.py --app out/linux-x64-all-devices-clang/all-devices-app --factory-reset --app-args "--device ambient-context-sensor --KVS kvs1 --discriminator 1234 --app-pipe /tmp/acs_fifo_3_3" --script src/python_testing/TC_ACS_3_3.py --script-args "--storage-path admin_storage1.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network --endpoint 1 --string-arg PIXIT.ACS.Event1_NSID:0x4B --string-arg PIXIT.ACS.Event1_TAGID:0x03 --string-arg PIXIT.ACS.Event2_NSID:0x49 --string-arg PIXIT.ACS.Event2_TAGID:0x04 --string-arg PIXIT.ACS.Event3_NSID:0x4A --string-arg PIXIT.ACS.Event3_TAGID:0x03 --float-arg PIXIT.ACS.Holdtime:10"